### PR TITLE
[PR] Zustand 인라인 셀렉터로 통일 및 dead code 제거

### DIFF
--- a/src/features/configure-node/ui/PanelRenderer.tsx
+++ b/src/features/configure-node/ui/PanelRenderer.tsx
@@ -1,12 +1,14 @@
 import { Text } from "@chakra-ui/react";
 
-import { selectActiveNode, useWorkflowStore } from "@/shared";
+import { useWorkflowStore } from "@/shared";
 
 // PANEL_MAP — 패널 컴포넌트는 다음 이슈에서 구현 예정
 // const PANEL_MAP = {} as Record<string, React.ComponentType>;
 
 export const PanelRenderer = () => {
-  const activeNode = useWorkflowStore(selectActiveNode);
+  const activeNode = useWorkflowStore(
+    (s) => s.nodes.find((n) => n.id === s.activePanelNodeId) ?? null,
+  );
 
   if (!activeNode) return null;
 

--- a/src/shared/model/workflowStore.ts
+++ b/src/shared/model/workflowStore.ts
@@ -167,20 +167,3 @@ export const useWorkflowStore = create<
     resetEditor: () => set(() => ({ ...initialState })),
   })),
 );
-
-// ─── 파생 셀렉터 ─────────────────────────────────────────────
-// useWorkflowStore(selectActiveNode) 형태로 구독 범위를 최소화합니다.
-
-export const selectActiveNode = (
-  state: WorkflowEditorState & WorkflowEditorActions,
-): Node | null =>
-  state.nodes.find((n) => n.id === state.activePanelNodeId) ?? null;
-
-export const selectIsConfigured =
-  (id: string) =>
-  (state: WorkflowEditorState & WorkflowEditorActions): boolean => {
-    const node = state.nodes.find((n) => n.id === id);
-    return (
-      (node?.data as Record<string, unknown> | undefined)?.isConfigured === true
-    );
-  };


### PR DESCRIPTION
## 📝 요약 (Summary)

Zustand store 접근 패턴을 인라인 셀렉터로 통일하고, 사용되지 않는 셀렉터를 제거합니다.

## ✅ 주요 변경 사항 (Key Changes)

- selectIsConfigured 삭제 (dead code)
- selectActiveNode 삭제, PanelRenderer에서 인라인 셀렉터로 전환
- seed-fe 컨벤션 기준 (state) => state.xxx 패턴으로 통일

## 💻 상세 구현 내용 (Implementation Details)

기존에 사전 정의 셀렉터(selectActiveNode, selectIsConfigured)와 인라인 셀렉터가 혼용되고 있었습니다. seed-fe 프로젝트 기준으로 모든 store 접근을 인라인 셀렉터 패턴으로 통일하고, workflowStore.ts의 파생 셀렉터 섹션을 제거했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

없음

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #17
