### PR TITLE
[PR] 중복 타입 정의 제거, entities를 single source of truth로 통일

### DIFF
--- a/src/shared/api/workflow.api.ts
+++ b/src/shared/api/workflow.api.ts
@@ -1,32 +1,18 @@
+import type { Workflow, WorkflowSummary } from "@/entities/workflow";
+
 import type { ApiResponse } from "../types";
 
 import { apiClient } from "./client";
 
-// ─── 타입 ───────────────────────────────────────────────
-export type WorkflowStatus = "active" | "inactive";
-
-export interface WorkflowSummary {
-  id: string;
-  name: string;
-  status: WorkflowStatus;
-  createdAt: string;
-  updatedAt: string;
-}
-
-// nodes / edges의 상세 타입은 entities/node에서 정의된 후 교체 예정
-export interface WorkflowDetail extends WorkflowSummary {
-  nodes: unknown[];
-  edges: unknown[];
-}
-
+// ─── API 전용 타입 ──────────────────────────────────────────
 export interface CreateWorkflowRequest {
   name: string;
 }
 
 export interface UpdateWorkflowRequest {
   name?: string;
-  nodes?: unknown[];
-  edges?: unknown[];
+  nodes?: Workflow["nodes"];
+  edges?: Workflow["edges"];
 }
 
 export interface ExecuteWorkflowResponse {
@@ -41,15 +27,15 @@ export const workflowApi = {
 
   /** 워크플로우 상세 조회 */
   getById: (id: string) =>
-    apiClient.get<ApiResponse<WorkflowDetail>>(`/workflows/${id}`),
+    apiClient.get<ApiResponse<Workflow>>(`/workflows/${id}`),
 
   /** 워크플로우 생성 */
   create: (body: CreateWorkflowRequest) =>
-    apiClient.post<ApiResponse<WorkflowDetail>>("/workflows", body),
+    apiClient.post<ApiResponse<Workflow>>("/workflows", body),
 
   /** 워크플로우 수정 (노드/엣지 저장 포함) */
   update: (id: string, body: UpdateWorkflowRequest) =>
-    apiClient.put<ApiResponse<WorkflowDetail>>(`/workflows/${id}`, body),
+    apiClient.put<ApiResponse<Workflow>>(`/workflows/${id}`, body),
 
   /** 워크플로우 삭제 */
   delete: (id: string) =>


### PR DESCRIPTION
## 📝 요약 (Summary)

shared/api와 entities/workflow에 중복 정의된 타입을 제거하고, entities를 단일 출처로 통일합니다.

## ✅ 주요 변경 사항 (Key Changes)

- shared/api/workflow.api.ts에서 WorkflowStatus, WorkflowSummary, WorkflowDetail 타입 정의 제거
- entities/workflow의 Workflow, WorkflowSummary를 import하여 사용
- WorkflowDetail(nodes: unknown[])을 Workflow(nodes: Node<FlowNodeData>[])로 대체하여 타입 안전성 강화

## 💻 상세 구현 내용 (Implementation Details)

### 타입 단일 출처 정리
- `entities/workflow/model/types.ts`를 워크플로우 관련 타입의 single source of truth로 지정
- API 레이어에서는 요청/응답 전용 타입(CreateWorkflowRequest, UpdateWorkflowRequest, ExecuteWorkflowResponse)만 유지
- UpdateWorkflowRequest의 nodes, edges 필드도 `unknown[]` → `Workflow["nodes"]`, `Workflow["edges"]`로 타입 강화

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

없음

## 📸 스크린샷 (Screenshots)

해당 없음 (타입 정의 변경만 포함)

## #️⃣ 관련 이슈 (Related Issues)

- #13
