### PR TITLE
[PR] 팀원 작업 패턴 확립

### DIFF
--- a/src/entities/node/model/nodePresentation.ts
+++ b/src/entities/node/model/nodePresentation.ts
@@ -1,5 +1,4 @@
 import type { IconType } from "react-icons";
-import { MdApps } from "react-icons/md";
 
 import { NODE_REGISTRY } from "./nodeRegistry";
 import { getTypedConfig } from "./types";
@@ -32,8 +31,6 @@ export interface NodePresentation {
   surfaceState: NodeSurfaceState;
   iconComponent: IconType;
 }
-
-const TEMPORARY_ICON = MdApps;
 
 const STORAGE_SERVICE_TITLE: Record<
   NonNullable<StorageNodeConfig["service"]>,
@@ -75,18 +72,46 @@ const getRoleLabel = (role: NodeRole): string => {
 
 const getConfiguredTitle = (data: FlowNodeData): string | null => {
   switch (data.type) {
-    case "storage": {
-      const config = getTypedConfig("storage", data.config);
-      return config.service ? STORAGE_SERVICE_TITLE[config.service] : null;
-    }
     case "communication": {
       const config = getTypedConfig("communication", data.config);
       return config.service
         ? COMMUNICATION_SERVICE_TITLE[config.service]
         : null;
     }
-    default:
+    case "storage": {
+      const config = getTypedConfig("storage", data.config);
+      return config.service ? STORAGE_SERVICE_TITLE[config.service] : null;
+    }
+    case "spreadsheet": {
+      const config = getTypedConfig("spreadsheet", data.config);
+      return config.service ? "Google Sheets" : null;
+    }
+    case "calendar": {
+      const config = getTypedConfig("calendar", data.config);
+      return config.service ? "Google Calendar" : null;
+    }
+    case "web-scraping": {
+      const config = getTypedConfig("web-scraping", data.config);
+      return config.targetUrl ?? null;
+    }
+    case "filter":
+    case "loop":
+    case "condition":
+    case "multi-output":
+    case "data-process":
+    case "output-format":
+    case "early-exit":
+    case "notification":
+    case "trigger":
       return null;
+    case "llm": {
+      const config = getTypedConfig("llm", data.config);
+      return config.model ?? null;
+    }
+    default: {
+      const _exhaustive: never = data.type;
+      return _exhaustive;
+    }
   }
 };
 
@@ -129,6 +154,6 @@ export const getNodePresentation = (
     title: configuredTitle ?? fallbackTitle,
     helperText: getHelperText(role, surfaceState),
     surfaceState,
-    iconComponent: TEMPORARY_ICON,
+    iconComponent: meta.iconComponent,
   };
 };

--- a/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
@@ -1,20 +1,33 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import type { Node, NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
+const COMMUNICATION_SERVICE_LABEL: Record<"gmail" | "slack", string> = {
+  gmail: "Gmail",
+  slack: "Slack",
+};
+
 export const CommunicationNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("communication", data.config);
+  const summary =
+    config.service || config.action ? (
+      <Text fontSize="xs" color="text.secondary">
+        {config.service ? COMMUNICATION_SERVICE_LABEL[config.service] : null}
+        {config.service && config.action ? " / " : null}
+        {config.action}
+      </Text>
+    ) : null;
+
   return (
-    <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.service ?? "서비스 미설정"}</Text>
-      <Text>{config.action ?? "동작 미설정"}</Text>
+    <BaseNode id={id} data={data} selected={selected ?? false}>
+      {summary}
     </BaseNode>
   );
 };

--- a/src/entities/node/ui/custom-nodes/StorageNode.tsx
+++ b/src/entities/node/ui/custom-nodes/StorageNode.tsx
@@ -1,20 +1,33 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import type { Node, NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import type { FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
+const STORAGE_SERVICE_LABEL: Record<"google-drive" | "notion", string> = {
+  "google-drive": "Google Drive",
+  notion: "Notion",
+};
+
 export const StorageNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("storage", data.config);
+  const summary =
+    config.service || config.action ? (
+      <Text fontSize="xs" color="text.secondary">
+        {config.service ? STORAGE_SERVICE_LABEL[config.service] : null}
+        {config.service && config.action ? " / " : null}
+        {config.action}
+      </Text>
+    ) : null;
+
   return (
-    <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.service ?? "서비스 미설정"}</Text>
-      <Text>{config.action ?? "동작 미설정"}</Text>
+    <BaseNode id={id} data={data} selected={selected ?? false}>
+      {summary}
     </BaseNode>
   );
 };

