### PR TITLE
[PR] 노드 텍스트 truncation을 BaseNode로 공통 적용

### DIFF
--- a/src/entities/node/ui/BaseNode.tsx
+++ b/src/entities/node/ui/BaseNode.tsx
@@ -77,7 +77,16 @@ export const BaseNode = ({ id, data, selected, children }: BaseNodeProps) => {
       </HStack>
 
       {/* 본문 — 설정 요약 */}
-      <Box px={3} py={2} fontSize="xs" color="text.secondary" minH="36px">
+      <Box
+        px={3}
+        py={2}
+        fontSize="xs"
+        color="text.secondary"
+        minH="36px"
+        overflow="hidden"
+        textOverflow="ellipsis"
+        whiteSpace="nowrap"
+      >
         {data.config.isConfigured ? (
           children
         ) : (

--- a/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
+++ b/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
@@ -12,9 +12,7 @@ export const EarlyExitNode = ({
   const config = data.config as EarlyExitNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-        {config.condition ?? "조건 미설정"}
-      </Text>
+      <Text>{config.condition ?? "조건 미설정"}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/LLMNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LLMNode.tsx
@@ -13,9 +13,7 @@ export const LLMNode = ({
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.model ?? "모델 미선택"}</Text>
-      <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-        {config.prompt || "프롬프트 미입력"}
-      </Text>
+      <Text>{config.prompt || "프롬프트 미입력"}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
+++ b/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
@@ -12,9 +12,7 @@ export const WebScrapingNode = ({
   const config = data.config as WebScrapingNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
-        {config.targetUrl ?? "URL 미설정"}
-      </Text>
+      <Text>{config.targetUrl ?? "URL 미설정"}</Text>
     </BaseNode>
   );
 };


### PR DESCRIPTION
## 📝 요약 (Summary)

커스텀 노드의 텍스트 truncation 처리를 BaseNode에 공통 적용하여 렌더링 패턴을 통일합니다.

## ✅ 주요 변경 사항 (Key Changes)

- BaseNode 본문 영역에 overflow/ellipsis 스타일 공통 적용
- LLMNode, WebScrapingNode, EarlyExitNode에서 개별 truncation 스타일 제거

## 💻 상세 구현 내용 (Implementation Details)

기존에 15개 커스텀 노드 중 3개만 텍스트 truncation이 적용되어 있었으나, 긴 텍스트가 들어올 수 있는 필드는 모든 노드에 존재합니다. BaseNode의 본문 Box에 공통으로 적용하여 개별 노드에서 반복하지 않도록 변경했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- DataProcessNode의 OPERATION_LABEL, OutputFormatNode의 toUpperCase()는 각 노드 고유 로직이므로 유지

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #14
