### PR TITLE
[PR] 워크플로우 에디터 UI 조립

### DIFF
--- a/src/features/add-node/index.ts
+++ b/src/features/add-node/index.ts
@@ -1,0 +1,3 @@
+export { AddNodeButton } from "./ui/AddNodeButton";
+export { NodeCategoryDrawer } from "./ui/NodeCategoryDrawer";
+export { useAddNode } from "./model/useAddNode";

--- a/src/features/add-node/model/useAddNode.ts
+++ b/src/features/add-node/model/useAddNode.ts
@@ -1,0 +1,39 @@
+import { useRef } from "react";
+
+import type { Node } from "@xyflow/react";
+
+import { NODE_REGISTRY } from "@/entities/node";
+import type { NodeType } from "@/entities/node";
+import { useWorkflowStore } from "@/shared";
+
+const BASE_POSITION = { x: 250, y: 250 };
+const OFFSET_STEP = 30;
+
+export const useAddNode = () => {
+  const addNode = useWorkflowStore((s) => s.addNode);
+  const callCountRef = useRef(0);
+
+  const addNodeByType = (type: NodeType) => {
+    const meta = NODE_REGISTRY[type];
+    const offset = callCountRef.current * OFFSET_STEP;
+    callCountRef.current += 1;
+
+    const node: Node = {
+      id: crypto.randomUUID(),
+      type,
+      position: {
+        x: BASE_POSITION.x + offset,
+        y: BASE_POSITION.y + offset,
+      },
+      data: {
+        type,
+        label: meta.label,
+        config: { ...meta.defaultConfig },
+      },
+    };
+
+    addNode(node);
+  };
+
+  return { addNode: addNodeByType };
+};

--- a/src/features/add-node/ui/AddNodeButton.tsx
+++ b/src/features/add-node/ui/AddNodeButton.tsx
@@ -1,0 +1,24 @@
+import { MdAdd } from "react-icons/md";
+
+import { IconButton, useDisclosure } from "@chakra-ui/react";
+
+import { NodeCategoryDrawer } from "./NodeCategoryDrawer";
+
+export const AddNodeButton = () => {
+  const { open, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <IconButton
+        aria-label="노드 추가"
+        onClick={onOpen}
+        colorPalette="blue"
+        size="lg"
+        borderRadius="full"
+      >
+        <MdAdd />
+      </IconButton>
+      <NodeCategoryDrawer open={open} onClose={onClose} />
+    </>
+  );
+};

