### PR TITLE
[PR] 워크플로우 직접 생성 가이드형 UI 골격 구현

### DIFF
--- a/src/features/create-workflow/index.ts
+++ b/src/features/create-workflow/index.ts
@@ -1,0 +1,2 @@
+export * from "./model";
+export * from "./ui";

--- a/src/features/create-workflow/model/index.ts
+++ b/src/features/create-workflow/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./useCreateWorkflow";

--- a/src/features/create-workflow/model/useCreateWorkflow.ts
+++ b/src/features/create-workflow/model/useCreateWorkflow.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router";
+
+import type { NodeCategory } from "@/entities/node";
+import { buildPath, useWorkflowStore } from "@/shared";
+
+// ─── 스텝 정의 ──────────────────────────────────────────────
+export type CreationStep = "start-node" | "end-node" | "creation-method";
+
+const STEP_ORDER: CreationStep[] = [
+  "start-node",
+  "end-node",
+  "creation-method",
+];
+
+// ─── 노드 선택 상태 ─────────────────────────────────────────
+export interface NodeSelection {
+  category: NodeCategory | null;
+  service: string | null;
+}
+
+const INITIAL_SELECTION: NodeSelection = {
+  category: null,
+  service: null,
+};
+
+// ─── Hook ────────────────────────────────────────────────────
+export const useCreateWorkflow = () => {
+  const navigate = useNavigate();
+  const setWorkflowMeta = useWorkflowStore((s) => s.setWorkflowMeta);
+
+  const [currentStep, setCurrentStep] = useState<CreationStep>("start-node");
+  const [startNode, setStartNode] = useState<NodeSelection>(INITIAL_SELECTION);
+  const [endNode, setEndNode] = useState<NodeSelection>(INITIAL_SELECTION);
+
+  const currentStepIndex = STEP_ORDER.indexOf(currentStep);
+
+  const goNext = useCallback(() => {
+    const nextIndex = currentStepIndex + 1;
+    if (nextIndex < STEP_ORDER.length) {
+      setCurrentStep(STEP_ORDER[nextIndex]);
+    }
+  }, [currentStepIndex]);
+
+  const goPrev = useCallback(() => {
+    const prevIndex = currentStepIndex - 1;
+    if (prevIndex >= 0) {
+      setCurrentStep(STEP_ORDER[prevIndex]);
+    }
+  }, [currentStepIndex]);
+
+  const submitCreation = useCallback(
+    (method: "ai" | "direct") => {
+      // TODO: API 연동 후 실제 워크플로우 생성 요청
+      const tempId = crypto.randomUUID();
+      setWorkflowMeta(tempId, "새 워크플로우");
+      navigate(buildPath.workflowEditor(tempId));
+
+      // method는 추후 AI 생성 흐름 구현 시 분기에 사용
+      void method;
+    },
+    [navigate, setWorkflowMeta],
+  );
+
+  return {
+    currentStep,
+    startNode,
+    endNode,
+    setStartNode,
+    setEndNode,
+    goNext,
+    goPrev,
+    submitCreation,
+    isFirstStep: currentStepIndex === 0,
+    isLastStep: currentStepIndex === STEP_ORDER.length - 1,
+  };
+};

--- a/src/features/create-workflow/ui/CreationGuide.tsx
+++ b/src/features/create-workflow/ui/CreationGuide.tsx
@@ -1,0 +1,43 @@
+import { Box } from "@chakra-ui/react";
+
+import { useCreateWorkflow } from "../model/useCreateWorkflow";
+
+import { CreationMethodStep } from "./CreationMethodStep";
+import { EndNodeStep } from "./EndNodeStep";
+import { StartNodeStep } from "./StartNodeStep";
+
+export const CreationGuide = () => {
+  const {
+    currentStep,
+    startNode,
+    endNode,
+    setStartNode,
+    setEndNode,
+    goNext,
+    goPrev,
+    submitCreation,
+  } = useCreateWorkflow();
+
+  return (
+    <Box maxW="560px" mx="auto" mt={20} px={6}>
+      {currentStep === "start-node" && (
+        <StartNodeStep
+          selection={startNode}
+          onSelect={setStartNode}
+          onNext={goNext}
+        />
+      )}
+      {currentStep === "end-node" && (
+        <EndNodeStep
+          selection={endNode}
+          onSelect={setEndNode}
+          onNext={goNext}
+          onPrev={goPrev}
+        />
+      )}
+      {currentStep === "creation-method" && (
+        <CreationMethodStep onSubmit={submitCreation} onPrev={goPrev} />
+      )}
+    </Box>
+  );
+};

