### PR TITLE
[PR] UX 표면 기술 용어를 일상 언어로 전환

### DIFF
--- a/src/entities/node/model/nodeRegistry.ts
+++ b/src/entities/node/model/nodeRegistry.ts
@@ -97,7 +97,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   "web-scraping": {
     type: "web-scraping",
-    label: "웹 스크래핑",
+    label: "웹 수집",
     category: "domain",
     iconComponent: MdLanguage,
     color: "nodeColor.webScraping",
@@ -133,7 +133,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
   // ── 프로세싱 & 로직 ──────────────────────────────────────
   trigger: {
     type: "trigger",
-    label: "트리거",
+    label: "시작 조건",
     category: "processing",
     iconComponent: MdBolt,
     color: "nodeColor.trigger",
@@ -150,7 +150,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   filter: {
     type: "filter",
-    label: "필터",
+    label: "걸러내기",
     category: "processing",
     iconComponent: MdFilterList,
     color: "nodeColor.filter",
@@ -177,7 +177,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   loop: {
     type: "loop",
-    label: "반복",
+    label: "하나씩 처리",
     category: "processing",
     iconComponent: MdLoop,
     color: "nodeColor.loop",
@@ -193,7 +193,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   condition: {
     type: "condition",
-    label: "조건 분기",
+    label: "분류",
     category: "processing",
     iconComponent: MdCallSplit,
     color: "nodeColor.condition",
@@ -223,7 +223,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   "multi-output": {
     type: "multi-output",
-    label: "다중 출력",
+    label: "여러 결과",
     category: "processing",
     iconComponent: MdCallMade,
     color: "nodeColor.multiOutput",
@@ -252,7 +252,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   "data-process": {
     type: "data-process",
-    label: "데이터 처리",
+    label: "가공",
     category: "processing",
     iconComponent: MdSettings,
     color: "nodeColor.dataProcess",
@@ -276,7 +276,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   "output-format": {
     type: "output-format",
-    label: "출력 포맷",
+    label: "형식 변환",
     category: "processing",
     iconComponent: MdArticle,
     color: "nodeColor.outputFormat",
@@ -291,7 +291,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
 
   "early-exit": {
     type: "early-exit",
-    label: "조기 종료",
+    label: "중단",
     category: "processing",
     iconComponent: MdExitToApp,
     color: "nodeColor.earlyExit",
@@ -330,7 +330,7 @@ export const NODE_REGISTRY: Record<NodeType, NodeMeta> = {
   // ── AI ───────────────────────────────────────────────────
   llm: {
     type: "llm",
-    label: "AI 처리",
+    label: "AI",
     category: "ai",
     iconComponent: MdAutoAwesome,
     color: "nodeColor.llm",

--- a/src/entities/node/ui/custom-nodes/ConditionNode.tsx
+++ b/src/entities/node/ui/custom-nodes/ConditionNode.tsx
@@ -13,7 +13,7 @@ export const ConditionNode = ({
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>
-        {config.field ?? "필드 미설정"} {config.operator ?? ""}{" "}
+        {config.field ?? "대상 미설정"} {config.operator ?? ""}{" "}
         {config.value ?? ""}
       </Text>
     </BaseNode>

--- a/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
+++ b/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
@@ -25,7 +25,7 @@ export const DataProcessNode = ({
       <Text>
         {config.operation ? OPERATION_LABEL[config.operation] : "동작 미설정"}
       </Text>
-      <Text>{config.field ?? "필드 미설정"}</Text>
+      <Text>{config.field ?? "대상 미설정"}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/FilterNode.tsx
+++ b/src/entities/node/ui/custom-nodes/FilterNode.tsx
@@ -12,7 +12,7 @@ export const FilterNode = ({
   const config = data.config as FilterNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.field ?? "필드 미설정"}</Text>
+      <Text>{config.field ?? "대상 미설정"}</Text>
       <Text>{config.operator ?? "조건 미설정"}</Text>
     </BaseNode>
   );

--- a/src/entities/node/ui/custom-nodes/LLMNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LLMNode.tsx
@@ -13,7 +13,7 @@ export const LLMNode = ({
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.model ?? "모델 미설정"}</Text>
-      <Text>{config.prompt || "프롬프트 미설정"}</Text>
+      <Text>{config.prompt || "지시사항 미설정"}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/LoopNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LoopNode.tsx
@@ -12,7 +12,7 @@ export const LoopNode = ({
   const config = data.config as LoopNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.targetField ?? "반복 대상 미설정"}</Text>
+      <Text>{config.targetField ?? "처리 대상 미설정"}</Text>
       <Text>최대 {config.maxIterations}회</Text>
     </BaseNode>
   );

--- a/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
+++ b/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
@@ -12,7 +12,7 @@ export const OutputFormatNode = ({
   const config = data.config as OutputFormatNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.format ? config.format.toUpperCase() : "포맷 미설정"}</Text>
+      <Text>{config.format ? config.format.toUpperCase() : "형식 미설정"}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/TriggerNode.tsx
+++ b/src/entities/node/ui/custom-nodes/TriggerNode.tsx
@@ -12,7 +12,7 @@ export const TriggerNode = ({
   const config = data.config as TriggerNodeConfig;
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.triggerType ?? "트리거 타입 미설정"}</Text>
+      <Text>{config.triggerType ?? "시작 조건 미설정"}</Text>
       <Text>{config.schedule ?? config.eventType ?? "일정 미설정"}</Text>
     </BaseNode>
   );

--- a/src/features/configure-node/ui/PanelRenderer.tsx
+++ b/src/features/configure-node/ui/PanelRenderer.tsx
@@ -12,5 +12,5 @@ export const PanelRenderer = () => {
 
   if (!activeNode) return null;
 
-  return <Text>노드 설정 패널 준비 중</Text>;
+  return <Text>설정 패널 준비 중</Text>;
 };


### PR DESCRIPTION
## 📝 요약 (Summary)

캔버스에 표시되는 노드 라벨과 미설정 텍스트에서 기술 용어를 일상 언어로 전환합니다.

## ✅ 주요 변경 사항 (Key Changes)

- NODE_REGISTRY label 10개를 일상 언어로 변경 (트리거 → 시작 조건, 필터 → 걸러내기 등)
- 커스텀 노드 미설정 텍스트 7개 파일에서 기술 용어 제거 (필드 → 대상, 프롬프트 → 지시사항 등)
- PanelRenderer placeholder 텍스트에서 "노드" 용어 제거

## 💻 상세 구현 내용 (Implementation Details)

### NODE_REGISTRY label 변경
프로세싱 노드의 기술 용어를 비전문가가 이해할 수 있는 일상 언어로 교체했습니다. 내부 코드(NodeType, 변수명, 주석)는 변경하지 않았습니다.

### 커스텀 노드 미설정 텍스트
"필드", "프롬프트", "포맷", "트리거 타입", "반복 대상" 등 기술적 필드명이 노출되던 미설정 상태 텍스트를 "대상", "지시사항", "형식", "시작 조건", "처리 대상"으로 교체했습니다.

### 제외 사항
NodeCategoryDrawer와 AddNodeButton은 가이드형 생성 흐름(#29)으로 대체될 예정이므로 이번 이슈에서 제외했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- NodeCategoryDrawer는 추후 가이드형 흐름으로 대체 시 삭제 예정

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #30