--- a/src/features/add-node/ui/NodeCategoryDrawer.tsx
+++ b/src/features/add-node/ui/NodeCategoryDrawer.tsx
@@ -1,0 +1,97 @@
+import {
+  Box,
+  Button,
+  DrawerBackdrop,
+  DrawerBody,
+  DrawerCloseTrigger,
+  DrawerContent,
+  DrawerHeader,
+  DrawerPositioner,
+  DrawerRoot,
+  DrawerTitle,
+  Icon,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+} from "@chakra-ui/react";
+
+import { getNodesByCategory } from "@/entities/node";
+import type { NodeCategory } from "@/entities/node";
+import type { NodeType } from "@/entities/node";
+
+import { useAddNode } from "../model/useAddNode";
+
+interface NodeCategoryDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const TABS: { label: string; value: NodeCategory }[] = [
+  { label: "도메인", value: "domain" },
+  { label: "프로세싱", value: "processing" },
+  { label: "AI", value: "ai" },
+];
+
+export const NodeCategoryDrawer = ({
+  open,
+  onClose,
+}: NodeCategoryDrawerProps) => {
+  const { addNode } = useAddNode();
+
+  const handleNodeClick = (type: NodeType) => {
+    addNode(type);
+    onClose();
+  };
+
+  return (
+    <DrawerRoot
+      open={open}
+      onOpenChange={(details) => {
+        if (!details.open) onClose();
+      }}
+      placement="start"
+      size="sm"
+    >
+      <DrawerBackdrop />
+      <DrawerPositioner>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>노드 추가</DrawerTitle>
+          </DrawerHeader>
+          <DrawerCloseTrigger />
+          <DrawerBody>
+            <TabsRoot defaultValue="domain">
+              <TabsList>
+                {TABS.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {TABS.map((tab) => (
+                <TabsContent key={tab.value} value={tab.value}>
+                  <Box display="flex" flexDirection="column" gap={2} pt={2}>
+                    {getNodesByCategory(tab.value).map((meta) => (
+                      <Button
+                        key={meta.type}
+                        variant="ghost"
+                        justifyContent="flex-start"
+                        gap={2}
+                        onClick={() => handleNodeClick(meta.type)}
+                      >
+                        <Icon as={meta.iconComponent} boxSize={5} />
+                        <Text>{meta.label}</Text>
+                      </Button>
+                    ))}
+                  </Box>
+                </TabsContent>
+              ))}
+            </TabsRoot>
+          </DrawerBody>
+        </DrawerContent>
+      </DrawerPositioner>
+    </DrawerRoot>
+  );
+};

--- a/src/features/configure-node/index.ts
+++ b/src/features/configure-node/index.ts
@@ -1,0 +1,1 @@
+export { PanelRenderer } from "./ui/PanelRenderer";

--- a/src/features/configure-node/ui/PanelRenderer.tsx
+++ b/src/features/configure-node/ui/PanelRenderer.tsx
@@ -1,0 +1,14 @@
+import { Text } from "@chakra-ui/react";
+
+import { selectActiveNode, useWorkflowStore } from "@/shared";
+
+// PANEL_MAP — 패널 컴포넌트는 다음 이슈에서 구현 예정
+// const PANEL_MAP = {} as Record<string, React.ComponentType>;
+
+export const PanelRenderer = () => {
+  const activeNode = useWorkflowStore(selectActiveNode);
+
+  if (!activeNode) return null;
+
+  return <Text>노드 설정 패널 준비 중</Text>;
+};

--- a/src/pages/workflow-editor/WorkflowEditorPage.tsx
+++ b/src/pages/workflow-editor/WorkflowEditorPage.tsx
@@ -1,3 +1,47 @@
+import { useEffect } from "react";
+import { useParams } from "react-router";
+
+import { Box } from "@chakra-ui/react";
+import { ReactFlowProvider } from "@xyflow/react";
+
+import { AddNodeButton } from "@/features/add-node";
+import { useWorkflowStore } from "@/shared";
+import { Canvas, EditorToolbar, NodeSettingsPanel } from "@/widgets";
+
+const WorkflowEditorInner = () => {
+  const { id } = useParams<{ id: string }>();
+  const setWorkflowMeta = useWorkflowStore((s) => s.setWorkflowMeta);
+  const resetEditor = useWorkflowStore((s) => s.resetEditor);
+
+  useEffect(() => {
+    if (id) {
+      setWorkflowMeta(id, "");
+    }
+    return () => {
+      resetEditor();
+    };
+  }, [id, setWorkflowMeta, resetEditor]);
+
+  return (
+    <Box display="flex" flexDirection="column" height="100%">
+      <EditorToolbar />
+      <Box display="flex" flex={1} overflow="hidden">
+        <Box flex={1} position="relative">
+          <Canvas />
+          <Box position="absolute" bottom={4} left={4} zIndex={10}>
+            <AddNodeButton />
+          </Box>
+        </Box>
+        <NodeSettingsPanel />
+      </Box>
+    </Box>
+  );
+};
+
 export const WorkflowEditorPage = () => {
-  return <div>WorkflowEditorPage</div>;
+  return (
+    <ReactFlowProvider>
+      <WorkflowEditorInner />
+    </ReactFlowProvider>
+  );
 };

--- a/src/widgets/editor-toolbar/index.ts
+++ b/src/widgets/editor-toolbar/index.ts
@@ -1,0 +1,1 @@
+export { EditorToolbar } from "./ui/EditorToolbar";

--- a/src/widgets/editor-toolbar/ui/EditorToolbar.tsx
+++ b/src/widgets/editor-toolbar/ui/EditorToolbar.tsx
@@ -1,0 +1,54 @@
+import { MdPlayArrow, MdSave } from "react-icons/md";
+
+import { Box, IconButton, Text } from "@chakra-ui/react";
+
+import type { ExecutionStatus } from "@/shared";
+import { useWorkflowStore } from "@/shared";
+
+const getRunButtonColor = (status: ExecutionStatus) => {
+  switch (status) {
+    case "running":
+      return "yellow";
+    case "failed":
+      return "red";
+    case "idle":
+    case "success":
+    default:
+      return "green";
+  }
+};
+
+export const EditorToolbar = () => {
+  const workflowName = useWorkflowStore((s) => s.workflowName);
+  const executionStatus = useWorkflowStore((s) => s.executionStatus);
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      height="48px"
+      px={4}
+      bg="bg.surface"
+      borderBottom="1px solid"
+      borderColor="border.default"
+      flexShrink={0}
+    >
+      <Text fontWeight="semibold" fontSize="sm">
+        {workflowName || "새 워크플로우"}
+      </Text>
+      <Box display="flex" gap={2}>
+        <IconButton
+          aria-label="워크플로우 실행"
+          size="sm"
+          colorPalette={getRunButtonColor(executionStatus)}
+        >
+          <MdPlayArrow />
+        </IconButton>
+        <IconButton aria-label="워크플로우 저장" size="sm" variant="outline">
+          <MdSave />
+        </IconButton>
+      </Box>
+    </Box>
+  );
+};

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -1,3 +1,5 @@
 export * from "./canvas";
 export * from "./editor-layout";
+export * from "./editor-toolbar";
 export * from "./layout";
+export * from "./node-settings-panel";

