### PR TITLE
[PR] 데이터 타입 시스템 타입 정의 도입

### DIFF
--- a/src/entities/node/model/dataType.ts
+++ b/src/entities/node/model/dataType.ts
@@ -1,0 +1,53 @@
+// ─── 노드 간 데이터 흐름 타입 ─────────────────────────────────
+/**
+ * 노드 사이를 흐르는 데이터의 종류.
+ * 이전 노드의 outputType → 다음 노드의 inputType 으로 연결된다.
+ */
+export type DataType =
+  | "file-list" // 여러 파일 (Google Drive 폴더 등)
+  | "single-file" // 단일 파일
+  | "text" // AI 요약 결과, 알림 메시지 등 텍스트
+  | "spreadsheet" // 시트/셀 단위 구조화 데이터
+  | "email-list" // 여러 이메일
+  | "api-response"; // JSON 형식 외부 API 응답
+
+// ─── 노드의 입출력 타입 정의 ──────────────────────────────────
+/**
+ * 단일 노드가 받아들이는 입력과 내보내는 출력의 데이터 타입.
+ * inputTypes 가 빈 배열이면 시작 노드(소스)로 사용 가능하다.
+ */
+export interface NodeDataIO {
+  inputTypes: DataType[];
+  outputTypes: DataType[];
+}
+
+// ─── 호환성 검증 ─────────────────────────────────────────────
+/**
+ * 이전 노드의 출력이 다음 노드의 입력과 호환되는지 확인한다.
+ * 하나라도 겹치는 DataType 이 있으면 호환으로 판정한다.
+ *
+ * TODO: 매핑 규칙 확정 후 세부 로직 구현
+ */
+export const isDataTypeCompatible = (
+  sourceOutput: DataType[],
+  targetInput: DataType[],
+): boolean => {
+  // 입력 또는 출력이 비어있으면 제약 없음 (시작/종단 노드)
+  if (sourceOutput.length === 0 || targetInput.length === 0) {
+    return true;
+  }
+
+  return sourceOutput.some((type) => targetInput.includes(type));
+};
+
+// ─── 타입 변환 매핑 ──────────────────────────────────────────
+/**
+ * 특정 노드 타입이 입력 데이터를 어떤 출력 데이터로 변환하는지 정의한다.
+ * 예: file-list → LLM 요약 → text
+ *
+ * TODO: 매핑 규칙 확정 후 실제 변환 테이블 구현
+ */
+export type DataTypeTransformRule = {
+  inputType: DataType;
+  outputType: DataType;
+};

--- a/src/entities/node/model/index.ts
+++ b/src/entities/node/model/index.ts
@@ -1,2 +1,3 @@
+export * from "./dataType";
 export * from "./nodeRegistry";
 export * from "./types";

--- a/src/entities/node/model/nodeRegistry.ts
+++ b/src/entities/node/model/nodeRegistry.ts
@@ -17,6 +17,7 @@ import {
   MdTableChart,
 } from "react-icons/md";
 
+import type { DataType } from "./dataType";
 import type { NodeCategory, NodeConfig, NodeType } from "./types";
 
 // ─── NodeMeta 인터페이스 ─────────────────────────────────────
@@ -30,6 +31,10 @@ export interface NodeMeta {
   color: string;
   /** 노드 생성 시 사용할 기본 Config */
   defaultConfig: NodeConfig;
+  /** 이 노드가 받아들이는 데이터 타입 (빈 배열 = 시작 노드) */
+  defaultInputTypes: DataType[];
+  /** 이 노드가 내보내는 데이터 타입 */
+  defaultOutputTypes: DataType[];
 }
 
 // ─── NODE_REGISTRY ───────────────────────────────────────────
@@ -51,6 +56,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       labelFilter: null,
       messageFormat: null,
     },
+    defaultInputTypes: [],
+    defaultOutputTypes: ["email-list", "text"],
   },
 
   storage: {
@@ -66,6 +73,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       action: null,
       permissions: null,
     },
+    defaultInputTypes: [],
+    defaultOutputTypes: ["file-list", "single-file"],
   },
 
   spreadsheet: {
@@ -82,6 +91,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       action: null,
       range: null,
     },
+    defaultInputTypes: [],
+    defaultOutputTypes: ["spreadsheet"],
   },
 
   "web-scraping": {
@@ -97,6 +108,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       outputFields: [],
       pagination: false,
     },
+    defaultInputTypes: [],
+    defaultOutputTypes: ["api-response"],
   },
 
   calendar: {
@@ -113,6 +126,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       calendarId: null,
       dateRange: null,
     },
+    defaultInputTypes: [],
+    defaultOutputTypes: ["api-response"],
   },
 
   // ── 프로세싱 & 로직 ──────────────────────────────────────
@@ -129,6 +144,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       eventService: null,
       eventType: null,
     },
+    defaultInputTypes: [],
+    defaultOutputTypes: [],
   },
 
   filter: {
@@ -144,6 +161,18 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       value: null,
       removeDuplicates: false,
     },
+    defaultInputTypes: [
+      "file-list",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
+    defaultOutputTypes: [
+      "file-list",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
   },
 
   loop: {
@@ -158,6 +187,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       maxIterations: 100,
       timeout: 300,
     },
+    defaultInputTypes: ["file-list", "email-list", "spreadsheet"],
+    defaultOutputTypes: ["single-file", "text", "spreadsheet"],
   },
 
   condition: {
@@ -172,6 +203,22 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       operator: null,
       value: null,
     },
+    defaultInputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
+    defaultOutputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
   },
 
   "multi-output": {
@@ -185,6 +232,22 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       outputCount: 2,
       conditions: [],
     },
+    defaultInputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
+    defaultOutputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
   },
 
   "data-process": {
@@ -200,6 +263,15 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       sortDirection: null,
       aggregateFunction: null,
     },
+    defaultInputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
+    defaultOutputTypes: ["text", "spreadsheet", "api-response"],
   },
 
   "output-format": {
@@ -213,6 +285,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       format: null,
       template: null,
     },
+    defaultInputTypes: ["text", "spreadsheet", "api-response"],
+    defaultOutputTypes: ["text"],
   },
 
   "early-exit": {
@@ -226,6 +300,15 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       condition: null,
       exitMessage: null,
     },
+    defaultInputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
+    defaultOutputTypes: [],
   },
 
   notification: {
@@ -240,6 +323,8 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       recipient: null,
       messageTemplate: null,
     },
+    defaultInputTypes: ["text"],
+    defaultOutputTypes: [],
   },
 
   // ── AI ───────────────────────────────────────────────────
@@ -256,6 +341,15 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
       outputFormat: "text",
       temperature: 0.7,
     },
+    defaultInputTypes: [
+      "file-list",
+      "single-file",
+      "text",
+      "email-list",
+      "spreadsheet",
+      "api-response",
+    ],
+    defaultOutputTypes: ["text"],
   },
 };
 

--- a/src/entities/node/model/types.ts
+++ b/src/entities/node/model/types.ts
@@ -172,4 +172,8 @@ export interface FlowNodeData extends Record<string, unknown> {
   type: NodeType;
   label: string;
   config: NodeConfig;
+  /** 이 노드가 받아들이는 데이터 타입 목록 (빈 배열 = 시작 노드) */
+  inputTypes: import("./dataType").DataType[];
+  /** 이 노드가 내보내는 데이터 타입 목록 */
+  outputTypes: import("./dataType").DataType[];
 }

--- a/src/features/add-node/model/useAddNode.ts
+++ b/src/features/add-node/model/useAddNode.ts
@@ -29,6 +29,8 @@ export const useAddNode = () => {
         type,
         label: meta.label,
         config: { ...meta.defaultConfig },
+        inputTypes: [...meta.defaultInputTypes],
+        outputTypes: [...meta.defaultOutputTypes],
       },
     };
 


### PR DESCRIPTION
## 📝 요약 (Summary)

노드 간 데이터 흐름의 기반이 되는 데이터 타입 체계를 타입 레벨에서 정의합니다.

## ✅ 주요 변경 사항 (Key Changes)

- 6가지 DataType union 타입 정의 (file-list, single-file, text, spreadsheet, email-list, api-response)
- FlowNodeData에 inputTypes, outputTypes 필드 추가
- NODE_REGISTRY 15개 노드에 기본 입출력 타입 설정
- 호환성 검증 유틸 함수 시그니처 정의 (구현은 매핑 규칙 확정 후)

## 💻 상세 구현 내용 (Implementation Details)

### dataType.ts 신규 생성
- DataType: 노드 간 흐르는 데이터 종류를 표현하는 union 타입
- NodeDataIO: 노드의 입출력 타입 쌍을 표현하는 인터페이스
- isDataTypeCompatible: 이전 노드 출력 ↔ 다음 노드 입력 호환성 검증 유틸 (매핑 규칙 확정 전이므로 항상 true 반환)
- DataTypeTransformRule: 노드 처리에 따른 타입 변환 규칙 정의

### FlowNodeData 확장
기존 type, label, config에 inputTypes, outputTypes 추가하여 각 노드 인스턴스가 자신의 데이터 타입 정보를 보유

### NODE_REGISTRY 확장
NodeMeta에 defaultInputTypes, defaultOutputTypes 추가. 도메인 노드는 시작 노드로 사용 가능(빈 입력), 프로세싱 노드는 역할에 따라 적절한 타입 설정

### useAddNode 수정
노드 생성 시 레지스트리의 기본 입출력 타입을 data에 주입

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- isDataTypeCompatible은 매핑 규칙 도출 후 실제 로직을 채울 예정
- 각 노드의 기본 입출력 타입은 시나리오 확보 후 조정될 수 있음

## 📸 스크린샷 (Screenshots)

해당 없음 (타입 정의만 포함)

## #️⃣ 관련 이슈 (Related Issues)

- #26
