### PR TITLE
[PR] 캔버스 빈 상태 UI 및 placeholder 노드 구현

### DIFF
--- a/src/entities/node/ui/custom-nodes/PlaceholderNode.tsx
+++ b/src/entities/node/ui/custom-nodes/PlaceholderNode.tsx
@@ -1,0 +1,28 @@
+import { MdAdd } from "react-icons/md";
+
+import { Box, Icon, Text, VStack } from "@chakra-ui/react";
+import { Handle, Position } from "@xyflow/react";
+
+export const PlaceholderNode = () => {
+  return (
+    <Box
+      border="2px dashed"
+      borderColor="border.default"
+      borderRadius="lg"
+      minW="200px"
+      bg="bg.surface"
+      cursor="pointer"
+      _hover={{ borderColor: "blue.400", bg: "blue.50" }}
+      transition="border-color 150ms ease, background 150ms ease"
+    >
+      <Handle type="target" position={Position.Left} />
+
+      <VStack gap={1} py={6} px={4}>
+        <Icon as={MdAdd} boxSize={6} color="text.secondary" />
+        <Text fontSize="sm" color="text.secondary">
+          다음 단계를 설정하세요
+        </Text>
+      </VStack>
+    </Box>
+  );
+};

--- a/src/entities/node/ui/custom-nodes/index.ts
+++ b/src/entities/node/ui/custom-nodes/index.ts
@@ -9,6 +9,7 @@ export * from "./LoopNode";
 export * from "./MultiOutputNode";
 export * from "./NotificationNode";
 export * from "./OutputFormatNode";
+export * from "./PlaceholderNode";
 export * from "./SpreadsheetNode";
 export * from "./StorageNode";
 export * from "./TriggerNode";

--- a/src/pages/workflow-editor/WorkflowEditorPage.tsx
+++ b/src/pages/workflow-editor/WorkflowEditorPage.tsx
@@ -7,7 +7,13 @@ import { ReactFlowProvider } from "@xyflow/react";
 
 import { AddNodeButton } from "@/features/add-node";
 import { ROUTE_PATHS, useWorkflowStore } from "@/shared";