--- a/src/widgets/node-settings-panel/index.ts
+++ b/src/widgets/node-settings-panel/index.ts
@@ -1,0 +1,1 @@
+export { NodeSettingsPanel } from "./ui/NodeSettingsPanel";

--- a/src/widgets/node-settings-panel/ui/NodeSettingsPanel.tsx
+++ b/src/widgets/node-settings-panel/ui/NodeSettingsPanel.tsx
@@ -1,0 +1,24 @@
+import { Box } from "@chakra-ui/react";
+
+import { PanelRenderer } from "@/features/configure-node";
+import { useWorkflowStore } from "@/shared";
+
+export const NodeSettingsPanel = () => {
+  const activePanelNodeId = useWorkflowStore((s) => s.activePanelNodeId);
+
+  return (
+    <Box
+      width="360px"
+      height="100%"
+      bg="bg.surface"
+      borderLeft="1px solid"
+      borderColor="border.default"
+      flexShrink={0}
+      display={activePanelNodeId ? "block" : "none"}
+      overflowY="auto"
+      p={4}
+    >
+      <PanelRenderer />
+    </Box>
+  );
+};


### PR DESCRIPTION
## 📝 요약 (Summary)

워크플로우 에디터 화면을 구성하는 핵심 UI 컴포넌트를 구현하고 페이지를 최종 조립합니다.
노드 추가 드로어, 상단 툴바, 우측 설정 패널을 각각 feature/widget 레이어에 구현한 뒤
`WorkflowEditorPage`에서 통합합니다.

## ✅ 주요 변경 사항 (Key Changes)

- `features/add-node`: 노드 추가 버튼 + 카테고리 드로어 구현
- `widgets/editor-toolbar`: 상단 툴바 구현
- `widgets/node-settings-panel`: 우측 설정 패널 슬라이드 구현
- `features/configure-node`: PanelRenderer 임시 구현 (설정 패널은 다음 이슈)
- `WorkflowEditorPage`: seed 코드 제거 후 전체 레이아웃 조립

## 💻 상세 구현 내용 (Implementation Details)

### features/add-node

**useAddNode.ts**
- `NODE_REGISTRY[type]`에서 메타데이터 조회 후 `Node` 객체 생성
- `crypto.randomUUID()`로 고유 id 생성
- `useRef`로 호출 횟수 추적 → `OFFSET_STEP(30px)` 씩 position 분산하여 노드 겹침 방지
- `useWorkflowStore.addNode(node)` 호출

**AddNodeButton.tsx**
- `useDisclosure`로 Drawer 열기/닫기 상태 내부 관리
- `MdAdd` 아이콘 버튼 클릭 시 `NodeCategoryDrawer` 오픈

**NodeCategoryDrawer.tsx**
- Chakra UI v3 `DrawerRoot` (`placement="start"`, `size="sm"`)
- 탭 3개: 도메인 / 프로세싱 / AI (`getNodesByCategory()` 활용)
- 각 노드: `iconComponent` + `label` 버튼 → 클릭 시 노드 추가 후 Drawer 닫기

### widgets/editor-toolbar

**EditorToolbar.tsx**
- 높이 48px, `bg.surface`, `border.default` 하단 구분선
- 좌측: `workflowName` (없으면 "새 워크플로우")
- 우측: 실행 버튼(MdPlayArrow), 저장 버튼(MdSave)
- `executionStatus`에 따른 실행 버튼 컬러 분기 (`idle/success` → green, `running` → yellow, `failed` → red)

### widgets/node-settings-panel

**NodeSettingsPanel.tsx**
- `width="360px"`, `bg.surface`, 좌측 구분선
- `activePanelNodeId`가 `null`이면 `display="none"` 처리
- 내부에 `PanelRenderer` 렌더링

### features/configure-node

**PanelRenderer.tsx**
- `selectActiveNode` 셀렉터로 activeNode 조회
- 현재는 임시 텍스트 표시 → 다음 이슈에서 15종 패널 구현 예정

### pages/workflow-editor

**WorkflowEditorPage.tsx**
- 개발 확인용 seed 노드 코드 제거
- `useParams`로 `:id` 파람 조회 → `setWorkflowMeta` 호출
- 페이지 unmount 시 `resetEditor` 호출 (메모리 정리)
- 레이아웃: `EditorToolbar(48px)` + 하단 row (`Canvas flex:1` + `NodeSettingsPanel`)
- `AddNodeButton`을 Canvas 위 좌하단 absolute 배치 (`zIndex: 10`)

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- `PanelRenderer`는 현재 임시 구현 — 노드 타입별 설정 패널 15종은 다음 이슈에서 구현
- 실행/저장 버튼의 실제 API 연동은 별도 이슈에서 처리 예정
- `useAddNode`의 position offset은 `useRef` 기반으로 페이지 리렌더링 시 초기화됨 — 추후 개선 가능

## 📸 스크린샷 (Screenshots)

> 디자인 확정 전으로 시각적 확인은 추후 진행 예정

## #️⃣ 관련 이슈 (Related Issues)

- #6
