### PR TITLE
[PR] BaseNode inline style을 Chakra props로 전환

### DIFF
--- a/src/entities/node/ui/BaseNode.tsx
+++ b/src/entities/node/ui/BaseNode.tsx
@@ -16,12 +16,6 @@ interface BaseNodeProps {
   children?: React.ReactNode;
 }
 
-const ICON_STYLE: React.CSSProperties = {
-  color: "white",
-  width: "16px",
-  height: "16px",
-};
-
 export const BaseNode = ({ id, data, selected, children }: BaseNodeProps) => {
   const meta = NODE_REGISTRY[data.type];
   const openPanel = useWorkflowStore((s) => s.openPanel);
@@ -49,7 +43,7 @@ export const BaseNode = ({ id, data, selected, children }: BaseNodeProps) => {
         justify="space-between"
       >
         <HStack gap={1.5}>
-          <Icon as={meta.iconComponent as IconType} style={ICON_STYLE} />
+          <Icon as={meta.iconComponent as IconType} color="white" boxSize={4} />
           <Text color="white" fontWeight="bold" fontSize="sm">
             {meta.label}
           </Text>


### PR DESCRIPTION
## 📝 요약 (Summary)

BaseNode의 React inline style을 Chakra UI props로 전환하여 프로젝트 전체 스타일링 방식을 통일합니다.

## ✅ 주요 변경 사항 (Key Changes)

- ICON_STYLE (React.CSSProperties) 상수 제거
- style={ICON_STYLE} → Chakra props (color, boxSize)로 전환

## 💻 상세 구현 내용 (Implementation Details)

프로젝트에서 유일하게 React inline style을 사용하던 BaseNode의 아이콘 스타일을 Chakra UI props로 변환했습니다.

```tsx
// Before
const ICON_STYLE: React.CSSProperties = { color: "white", width: "16px", height: "16px" };
<Icon style={ICON_STYLE} />

// After
<Icon color="white" boxSize={4} />
```

## 🚀 트러블 슈팅 (Trouble Shooting)

해당 없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

해당 없음

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #16