### PR TITLE
[PR] 노드 삭제 시 후속 노드 연쇄 삭제 구현

### DIFF
--- a/src/shared/libs/graph.ts
+++ b/src/shared/libs/graph.ts
@@ -1,0 +1,27 @@
+import type { Edge } from "@xyflow/react";
+
+/**
+ * 시작 노드에서 엣지를 따라 하위 방향(source → target)으로 탐색하여
+ * 모든 후속 노드 ID를 수집한다.
+ * 조건 분기 노드의 경우 모든 분기 경로를 포함한다.
+ */
+export const collectDescendantIds = (
+  startId: string,
+  edges: Edge[],
+): Set<string> => {
+  const descendants = new Set<string>();
+  const queue = [startId];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+
+    for (const edge of edges) {
+      if (edge.source === currentId && !descendants.has(edge.target)) {
+        descendants.add(edge.target);
+        queue.push(edge.target);
+      }
+    }
+  }
+
+  return descendants;
+};

--- a/src/shared/libs/index.ts
+++ b/src/shared/libs/index.ts
@@ -1,1 +1,2 @@
+export * from "./graph";
 export * from "./query-client";

--- a/src/shared/model/workflowStore.ts
+++ b/src/shared/model/workflowStore.ts
@@ -12,6 +12,8 @@ import { current } from "immer";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
+import { collectDescendantIds } from "../libs/graph";
+
 // ─── 실행 상태 타입 ──────────────────────────────────────────
 export type ExecutionStatus = "idle" | "running" | "success" | "failed";
 
@@ -45,7 +47,7 @@ interface WorkflowEditorActions {
    */
   addNode: (node: Node) => void;
 
-  /** 노드 삭제 (연결된 엣지도 함께 제거) */
+  /** 노드 삭제 (후속 노드 및 관련 엣지도 함께 제거) */
   removeNode: (id: string) => void;
 
   /**
@@ -116,11 +118,19 @@ export const useWorkflowStore = create<
 
     removeNode: (id) =>
       set((state) => {
-        state.nodes = state.nodes.filter((n) => n.id !== id);
+        const plainEdges = current(state.edges);
+        const descendants = collectDescendantIds(id, plainEdges);
+        const removeTargets = new Set([id, ...descendants]);
+
+        state.nodes = state.nodes.filter((n) => !removeTargets.has(n.id));
         state.edges = state.edges.filter(
-          (e) => e.source !== id && e.target !== id,
+          (e) => !removeTargets.has(e.source) && !removeTargets.has(e.target),
         );
-        if (state.activePanelNodeId === id) {
+
+        if (
+          state.activePanelNodeId &&
+          removeTargets.has(state.activePanelNodeId)
+        ) {
           state.activePanelNodeId = null;
         }
       }),


### PR DESCRIPTION
## 📝 요약 (Summary)

노드 삭제 시 해당 노드의 하위 경로에 있는 모든 후속 노드를 함께 삭제하도록 변경합니다.

## ✅ 주요 변경 사항 (Key Changes)

- collectDescendantIds 그래프 탐색 유틸 함수 추가 (shared/libs)
- removeNode 액션을 연쇄 삭제 방식으로 수정

## 💻 상세 구현 내용 (Implementation Details)

### collectDescendantIds (shared/libs/graph.ts)
시작 노드에서 엣지의 source → target 방향으로 BFS 탐색하여 모든 후속 노드 ID를 Set으로 반환합니다. 조건 분기 노드의 경우 모든 분기 경로를 자동으로 포함합니다.

### removeNode 수정 (shared/model/workflowStore.ts)
1. collectDescendantIds로 후속 노드 ID 수집
2. 삭제 대상 = 자기 자신 + 후속 노드 전체
3. 대상에 포함된 노드와 엣지를 일괄 필터링
4. activePanelNodeId가 삭제 대상에 포함되면 패널 닫기

immer draft의 edges를 current()로 plain 객체 변환 후 탐색에 사용합니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 삭제 전 확인 다이얼로그는 UI 이슈로 별도 진행 예정

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #28
