### PR TITLE
[PR] PlaceholderNode 렌더링 버그 수정

### DIFF
--- a/src/widgets/canvas/ui/Canvas.tsx
+++ b/src/widgets/canvas/ui/Canvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   Background,
@@ -6,6 +6,7 @@ import {
   Controls,
   MiniMap,
   type Node,
+  type NodeChange,
   type NodeTypes,
   ReactFlow,
 } from "@xyflow/react";
@@ -59,6 +60,16 @@ export const Canvas = () => {
   const onEdgesChange = useWorkflowStore((s) => s.onEdgesChange);
   const onConnect = useWorkflowStore((s) => s.onConnect);
 
+  const handleNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      const filtered = changes.filter(
+        (change) => !("id" in change && change.id.startsWith("placeholder-")),
+      );
+      onNodesChange(filtered);
+    },
+    [onNodesChange],
+  );
+
   const nodesWithPlaceholders = useMemo(() => {
     if (nodes.length === 0) return nodes;
 
@@ -75,6 +86,8 @@ export const Canvas = () => {
           y: leafNode.position.y,
         },
         data: {},
+        initialWidth: 100,
+        initialHeight: 134,
         selectable: false,
         draggable: false,
       };
@@ -88,7 +101,7 @@ export const Canvas = () => {
       nodes={nodesWithPlaceholders}
       edges={edges}
       nodeTypes={nodeTypes}
-      onNodesChange={onNodesChange}
+      onNodesChange={handleNodesChange}
       onEdgesChange={onEdgesChange}
       onConnect={onConnect}
       fitView


### PR DESCRIPTION
## 📝 요약 (Summary)

PlaceholderNode의 변경 이벤트가 Zustand store로 전달되면서 발생하던 렌더링 버그를 수정합니다.

## ✅ 주요 변경 사항 (Key Changes)

- `handleNodesChange`에서 placeholder ID prefix로 변경 이벤트 필터링
- PlaceholderNode에 `initialWidth`/`initialHeight` 설정으로 React Flow 초기 렌더링 보장

## 💻 상세 구현 내용 (Implementation Details)

### 변경 이벤트 필터링
PlaceholderNode는 `useMemo`로 계산되어 store에 존재하지 않는 가상 노드입니다.
React Flow controlled 모드에서 dimension 초기화 등의 변경 이벤트가 store의 `applyNodeChanges`로 전달되면, 해당 노드를 찾을 수 없어 상태 불일치가 발생합니다.

`handleNodesChange`를 추가하여 `placeholder-` prefix를 가진 변경 이벤트를 필터링한 뒤 store에 전달합니다.

### initialWidth/initialHeight 설정
React Flow v12에서 노드 첫 렌더링 시 dimension 측정 과정이 필요합니다.
`initialWidth: 100`, `initialHeight: 134`를 설정하여 측정 없이도 즉시 렌더링되도록 합니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

PlaceholderNode가 canvas에 표시되지 않는 문제의 원인을 분석한 결과, React Flow controlled 모드에서 store에 존재하지 않는 노드의 변경 이벤트가 `applyNodeChanges`에 전달되는 것이 근본 원인이었습니다. 변경 이벤트 필터링과 초기 크기 지정으로 해결했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- PlaceholderNode 클릭 시 설정창 연동은 후속 이슈에서 구현 예정

## 📸 스크린샷 (Screenshots)

> (구현한 페이지에 대한 스크린샷)

## #️⃣ 관련 이슈 (Related Issues)

- #43