--- a/src/features/create-workflow/ui/CreationMethodStep.tsx
+++ b/src/features/create-workflow/ui/CreationMethodStep.tsx
@@ -1,0 +1,72 @@
+import { MdAutoAwesome, MdTune } from "react-icons/md";
+
+import { Box, Button, HStack, Heading, Text, VStack } from "@chakra-ui/react";
+
+interface CreationMethodStepProps {
+  onSubmit: (method: "ai" | "direct") => void;
+  onPrev: () => void;
+}
+
+export const CreationMethodStep = ({
+  onSubmit,
+  onPrev,
+}: CreationMethodStepProps) => {
+  return (
+    <VStack gap={6} align="stretch">
+      <Box>
+        <Heading size="md">중간 과정을 어떻게 만들까요?</Heading>
+        <Text fontSize="sm" color="text.secondary" mt={1}>
+          생성 방식을 선택하세요
+        </Text>
+      </Box>
+
+      <VStack gap={4}>
+        <Box
+          as="button"
+          w="100%"
+          p={6}
+          borderRadius="lg"
+          border="1px solid"
+          borderColor="border.default"
+          textAlign="left"
+          cursor="pointer"
+          _hover={{ borderColor: "blue.400", bg: "blue.50" }}
+          onClick={() => onSubmit("ai")}
+        >
+          <HStack gap={3} mb={2}>
+            <Box as={MdAutoAwesome} boxSize={5} color="blue.500" />
+            <Text fontWeight="bold">AI로 생성하기</Text>
+          </HStack>
+          <Text fontSize="sm" color="text.secondary">
+            대화를 통해 AI가 자동으로 중간 과정을 구성합니다
+          </Text>
+        </Box>
+
+        <Box
+          as="button"
+          w="100%"
+          p={6}
+          borderRadius="lg"
+          border="1px solid"
+          borderColor="border.default"
+          textAlign="left"
+          cursor="pointer"
+          _hover={{ borderColor: "green.400", bg: "green.50" }}
+          onClick={() => onSubmit("direct")}
+        >
+          <HStack gap={3} mb={2}>
+            <Box as={MdTune} boxSize={5} color="green.500" />
+            <Text fontWeight="bold">직접 설정하기</Text>
+          </HStack>
+          <Text fontSize="sm" color="text.secondary">
+            단계별로 직접 노드를 구성합니다
+          </Text>
+        </Box>
+      </VStack>
+
+      <Button variant="outline" alignSelf="flex-start" onClick={onPrev}>
+        이전
+      </Button>
+    </VStack>
+  );
+};

--- a/src/features/create-workflow/ui/EndNodeStep.tsx
+++ b/src/features/create-workflow/ui/EndNodeStep.tsx
@@ -1,0 +1,51 @@
+import { Box, Button, HStack, Heading, Text, VStack } from "@chakra-ui/react";
+
+import type { NodeSelection } from "../model/useCreateWorkflow";
+
+interface EndNodeStepProps {
+  selection: NodeSelection;
+  onSelect: (selection: NodeSelection) => void;
+  onNext: () => void;
+  onPrev: () => void;
+}
+
+export const EndNodeStep = ({
+  selection,
+  onSelect,
+  onNext,
+  onPrev,
+}: EndNodeStepProps) => {
+  // TODO: 매핑 규칙 확정 후 카테고리 → 서비스 → 동작 유형 선택지 구현
+  void selection;
+  void onSelect;
+
+  return (
+    <VStack gap={6} align="stretch">
+      <Box>
+        <Heading size="md">결과를 어디에 보낼까요?</Heading>
+        <Text fontSize="sm" color="text.secondary" mt={1}>
+          자동화의 도착점을 선택하세요
+        </Text>
+      </Box>
+
+      <Box
+        p={6}
+        borderRadius="lg"
+        border="1px dashed"
+        borderColor="border.default"
+        textAlign="center"
+      >
+        <Text fontSize="sm" color="text.secondary">
+          카테고리 및 서비스 선택지 준비 중
+        </Text>
+      </Box>
+
+      <HStack justify="space-between">
+        <Button variant="outline" onClick={onPrev}>
+          이전
+        </Button>
+        <Button onClick={onNext}>다음</Button>
+      </HStack>
+    </VStack>
+  );
+};

