### PR TITLE
[PR] 노드 미설정 상태 텍스트를 '미설정'으로 통일

### DIFF
--- a/src/entities/node/ui/custom-nodes/CalendarNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CalendarNode.tsx
@@ -12,7 +12,7 @@ export const CalendarNode = ({
   const config = data.config as CalendarNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.service ?? "서비스 미선택"}</Text>
+      <Text>{config.service ?? "서비스 미설정"}</Text>
       <Text>{config.action ?? "동작 미설정"}</Text>
     </BaseNode>
   );

--- a/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
@@ -12,7 +12,7 @@ export const CommunicationNode = ({
   const config = data.config as CommunicationNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.service ?? "서비스 미선택"}</Text>
+      <Text>{config.service ?? "서비스 미설정"}</Text>
       <Text>{config.action ?? "동작 미설정"}</Text>
     </BaseNode>
   );

--- a/src/entities/node/ui/custom-nodes/LLMNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LLMNode.tsx
@@ -12,8 +12,8 @@ export const LLMNode = ({
   const config = data.config as LLMNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.model ?? "모델 미선택"}</Text>
-      <Text>{config.prompt || "프롬프트 미입력"}</Text>
+      <Text>{config.model ?? "모델 미설정"}</Text>
+      <Text>{config.prompt || "프롬프트 미설정"}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/StorageNode.tsx
+++ b/src/entities/node/ui/custom-nodes/StorageNode.tsx
@@ -12,7 +12,7 @@ export const StorageNode = ({
   const config = data.config as StorageNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.service ?? "서비스 미선택"}</Text>
+      <Text>{config.service ?? "서비스 미설정"}</Text>
       <Text>{config.action ?? "동작 미설정"}</Text>
     </BaseNode>
   );


### PR DESCRIPTION
## 📝 요약 (Summary)

커스텀 노드의 null/미설정 상태 fallback 텍스트 용어를 "미설정"으로 통일합니다.

## ✅ 주요 변경 사항 (Key Changes)

- "미선택" → "미설정"으로 변경 (CommunicationNode, StorageNode, CalendarNode, LLMNode)
- "미입력" → "미설정"으로 변경 (LLMNode)

## 💻 상세 구현 내용 (Implementation Details)

기존에 같은 의미를 "미설정", "미선택", "미입력" 세 가지 용어로 표현하고 있었습니다. 모든 노드에서 "미설정"으로 통일하여 UI 텍스트 일관성을 확보했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

없음

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #15
