### PR TITLE
[PR] 타입 정합 정리

### DIFF
--- a/src/entities/node/model/dataType.ts
+++ b/src/entities/node/model/dataType.ts
@@ -1,53 +1,28 @@
-// ─── 노드 간 데이터 흐름 타입 ─────────────────────────────────
 /**
- * 노드 사이를 흐르는 데이터의 종류.
- * 이전 노드의 outputType → 다음 노드의 inputType 으로 연결된다.
+ * Data shapes that can flow between nodes.
+ * If a node's output matches a downstream node's input, the edge is allowed.
  */
 export type DataType =
-  | "file-list" // 여러 파일 (Google Drive 폴더 등)
-  | "single-file" // 단일 파일
-  | "text" // AI 요약 결과, 알림 메시지 등 텍스트
-  | "spreadsheet" // 시트/셀 단위 구조화 데이터
-  | "email-list" // 여러 이메일
-  | "api-response"; // JSON 형식 외부 API 응답
+  | "file-list"
+  | "single-file"
+  | "text"
+  | "spreadsheet"
+  | "email-list"
+  | "single-email"
+  | "schedule-data"
+  | "api-response";
 
-// ─── 노드의 입출력 타입 정의 ──────────────────────────────────
 /**
- * 단일 노드가 받아들이는 입력과 내보내는 출력의 데이터 타입.
- * inputTypes 가 빈 배열이면 시작 노드(소스)로 사용 가능하다.
- */
-export interface NodeDataIO {
-  inputTypes: DataType[];
-  outputTypes: DataType[];
-}
-
-// ─── 호환성 검증 ─────────────────────────────────────────────
-/**
- * 이전 노드의 출력이 다음 노드의 입력과 호환되는지 확인한다.
- * 하나라도 겹치는 DataType 이 있으면 호환으로 판정한다.
- *
- * TODO: 매핑 규칙 확정 후 세부 로직 구현
+ * Returns whether two nodes are compatible based on their I/O types.
+ * Empty input/output arrays mean the node has no type constraint.
  */
 export const isDataTypeCompatible = (
   sourceOutput: DataType[],
   targetInput: DataType[],
 ): boolean => {
-  // 입력 또는 출력이 비어있으면 제약 없음 (시작/종단 노드)
   if (sourceOutput.length === 0 || targetInput.length === 0) {
     return true;
   }
 
   return sourceOutput.some((type) => targetInput.includes(type));
-};
-
-// ─── 타입 변환 매핑 ──────────────────────────────────────────
-/**
- * 특정 노드 타입이 입력 데이터를 어떤 출력 데이터로 변환하는지 정의한다.
- * 예: file-list → LLM 요약 → text
- *
- * TODO: 매핑 규칙 확정 후 실제 변환 테이블 구현
- */
-export type DataTypeTransformRule = {
-  inputType: DataType;
-  outputType: DataType;
 };

--- a/src/entities/node/model/nodePresentation.ts
+++ b/src/entities/node/model/nodePresentation.ts
@@ -2,6 +2,7 @@ import type { IconType } from "react-icons";
 import { MdApps } from "react-icons/md";
 
 import { NODE_REGISTRY } from "./nodeRegistry";