--- a/src/features/create-workflow/ui/StartNodeStep.tsx
+++ b/src/features/create-workflow/ui/StartNodeStep.tsx
@@ -1,0 +1,46 @@
+import { Box, Button, Heading, Text, VStack } from "@chakra-ui/react";
+
+import type { NodeSelection } from "../model/useCreateWorkflow";
+
+interface StartNodeStepProps {
+  selection: NodeSelection;
+  onSelect: (selection: NodeSelection) => void;
+  onNext: () => void;
+}
+
+export const StartNodeStep = ({
+  selection,
+  onSelect,
+  onNext,
+}: StartNodeStepProps) => {
+  // TODO: 매핑 규칙 확정 후 카테고리 → 서비스 → 실행 조건 → 데이터 대상 선택지 구현
+  void selection;
+  void onSelect;
+
+  return (
+    <VStack gap={6} align="stretch">
+      <Box>
+        <Heading size="md">어디에서 데이터를 가져올까요?</Heading>
+        <Text fontSize="sm" color="text.secondary" mt={1}>
+          자동화의 시작점을 선택하세요
+        </Text>
+      </Box>
+
+      <Box
+        p={6}
+        borderRadius="lg"
+        border="1px dashed"
+        borderColor="border.default"
+        textAlign="center"
+      >
+        <Text fontSize="sm" color="text.secondary">
+          카테고리 및 서비스 선택지 준비 중
+        </Text>
+      </Box>
+
+      <Button alignSelf="flex-end" onClick={onNext}>
+        다음
+      </Button>
+    </VStack>
+  );
+};

--- a/src/features/create-workflow/ui/index.ts
+++ b/src/features/create-workflow/ui/index.ts
@@ -1,0 +1,4 @@
+export * from "./CreationGuide";
+export * from "./CreationMethodStep";
+export * from "./EndNodeStep";
+export * from "./StartNodeStep";

--- a/src/pages/workflow-new/WorkflowNewPage.tsx
+++ b/src/pages/workflow-new/WorkflowNewPage.tsx
@@ -1,3 +1,5 @@
+import { CreationGuide } from "@/features/create-workflow";
+
 export default function WorkflowNewPage() {
-  return <div>WorkflowNewPage</div>;
+  return <CreationGuide />;
 }


### PR DESCRIPTION
## 📝 요약 (Summary)

워크플로우 직접 생성 시 시작 노드 → 도착 노드 → 생성 방식 결정 순서의 가이드형 UI 골격을 구현합니다.

## ✅ 주요 변경 사항 (Key Changes)

- create-workflow feature 신규 생성 (FSD 구조)
- 3단계 스텝 UI 골격 구현 (StartNodeStep, EndNodeStep, CreationMethodStep)
- useCreateWorkflow hook으로 스텝 상태 관리
- WorkflowNewPage에서 CreationGuide 렌더링

## 💻 상세 구현 내용 (Implementation Details)

### useCreateWorkflow hook
스텝 전환(goNext/goPrev), 시작/도착 노드 선택 상태, 생성 제출 로직을 관리합니다. 생성 방식 선택 시 임시 ID로 워크플로우를 생성하고 에디터 페이지로 이동합니다.

### Step 컴포넌트 3개
각 스텝은 일상 언어로 질문하는 UI 골격입니다. 카테고리/서비스 선택지 내용은 매핑 규칙 확정 후 채울 예정입니다. CreationMethodStep은 "AI로 생성하기"와 "직접 설정하기" 두 가지 카드 형태의 선택지를 제공합니다.

### CreationGuide 컨테이너
현재 스텝에 따라 적절한 Step 컴포넌트를 렌더링합니다. 중앙 정렬된 560px 폼 레이아웃입니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 각 Step의 선택지 내용은 매핑 규칙 확정 후 구현 예정
- submitCreation의 API 연동은 백엔드 구현 후 교체 예정
- AI 생성 흐름은 직접 설정 기능 완성 후 구현 예정

## 📸 스크린샷 (Screenshots)

해당 없음 (골격 UI)

## #️⃣ 관련 이슈 (Related Issues)

- #29