--- a/src/features/configure-node/model/panelRegistry.ts
+++ b/src/features/configure-node/model/panelRegistry.ts
@@ -1,7 +1,11 @@
+import { CommunicationPanel } from "../ui/panels";
+
 import type { NodePanelRegistry } from "./types";
 
 /**
  * 각 노드 타입별 설정 패널을 연결하는 registry입니다.
  * 실제 패널이 준비되면 이 객체에 컴포넌트를 추가하면 됩니다.
  */
-export const NODE_PANEL_REGISTRY: NodePanelRegistry = {};
+export const NODE_PANEL_REGISTRY: NodePanelRegistry = {
+  communication: CommunicationPanel,
+};

--- a/src/features/configure-node/ui/panels/CommunicationPanel.tsx
+++ b/src/features/configure-node/ui/panels/CommunicationPanel.tsx
@@ -1,0 +1,83 @@
+import { Box, Button, Text } from "@chakra-ui/react";
+
+import {
+  type CommunicationNodeConfig,
+  getNodePresentation,
+  getTypedConfig,
+} from "@/entities/node";
+import { useWorkflowStore } from "@/shared";
+
+import type { NodePanelProps } from "../../model";
+
+import { NodePanelShell } from "./NodePanelShell";
+
+const COMMUNICATION_SERVICE_OPTIONS = [
+  { value: "gmail", label: "Gmail" },
+  { value: "slack", label: "Slack" },
+] as const satisfies ReadonlyArray<{
+  value: NonNullable<CommunicationNodeConfig["service"]>;
+  label: string;
+}>;
+
+export const CommunicationPanel = ({ nodeId, data }: NodePanelProps) => {
+  const startNodeId = useWorkflowStore((s) => s.startNodeId);
+  const endNodeId = useWorkflowStore((s) => s.endNodeId);
+  const updateNodeConfig = useWorkflowStore((s) => s.updateNodeConfig);
+
+  const presentation = getNodePresentation(data, {
+    nodeId,
+    startNodeId,
+    endNodeId,
+  });
+  const config = getTypedConfig("communication", data.config);
+
+  const handleServiceChange = (
+    service: NonNullable<CommunicationNodeConfig["service"]>,
+  ) => {
+    updateNodeConfig(nodeId, { ...config, service });
+  };
+
+  return (
+    <NodePanelShell
+      eyebrow={presentation.roleLabel}
+      title={presentation.title}
+      description="Select the communication service for this node."
+    >
+      <Box display="flex" flexDirection="column" gap={3}>
+        <Text fontSize="sm" fontWeight="medium" color="text.primary">
+          Service
+        </Text>
+
+        <Box display="flex" gap={2} flexWrap="wrap">
+          {COMMUNICATION_SERVICE_OPTIONS.map((option) => {
+            const selected = config.service === option.value;
+
+            return (
+              <Button
+                key={option.value}
+                size="sm"
+                variant={selected ? "solid" : "outline"}
+                onClick={() => handleServiceChange(option.value)}
+              >
+                {option.label}
+              </Button>
+            );
+          })}
+        </Box>
+      </Box>
+
+      {config.service ? (
+        <Text fontSize="xs" color="text.secondary">
+          Selected service:{" "}
+          {COMMUNICATION_SERVICE_OPTIONS.find(
+            (option) => option.value === config.service,
+          )?.label ?? config.service}
+        </Text>
+      ) : (
+        <Text fontSize="xs" color="text.secondary">
+          Choose one service to mark this node as configured.
+        </Text>
+      )}
+    </NodePanelShell>
+  );
+};

--- a/src/features/configure-node/ui/panels/index.ts
+++ b/src/features/configure-node/ui/panels/index.ts
@@ -1,2 +1,3 @@
+export * from "./CommunicationPanel";
 export * from "./GenericNodePanel";
 export * from "./NodePanelShell";


### PR DESCRIPTION
## 📝 요약 (Summary)