-import { Canvas, EditorToolbar, InputPanel, OutputPanel } from "@/widgets";
+import {
+  Canvas,
+  CanvasEmptyState,
+  EditorToolbar,
+  InputPanel,
+  OutputPanel,
+} from "@/widgets";
 
 // ─── 로딩 상태 ───────────────────────────────────────────────
 const EditorLoadingView = () => (
@@ -57,6 +63,7 @@ const WorkflowEditorInner = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
+  const nodes = useWorkflowStore((s) => s.nodes);
   const setWorkflowMeta = useWorkflowStore((s) => s.setWorkflowMeta);
   const resetEditor = useWorkflowStore((s) => s.resetEditor);
 
@@ -83,9 +90,16 @@ const WorkflowEditorInner = () => {
   return (
     <Box display="flex" flexDirection="column" height="100%">
       <EditorToolbar />
-      {/* Canvas 영역 — InputPanel·OutputPanel·AddNodeButton이 absolute로 올라탐 */}
+      {/* Canvas 영역 — 패널·버튼·빈 상태가 absolute로 올라탐 */}
       <Box flex={1} position="relative" overflow="hidden">
         <Canvas />
+        {nodes.length === 0 && (
+          <CanvasEmptyState
+            onAdd={() => {
+              // TODO: 가이드형 생성 흐름 연결
+            }}
+          />
+        )}
         <InputPanel />
         <OutputPanel />
         <Box position="absolute" bottom={4} left={4} zIndex={10}>

--- a/src/shared/libs/graph.ts
+++ b/src/shared/libs/graph.ts
@@ -25,3 +25,11 @@ export const collectDescendantIds = (
 
   return descendants;
 };
+
+/**
+ * outgoing edge가 없는 끝단(leaf) 노드의 ID 목록을 반환한다.
+ */
+export const getLeafNodeIds = (nodeIds: string[], edges: Edge[]): string[] => {
+  const sourcesWithOutgoing = new Set(edges.map((e) => e.source));
+  return nodeIds.filter((id) => !sourcesWithOutgoing.has(id));
+};

--- a/src/widgets/canvas/ui/Canvas.tsx
+++ b/src/widgets/canvas/ui/Canvas.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from "react";
+
 import {
   Background,
   BackgroundVariant,
   Controls,
   MiniMap,
+  type Node,
   type NodeTypes,
   ReactFlow,
 } from "@xyflow/react";
@@ -20,12 +23,15 @@ import {
   MultiOutputNode,
   NotificationNode,
   OutputFormatNode,
+  PlaceholderNode,
   SpreadsheetNode,
   StorageNode,
   TriggerNode,
   WebScrapingNode,
 } from "@/entities/node";
-import { useWorkflowStore } from "@/shared";
+import { getLeafNodeIds, useWorkflowStore } from "@/shared";
+
+const PLACEHOLDER_OFFSET_X = 280;
 
 const nodeTypes: NodeTypes = {
   communication: CommunicationNode,
@@ -43,6 +49,7 @@ const nodeTypes: NodeTypes = {
   "early-exit": EarlyExitNode,
   notification: NotificationNode,
   llm: LLMNode,
+  placeholder: PlaceholderNode,
 };
 
 export const Canvas = () => {
@@ -52,9 +59,33 @@ export const Canvas = () => {
   const onEdgesChange = useWorkflowStore((s) => s.onEdgesChange);
   const onConnect = useWorkflowStore((s) => s.onConnect);
 
+  const nodesWithPlaceholders = useMemo(() => {
+    if (nodes.length === 0) return nodes;
+
+    const nodeIds = nodes.map((n) => n.id);
+    const leafIds = getLeafNodeIds(nodeIds, edges);
+
+    const placeholders: Node[] = leafIds.map((leafId) => {
+      const leafNode = nodes.find((n) => n.id === leafId)!;
+      return {
+        id: `placeholder-${leafId}`,
+        type: "placeholder",
+        position: {
+          x: leafNode.position.x + PLACEHOLDER_OFFSET_X,
+          y: leafNode.position.y,
+        },
+        data: {},
+        selectable: false,
+        draggable: false,
+      };
+    });
+
+    return [...nodes, ...placeholders];
+  }, [nodes, edges]);
+
   return (
     <ReactFlow
-      nodes={nodes}
+      nodes={nodesWithPlaceholders}
       edges={edges}
       nodeTypes={nodeTypes}
       onNodesChange={onNodesChange}

--- a/src/widgets/canvas/ui/CanvasEmptyState.tsx
+++ b/src/widgets/canvas/ui/CanvasEmptyState.tsx
@@ -1,0 +1,38 @@
+import { MdAdd } from "react-icons/md";
+
+import { Box, Icon, IconButton, Text, VStack } from "@chakra-ui/react";
+
+interface CanvasEmptyStateProps {
+  onAdd: () => void;
+}
+
+export const CanvasEmptyState = ({ onAdd }: CanvasEmptyStateProps) => {
+  return (
+    <Box
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      pointerEvents="none"
+      zIndex={5}
+    >
+      <VStack gap={4} pointerEvents="auto">
+        <Text fontSize="md" color="text.secondary" fontWeight="medium">
+          워크플로우를 시작하세요
+        </Text>
+        <IconButton
+          aria-label="시작하기"
+          rounded="full"
+          size="lg"
+          onClick={onAdd}
+        >
+          <Icon as={MdAdd} boxSize={6} />
+        </IconButton>
+      </VStack>
+    </Box>
+  );
+};

--- a/src/widgets/canvas/ui/index.ts
+++ b/src/widgets/canvas/ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./Canvas";
+export * from "./CanvasEmptyState";


### PR DESCRIPTION
## 📝 요약 (Summary)

캔버스에 빈 상태 안내 UI와 끝단 노드 뒤에 자동 배치되는 placeholder "+" 노드를 구현합니다.

## ✅ 주요 변경 사항 (Key Changes)

- CanvasEmptyState 컴포넌트 신규 생성 (노드 0개일 때 표시)
- PlaceholderNode 커스텀 노드 신규 생성 (점선 테두리 + 안내 텍스트)
- getLeafNodeIds 그래프 유틸 함수 추가
- Canvas에서 끝단 노드 뒤에 placeholder 노드 자동 배치

## 💻 상세 구현 내용 (Implementation Details)

### CanvasEmptyState
노드가 없을 때 캔버스 중앙에 "워크플로우를 시작하세요" 텍스트와 "+" 버튼을 표시합니다. pointer-events 제어로 캔버스 조작을 방해하지 않습니다.

### PlaceholderNode
React Flow 커스텀 노드로 등록됩니다. 점선 테두리, "+" 아이콘, "다음 단계를 설정하세요" 텍스트를 표시하며 hover 시 시각적 피드백을 제공합니다. 입력 Handle만 존재합니다.

### 자동 배치 로직
Canvas 컴포넌트에서 useMemo로 끝단 노드(outgoing edge 없는 노드)를 탐색하고, 각 끝단 노드 오른쪽(280px offset)에 placeholder를 배치합니다. placeholder는 스토어에 저장하지 않아 상태를 오염시키지 않습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

없음

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- CanvasEmptyState의 onAdd는 가이드형 생성 흐름 연결 후 구현 예정
- PlaceholderNode 클릭 이벤트는 설정 흐름 구현 후 연결 예정

## 📸 스크린샷 (Screenshots)

해당 없음

## #️⃣ 관련 이슈 (Related Issues)

- #31