+import { getTypedConfig } from "./types";
 import type {
   CommunicationNodeConfig,
   FlowNodeData,
@@ -75,12 +76,14 @@ const getRoleLabel = (role: NodeRole): string => {
 const getConfiguredTitle = (data: FlowNodeData): string | null => {
   switch (data.type) {
     case "storage": {
-      const service = (data.config as StorageNodeConfig).service;
-      return service ? STORAGE_SERVICE_TITLE[service] : null;
+      const config = getTypedConfig("storage", data.config);
+      return config.service ? STORAGE_SERVICE_TITLE[config.service] : null;
     }
     case "communication": {
-      const service = (data.config as CommunicationNodeConfig).service;
-      return service ? COMMUNICATION_SERVICE_TITLE[service] : null;
+      const config = getTypedConfig("communication", data.config);
+      return config.service
+        ? COMMUNICATION_SERVICE_TITLE[config.service]
+        : null;
     }
     default:
       return null;

--- a/src/entities/node/model/types.ts
+++ b/src/entities/node/model/types.ts
@@ -167,6 +167,31 @@ export type NodeConfig =
   | NotificationNodeConfig
   | LLMNodeConfig;
 
+export type NodeConfigMap = {
+  communication: CommunicationNodeConfig;
+  storage: StorageNodeConfig;
+  spreadsheet: SpreadsheetNodeConfig;
+  "web-scraping": WebScrapingNodeConfig;
+  calendar: CalendarNodeConfig;
+  trigger: TriggerNodeConfig;
+  filter: FilterNodeConfig;
+  loop: LoopNodeConfig;
+  condition: ConditionNodeConfig;
+  "multi-output": MultiOutputNodeConfig;
+  "data-process": DataProcessNodeConfig;
+  "output-format": OutputFormatNodeConfig;
+  "early-exit": EarlyExitNodeConfig;
+  notification: NotificationNodeConfig;
+  llm: LLMNodeConfig;
+};
+
+export const getTypedConfig = <T extends NodeType>(
+  _type: T,
+  config: NodeConfig,
+): NodeConfigMap[T] => {
+  return config as NodeConfigMap[T];
+};
+
 // ─── React Flow Node data 필드 타입 ─────────────────────────
 export interface FlowNodeData extends Record<string, unknown> {
   type: NodeType;

--- a/src/entities/node/model/types.ts
+++ b/src/entities/node/model/types.ts
@@ -201,4 +201,5 @@ export interface FlowNodeData extends Record<string, unknown> {
   inputTypes: import("./dataType").DataType[];
   /** 이 노드가 내보내는 데이터 타입 목록 */
   outputTypes: import("./dataType").DataType[];
+  authWarning?: boolean;
 }

--- a/src/entities/node/ui/custom-nodes/CalendarNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CalendarNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { CalendarNodeConfig, FlowNodeData } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const CalendarNode = ({
@@ -9,7 +10,7 @@ export const CalendarNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as CalendarNodeConfig;
+  const config = getTypedConfig("calendar", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.service ?? "서비스 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { CommunicationNodeConfig, FlowNodeData } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const CommunicationNode = ({
@@ -9,7 +10,7 @@ export const CommunicationNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as CommunicationNodeConfig;
+  const config = getTypedConfig("communication", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.service ?? "서비스 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/ConditionNode.tsx
+++ b/src/entities/node/ui/custom-nodes/ConditionNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { ConditionNodeConfig, FlowNodeData } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const ConditionNode = ({
@@ -9,7 +10,7 @@ export const ConditionNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as ConditionNodeConfig;
+  const config = getTypedConfig("condition", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>

--- a/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
+++ b/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
@@ -1,6 +1,7 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
+import { getTypedConfig } from "../../model";
 import type { DataProcessNodeConfig, FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
@@ -19,7 +20,7 @@ export const DataProcessNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as DataProcessNodeConfig;
+  const config = getTypedConfig("data-process", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>

--- a/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
+++ b/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { EarlyExitNodeConfig, FlowNodeData } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const EarlyExitNode = ({
@@ -9,7 +10,7 @@ export const EarlyExitNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as EarlyExitNodeConfig;
+  const config = getTypedConfig("early-exit", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.condition ?? "조건 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/FilterNode.tsx
+++ b/src/entities/node/ui/custom-nodes/FilterNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FilterNodeConfig, FlowNodeData } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const FilterNode = ({
@@ -9,7 +10,7 @@ export const FilterNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as FilterNodeConfig;
+  const config = getTypedConfig("filter", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.field ?? "대상 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/LLMNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LLMNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, LLMNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const LLMNode = ({
@@ -9,7 +10,7 @@ export const LLMNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as LLMNodeConfig;
+  const config = getTypedConfig("llm", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.model ?? "모델 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/LoopNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LoopNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, LoopNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const LoopNode = ({
@@ -9,7 +10,7 @@ export const LoopNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as LoopNodeConfig;
+  const config = getTypedConfig("loop", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.targetField ?? "처리 대상 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/MultiOutputNode.tsx
+++ b/src/entities/node/ui/custom-nodes/MultiOutputNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, MultiOutputNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const MultiOutputNode = ({
@@ -9,7 +10,7 @@ export const MultiOutputNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as MultiOutputNodeConfig;
+  const config = getTypedConfig("multi-output", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>출력 {config.outputCount}개</Text>

--- a/src/entities/node/ui/custom-nodes/NotificationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/NotificationNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, NotificationNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const NotificationNode = ({
@@ -9,7 +10,7 @@ export const NotificationNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as NotificationNodeConfig;
+  const config = getTypedConfig("notification", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.channel ?? "채널 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
+++ b/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, OutputFormatNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const OutputFormatNode = ({
@@ -9,7 +10,7 @@ export const OutputFormatNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as OutputFormatNodeConfig;
+  const config = getTypedConfig("output-format", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.format ? config.format.toUpperCase() : "형식 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/SpreadsheetNode.tsx
+++ b/src/entities/node/ui/custom-nodes/SpreadsheetNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, SpreadsheetNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const SpreadsheetNode = ({
@@ -9,7 +10,7 @@ export const SpreadsheetNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as SpreadsheetNodeConfig;
+  const config = getTypedConfig("spreadsheet", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.sheetName ?? "시트 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/StorageNode.tsx
+++ b/src/entities/node/ui/custom-nodes/StorageNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, StorageNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const StorageNode = ({
@@ -9,7 +10,7 @@ export const StorageNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as StorageNodeConfig;
+  const config = getTypedConfig("storage", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.service ?? "서비스 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/TriggerNode.tsx
+++ b/src/entities/node/ui/custom-nodes/TriggerNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, TriggerNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const TriggerNode = ({
@@ -9,7 +10,7 @@ export const TriggerNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as TriggerNodeConfig;
+  const config = getTypedConfig("trigger", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.triggerType ?? "시작 조건 미설정"}</Text>

--- a/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
+++ b/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@chakra-ui/react";
 import type { NodeProps } from "@xyflow/react";
 
-import type { FlowNodeData, WebScrapingNodeConfig } from "../../model/types";
+import { getTypedConfig } from "../../model";
+import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const WebScrapingNode = ({
@@ -9,7 +10,7 @@ export const WebScrapingNode = ({
   data,
   selected,
 }: NodeProps & { data: FlowNodeData }) => {
-  const config = data.config as WebScrapingNodeConfig;
+  const config = getTypedConfig("web-scraping", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
       <Text>{config.targetUrl ?? "URL 미설정"}</Text>

--- a/src/entities/workflow/model/types.ts
+++ b/src/entities/workflow/model/types.ts
@@ -2,24 +2,41 @@ import type { Edge, Node } from "@xyflow/react";
 
 import type { FlowNodeData } from "@/entities/node";
 
-// ─── 워크플로우 상태 ─────────────────────────────────────────
 export type WorkflowStatus = "active" | "inactive";
 
 export type ExecutionStatus = "idle" | "running" | "success" | "failed";
 
-// ─── 워크플로우 엔티티 ───────────────────────────────────────
+export interface TriggerConfig {
+  type: "manual" | "schedule" | "event";
+  schedule?: string;
+  eventService?: string;
+  eventType?: string;
+}
+
 export interface Workflow {
   id: string;
   name: string;
+  description: string;
   status: WorkflowStatus;
   nodes: Node<FlowNodeData>[];
   edges: Edge[];
+  userId: string;
+  sharedWith: string[];
+  isTemplate: boolean;
+  templateId: string | null;
+  trigger: TriggerConfig | null;
+  isActive: boolean;
   createdAt: string;
   updatedAt: string;
 }
 
-/** 목록 화면용 요약 타입 */
 export type WorkflowSummary = Pick<
   Workflow,
-  "id" | "name" | "status" | "createdAt" | "updatedAt"
+  | "id"
+  | "name"
+  | "description"
+  | "status"
+  | "isActive"
+  | "createdAt"
+  | "updatedAt"
 >;

--- a/src/shared/types/api.type.ts
+++ b/src/shared/types/api.type.ts
@@ -1,7 +1,14 @@
 export type ApiResponse<T> = {
+  success: boolean;
   data: T;
-  status: string;
-  serverDateTime: string;
+  message: string | null;
   errorCode: string | null;
-  errorMessage: string | null;
+};
+
+export type PageResponse<T> = {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
 };


### PR DESCRIPTION
## 📝 요약 (Summary)

> 백엔드 실제 응답/엔티티 구조에 맞춰 프론트엔드의 기반 타입을 정리했습니다.
> 이후 API 연동, 어댑터 계층 구현, 팀원별 노드 작업을 안전하게 진행할 수 있는 타입 기반을 마련했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- `ApiResponse`를 백엔드 계약에 맞게 교체하고 `PageResponse`를 추가했습니다.
- `DataType`에 `single-email`, `schedule-data`를 추가하고 미사용 타입 정의를 정리했습니다.
- `NodeConfigMap`과 `getTypedConfig`를 도입해 노드 설정 접근 패턴을 통일했습니다.
- `Workflow` / `WorkflowSummary`를 백엔드 엔티티 기준으로 확장했습니다.
- `FlowNodeData`에 읽기 전용 경고 필드 `authWarning`을 추가했습니다.

## 💻 상세 구현 내용 (Implementation Details)

### 1. 공통 응답 타입 정합

`src/shared/types/api.type.ts`

- 기존 프론트 전용 응답 구조:
  - `data`, `status`, `serverDateTime`, `errorCode`, `errorMessage`
- 변경 후 백엔드 기준 응답 구조:
  - `success`, `data`, `message`, `errorCode`
- 이후 목록성 API를 대비해 `PageResponse<T>`도 함께 추가

### 2. DataType 최소 확장

`src/entities/node/model/dataType.ts`

- 기존 6개 타입에 아래 2개를 추가
  - `single-email`
  - `schedule-data`
- 현재 사용되지 않는 `NodeDataIO`, `DataTypeTransformRule` 제거
- 프론트 내부 표기는 기존대로 kebab-case 유지
- 백엔드와의 케이스 변환은 추후 어댑터 레이어에서 처리 예정

### 3. 노드 설정 타입 접근 정리

`src/entities/node/model/types.ts`
`src/entities/node/model/nodePresentation.ts`
`src/entities/node/ui/custom-nodes/*`

- `NodeConfigMap` 추가
- `getTypedConfig(type, config)` 헬퍼 추가
- `nodePresentation`과 각 커스텀 노드에서 흩어져 있던 `as XxxNodeConfig`를 공용 헬퍼 호출로 정리

주의:
- `getTypedConfig`는 런타임 타입 가드가 아니라 중앙집중형 캐스팅 헬퍼입니다.
- switch case의 리터럴 타입 또는 노드 타입이 고정된 컴포넌트 맥락에서 사용하도록 정리했습니다.

### 4. Workflow 엔티티 확장

`src/entities/workflow/model/types.ts`

- `TriggerConfig` 추가
- `Workflow`에 아래 필드 추가
  - `description`
  - `userId`
  - `sharedWith`
  - `isTemplate`
  - `templateId`
  - `trigger`
  - `isActive`
- `WorkflowSummary`도 목록 화면 기준 필드로 확장

### 5. FlowNodeData 최소 확장

`src/entities/node/model/types.ts`

- `FlowNodeData`에 `authWarning?: boolean` 추가
- `role`은 저장하지 않고 `nodePresentation.ts` 계산 로직을 source of truth로 유지
- `inputTypes[]`, `outputTypes[]` 배열 모델도 그대로 유지

## 🚀 트러블 슈팅 (Trouble Shooting)

> React Flow의 제네릭 타입과 노드별 config 유니온이 섞이면서 `as` 캐스팅이 여러 파일에 퍼져 있었습니다. 이를 개별 컴포넌트마다 제각각 유지하지 않고 `getTypedConfig` 헬퍼로 모아 코드 패턴을 통일했습니다.
>
> 또 백엔드 모델과 프론트 편집 모델이 완전히 같지 않기 때문에, 이번 Phase에서는 프론트 내부 모델을 무리하게 바꾸지 않고 “타입 확장 + 최소 정합”까지만 먼저 처리했습니다. 실제 직렬화/역직렬화는 다음 Phase의 어댑터 레이어에서 분리할 계획입니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

> `DataType`은 프론트 내부에서 kebab-case를 유지하고 있습니다. 백엔드의 `UPPER_SNAKE_CASE`와의 변환은 아직 구현되지 않았으며, 추후 `workflow-adapter`에서 처리할 예정입니다.
>
> `getTypedConfig`는 진짜 타입 가드가 아니므로, 범용 함수 바깥에서 `data.type` 유니온 전체를 그대로 넘기는 식으로 사용하면 타입이 충분히 좁혀지지 않을 수 있습니다.
>
> `authWarning`은 현재 타입만 추가된 상태이며, 실제 서버 응답 수신 및 표시 로직은 후속 API/어댑터 작업에서 연결해야 합니다.

## 📸 스크린샷 (Screenshots)

> 타입 정합 작업으로 별도 UI 스크린샷 없음

## #️⃣ 관련 이슈 (Related Issues)

- #52 