> 노드 카드, 설정 패널, 커스텀 노드 구현 패턴을 정리해 팀원 작업 기준을 고정했습니다.
> 이후 노드별 패널 추가와 커스텀 노드 확장을 같은 방식으로 병렬 진행할 수 있는 상태를 만들었습니다.

## ✅ 주요 변경 사항 (Key Changes)

- `nodePresentation`이 `NODE_REGISTRY`의 실제 아이콘을 사용하도록 연결했습니다.
- `getConfiguredTitle()`을 모든 `NodeType`이 드러나는 switch 구조로 정리했습니다.
- 전용 설정 패널 레퍼런스로 `CommunicationPanel`을 추가하고 registry에 등록했습니다.
- `CommunicationNode`, `StorageNode`를 기준으로 커스텀 노드 props 타입과 summary 표시 패턴을 정리했습니다.

## 💻 상세 구현 내용 (Implementation Details)

### 1. 노드 카드 아이콘 연결

`src/entities/node/model/nodePresentation.ts`

- 임시 `MdApps` 아이콘 제거
- `NODE_REGISTRY[data.type].iconComponent`를 그대로 사용하도록 변경
- 이제 노드 카드 아이콘과 메타 registry가 항상 같은 source를 바라봄

### 2. getConfiguredTitle 확장 구조 정리

`src/entities/node/model/nodePresentation.ts`

- `communication`, `storage`, `spreadsheet`, `calendar`, `web-scraping`, `llm`은 설정 기반 표시 제목 연결
- 아직 규칙이 없는 타입은 명시적으로 `null` 반환
- 마지막에 exhaustive check를 추가해 새 `NodeType`이 생기면 switch 누락을 바로 드러낼 수 있게 정리

### 3. 레퍼런스 패널 구현

`src/features/configure-node/ui/panels/CommunicationPanel.tsx`
`src/features/configure-node/model/panelRegistry.ts`

- `NodePanelShell`을 기반으로 첫 전용 패널 `CommunicationPanel` 추가
- 역할 라벨과 제목은 `getNodePresentation()` 재사용
- 설정값은 `getTypedConfig("communication", data.config)`로 접근
- 서비스 선택 버튼 클릭 시 store의 `updateNodeConfig()`로 즉시 반영
- registry에 `communication` 패널 등록

현재 동작:
- `communication` 노드: 전용 패널 렌더링
- 나머지 노드: `GenericNodePanel` 렌더링

### 4. 커스텀 노드 패턴 정리

`src/entities/node/ui/custom-nodes/CommunicationNode.tsx`
`src/entities/node/ui/custom-nodes/StorageNode.tsx`

- props 타입을 `NodeProps & { data: FlowNodeData }`에서 `NodeProps<Node<FlowNodeData>>`로 정리
- `selected ?? false`로 `BaseNode`에 넘기는 패턴 통일
- 요약 텍스트는 실제 설정값이 있을 때만 렌더링
- 미설정 상태에서는 `null`을 넘겨 `BaseNode` helper text가 우선 노출되도록 정리

## 🚀 트러블 슈팅 (Trouble Shooting)

> 커스텀 노드마다 props 타입과 summary 처리 방식이 조금씩 달라질 수 있는 상태였기 때문에, 우선 대표 노드 2개에 동일한 패턴을 적용해 기준 구현을 만들었습니다.
>
> 또 설정 패널 구조는 이미 있었지만 실제 registry 사용 예시가 없어 팀원이 어디까지 구현하면 되는지 애매했는데, `CommunicationPanel`을 첫 레퍼런스로 추가해 확장 경로를 명확히 했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

> `communication` 외 노드들은 아직 전용 패널이 없어 `GenericNodePanel`이 렌더링됩니다.
>
> `getConfiguredTitle()`에서 여러 타입은 아직 `null` 반환만 하고 있으며, 구체적인 표시 규칙은 후속 작업에서 채워야 합니다.
>
> 커스텀 노드 props 패턴 정리는 대표 노드 2개에 먼저 적용한 상태이며, 나머지 노드들은 같은 방식으로 순차 정리할 수 있습니다.

## 📸 스크린샷 (Screenshots)

> 패턴 정리 작업으로 별도 UI 스크린샷 없음

## #️⃣ 관련 이슈 (Related Issues)

- #54 
