### PR TITLE
[PR] FSD import 규칙과 워크플로우 에디터 구조 정리

### DIFF
--- a/docs/CONVENTION.md
+++ b/docs/CONVENTION.md
@@ -121,9 +121,21 @@ import { useUploadFiles } from "./useUploadFiles";
 | 상황 | 경로 방식 | 예시 |
 |------|----------|------|
 | **다른** FSD 레이어 참조 | `@/` 절대경로 | `import { BaseNode } from "@/entities"` |
-| **같은** FSD 레이어 참조 | `./` `../` 상대경로 | `import { useUploadFiles } from "./useUploadFiles"` |
+| **같은 슬라이스 내부** 참조 | `./` `../` 상대경로 | `import { useUploadFiles } from "./useUploadFiles"` |
+| **다른 슬라이스** 참조 | 슬라이스 공개 API(`index.ts`)만 사용 | `import { useWorkflowStore } from "@/features/workflow-editor"` |
+| **shared** 참조 | segment 단위 deep import 허용 | `import { request } from "@/shared/api/core"` |
 
-> **절대 혼용 금지**: 같은 레이어에서 `@/` 사용 금지, 다른 레이어에서 상대경로 사용 금지
+> **슬라이스 정의**: `features/add-node/`, `features/configure-node/`처럼 최상위 FSD 레이어 바로 아래의 각 폴더를 하나의 슬라이스로 본다. 형제 슬라이스는 같은 레이어여도 "다른 슬라이스"다.
+>
+> **금지 규칙**
+> - 같은 슬라이스 내부에서 `@/` 절대경로 사용 금지
+> - 다른 레이어를 상대경로로 참조 금지
+> - 다른 슬라이스의 내부 경로 직접 참조 금지
+>   - 금지 예: `@/widgets/app-shell/model/useSidebarState`
+>   - 허용 예: `@/widgets/app-shell`
+>
+> **예외**
+> - `shared`는 slice가 아니라 segment 레이어이므로 `@/shared/api/core`, `@/shared/libs/graph` 같은 segment 단위 deep import를 허용한다.
 
 ### 3.3 Type Import
 
@@ -137,6 +149,30 @@ import { type AssignmentType, useCreateProject } from "@/entities";
 import type { AssignmentType } from "@/entities";
 import { useCreateProject } from "@/entities";
 ```
+
+값 import와 타입 import가 같은 모듈에서 함께 필요하면 **한 줄로 병합**한다:
+
+```typescript
+// O 올바름
+import { addEdge, type Edge, type Node } from "@xyflow/react";
+
+// X 금지
+import { addEdge } from "@xyflow/react";
+import type { Edge, Node } from "@xyflow/react";
+```
+
+`import type` 스타일이 다시 생기지 않도록 ESLint에서 `@typescript-eslint/consistent-type-imports`를 강제한다.
+
+#### Type Import 일괄 정리 절차
+
+`lint:fix`로 import 스타일을 일괄 정리할 때는 아래 순서를 따른다.
+
+1. `pnpm lint`로 사전 clean 상태를 확인한다.
+2. `eslint.config.js`에 `@typescript-eslint/consistent-type-imports` 규칙을 추가한다.
+3. `pnpm lint:fix`를 실행한다.
+4. `git diff`를 검토해 변경이 import 스타일 정리만인지 확인한다.
+5. `pnpm tsc`, `pnpm build`를 다시 실행한다.
+6. 확인이 끝난 뒤 커밋한다.
 
 ### 3.4 배럴 파일 (index.ts)
 

--- a/docs/CONVENTION.md
+++ b/docs/CONVENTION.md
@@ -161,7 +161,7 @@ import { addEdge } from "@xyflow/react";
 import type { Edge, Node } from "@xyflow/react";
 ```
 
-`import type` 스타일이 다시 생기지 않도록 ESLint에서 `@typescript-eslint/consistent-type-imports`를 강제한다.
+`import type` 스타일이 다시 생기지 않도록 ESLint에서 `@typescript-eslint/consistent-type-imports`를 강제하고, 별도 `import type` 선언은 추가 규칙으로 금지한다.
 
 #### Type Import 일괄 정리 절차
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,15 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          disallowTypeAnnotations: false,
+          fixStyle: 'inline-type-imports',
+        },
+      ],
+    },
   },
 ])

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,14 @@ export default defineConfig([
           fixStyle: 'inline-type-imports',
         },
       ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "ImportDeclaration[importKind='type']",
+          message:
+            '별도 `import type` 문 대신 인라인 `type` specifier를 사용하세요.',
+        },
+      ],
     },
   },
 ])

--- a/src/entities/auth/api/exchange-auth.api.ts
+++ b/src/entities/auth/api/exchange-auth.api.ts
@@ -1,7 +1,7 @@
 import { publicApiClient } from "@/shared/api";
 import { requestWithClient } from "@/shared/api/core";
 
-import type { LoginResponse } from "./types";
+import { type LoginResponse } from "./types";
 
 export const exchangeAuthAPI = (exchangeCode: string): Promise<LoginResponse> =>
   requestWithClient<LoginResponse>(publicApiClient, {

--- a/src/entities/auth/api/refresh-auth.api.ts
+++ b/src/entities/auth/api/refresh-auth.api.ts
@@ -1,7 +1,7 @@
 import { publicApiClient } from "@/shared/api";
 import { requestWithClient } from "@/shared/api/core";
 
-import type { LoginResponse } from "./types";
+import { type LoginResponse } from "./types";
 
 export const refreshAuthAPI = (refreshToken: string): Promise<LoginResponse> =>
   requestWithClient<LoginResponse>(publicApiClient, {

--- a/src/entities/auth/api/types.ts
+++ b/src/entities/auth/api/types.ts
@@ -1,4 +1,4 @@
-import type { AuthSessionUser } from "@/shared";
+import { type AuthSessionUser } from "@/shared";
 
 export type AuthUser = AuthSessionUser;
 

--- a/src/entities/connection/model/types.ts
+++ b/src/entities/connection/model/types.ts
@@ -1,4 +1,4 @@
-import type { Edge } from "@xyflow/react";
+import { type Edge } from "@xyflow/react";
 
 // ─── 엣지 확장 타입 ──────────────────────────────────────────
 export interface FlowEdgeData extends Record<string, unknown> {

--- a/src/entities/connection/ui/FlowArrowEdge.tsx
+++ b/src/entities/connection/ui/FlowArrowEdge.tsx
@@ -1,10 +1,10 @@
-import type { CSSProperties } from "react";
+import { type CSSProperties } from "react";
 
 import { Box, Text } from "@chakra-ui/react";
 import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath } from "@xyflow/react";
-import type { EdgeProps } from "@xyflow/react";
+import { type EdgeProps } from "@xyflow/react";
 
-import type { FlowEdgeData } from "../model";
+import { type FlowEdgeData } from "../model";
 
 const ARROW_WIDTH = 40;
 const ARROW_HEIGHT = 18;

--- a/src/entities/execution/api/get-execution-list.api.ts
+++ b/src/entities/execution/api/get-execution-list.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { ExecutionDetail } from "./types";
+import { type ExecutionDetail } from "./types";
 
 export const getExecutionListAPI = (
   workflowId: string,

--- a/src/entities/execution/api/get-execution.api.ts
+++ b/src/entities/execution/api/get-execution.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { ExecutionDetail } from "./types";
+import { type ExecutionDetail } from "./types";
 
 export const getExecutionAPI = (
   workflowId: string,

--- a/src/entities/node/model/nodePresentation.ts
+++ b/src/entities/node/model/nodePresentation.ts
@@ -1,11 +1,11 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 
 import { NODE_REGISTRY } from "./nodeRegistry";
 import { getTypedConfig } from "./types";
-import type {
-  CommunicationNodeConfig,
-  FlowNodeData,
-  StorageNodeConfig,
+import {
+  type CommunicationNodeConfig,
+  type FlowNodeData,
+  type StorageNodeConfig,
 } from "./types";
 
 export type NodeRole = "source" | "process" | "destination";

--- a/src/entities/node/model/nodeRegistry.ts
+++ b/src/entities/node/model/nodeRegistry.ts
@@ -1,4 +1,4 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 import {
   MdArticle,
   MdAutoAwesome,
@@ -17,8 +17,8 @@ import {
   MdTableChart,
 } from "react-icons/md";
 
-import type { DataType } from "./dataType";
-import type { NodeCategory, NodeConfig, NodeType } from "./types";
+import { type DataType } from "./dataType";
+import { type NodeCategory, type NodeConfig, type NodeType } from "./types";
 
 // ─── NodeMeta 인터페이스 ─────────────────────────────────────
 export interface NodeMeta {

--- a/src/entities/node/ui/BaseNode.tsx
+++ b/src/entities/node/ui/BaseNode.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import type { MouseEvent, ReactNode } from "react";
+import { type MouseEvent, type ReactNode } from "react";
 import { MdCancel } from "react-icons/md";
 
 import { Box, Icon, IconButton, Text } from "@chakra-ui/react";
 import { Handle, Position } from "@xyflow/react";
 
 import { getNodePresentation } from "../model";
-import type { FlowNodeData } from "../model/types";
+import { type FlowNodeData } from "../model/types";
 
 import { useNodeEditorContext } from "./NodeEditorContext";
 

--- a/src/entities/node/ui/NodeEditorProvider.tsx
+++ b/src/entities/node/ui/NodeEditorProvider.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 
-import type { NodeEditorContextValue } from "./NodeEditorContext";
+import { type NodeEditorContextValue } from "./NodeEditorContext";
 import { NodeEditorContext } from "./NodeEditorContext";
 
 type NodeEditorProviderProps = {

--- a/src/entities/node/ui/custom-nodes/CalendarNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CalendarNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const CalendarNode = ({

--- a/src/entities/node/ui/custom-nodes/CalendarNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CalendarNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const CalendarNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("calendar", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CommunicationNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { Node, NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 const COMMUNICATION_SERVICE_LABEL: Record<"gmail" | "slack", string> = {

--- a/src/entities/node/ui/custom-nodes/ConditionNode.tsx
+++ b/src/entities/node/ui/custom-nodes/ConditionNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const ConditionNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("condition", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/ConditionNode.tsx
+++ b/src/entities/node/ui/custom-nodes/ConditionNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const ConditionNode = ({

--- a/src/entities/node/ui/custom-nodes/CreationMethodNode.tsx
+++ b/src/entities/node/ui/custom-nodes/CreationMethodNode.tsx
@@ -1,7 +1,7 @@
 import { MdAdd, MdAutoAwesome } from "react-icons/md";
 
 import { Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
-import type { Node, NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 type CreationMethodNodeData = {
   onSelectManual?: () => void;

--- a/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
+++ b/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { DataProcessNodeConfig, FlowNodeData } from "../../model/types";
+import { type DataProcessNodeConfig, type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 const OPERATION_LABEL: Record<

--- a/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
+++ b/src/entities/node/ui/custom-nodes/DataProcessNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type DataProcessNodeConfig, type FlowNodeData } from "../../model/types";
@@ -19,7 +19,7 @@ export const DataProcessNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("data-process", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
+++ b/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const EarlyExitNode = ({

--- a/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
+++ b/src/entities/node/ui/custom-nodes/EarlyExitNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const EarlyExitNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("early-exit", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/FilterNode.tsx
+++ b/src/entities/node/ui/custom-nodes/FilterNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const FilterNode = ({

--- a/src/entities/node/ui/custom-nodes/FilterNode.tsx
+++ b/src/entities/node/ui/custom-nodes/FilterNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const FilterNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("filter", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/LLMNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LLMNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const LLMNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("llm", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/LLMNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LLMNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const LLMNode = ({

--- a/src/entities/node/ui/custom-nodes/LoopNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LoopNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const LoopNode = ({

--- a/src/entities/node/ui/custom-nodes/LoopNode.tsx
+++ b/src/entities/node/ui/custom-nodes/LoopNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const LoopNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("loop", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/MultiOutputNode.tsx
+++ b/src/entities/node/ui/custom-nodes/MultiOutputNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const MultiOutputNode = ({

--- a/src/entities/node/ui/custom-nodes/MultiOutputNode.tsx
+++ b/src/entities/node/ui/custom-nodes/MultiOutputNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const MultiOutputNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("multi-output", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/NotificationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/NotificationNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const NotificationNode = ({

--- a/src/entities/node/ui/custom-nodes/NotificationNode.tsx
+++ b/src/entities/node/ui/custom-nodes/NotificationNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const NotificationNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("notification", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
+++ b/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const OutputFormatNode = ({

--- a/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
+++ b/src/entities/node/ui/custom-nodes/OutputFormatNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const OutputFormatNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("output-format", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/PlaceholderNode.tsx
+++ b/src/entities/node/ui/custom-nodes/PlaceholderNode.tsx
@@ -1,7 +1,7 @@
 import { MdAdd } from "react-icons/md";
 
 import { Box, Icon, Text, VStack } from "@chakra-ui/react";
-import type { Node, NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 type PlaceholderNodeData = {
   label?: string;

--- a/src/entities/node/ui/custom-nodes/SpreadsheetNode.tsx
+++ b/src/entities/node/ui/custom-nodes/SpreadsheetNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const SpreadsheetNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("spreadsheet", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/SpreadsheetNode.tsx
+++ b/src/entities/node/ui/custom-nodes/SpreadsheetNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const SpreadsheetNode = ({

--- a/src/entities/node/ui/custom-nodes/StorageNode.tsx
+++ b/src/entities/node/ui/custom-nodes/StorageNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { Node, NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 const STORAGE_SERVICE_LABEL: Record<"google-drive" | "notion", string> = {

--- a/src/entities/node/ui/custom-nodes/TriggerNode.tsx
+++ b/src/entities/node/ui/custom-nodes/TriggerNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const TriggerNode = ({

--- a/src/entities/node/ui/custom-nodes/TriggerNode.tsx
+++ b/src/entities/node/ui/custom-nodes/TriggerNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const TriggerNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("trigger", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
+++ b/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { type NodeProps } from "@xyflow/react";
+import { type Node, type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
@@ -9,7 +9,7 @@ export const WebScrapingNode = ({
   id,
   data,
   selected,
-}: NodeProps & { data: FlowNodeData }) => {
+}: NodeProps<Node<FlowNodeData>>) => {
   const config = getTypedConfig("web-scraping", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>

--- a/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
+++ b/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@chakra-ui/react";
-import type { NodeProps } from "@xyflow/react";
+import { type NodeProps } from "@xyflow/react";
 
 import { getTypedConfig } from "../../model";
-import type { FlowNodeData } from "../../model/types";
+import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
 export const WebScrapingNode = ({

--- a/src/entities/oauth-token/api/connect-oauth-token.api.ts
+++ b/src/entities/oauth-token/api/connect-oauth-token.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { OAuthConnectResponse } from "./types";
+import { type OAuthConnectResponse } from "./types";
 
 export const connectOAuthTokenAPI = (
   service: string,

--- a/src/entities/oauth-token/api/get-oauth-tokens.api.ts
+++ b/src/entities/oauth-token/api/get-oauth-tokens.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { OAuthTokenSummary } from "./types";
+import { type OAuthTokenSummary } from "./types";
 
 export const getOAuthTokensAPI = (): Promise<OAuthTokenSummary[]> =>
   request<OAuthTokenSummary[]>({

--- a/src/entities/template/api/create-template.api.ts
+++ b/src/entities/template/api/create-template.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { CreateTemplateRequest, TemplateDetail } from "./types";
+import { type CreateTemplateRequest, type TemplateDetail } from "./types";
 
 export const createTemplateAPI = (
   body: CreateTemplateRequest,

--- a/src/entities/template/api/get-template-list.api.ts
+++ b/src/entities/template/api/get-template-list.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { TemplateSummary } from "./types";
+import { type TemplateSummary } from "./types";
 
 export const getTemplateListAPI = (
   category?: string,

--- a/src/entities/template/api/get-template.api.ts
+++ b/src/entities/template/api/get-template.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { TemplateDetail } from "./types";
+import { type TemplateDetail } from "./types";
 
 export const getTemplateAPI = (id: string): Promise<TemplateDetail> =>
   request<TemplateDetail>({

--- a/src/entities/template/api/instantiate-template.api.ts
+++ b/src/entities/template/api/instantiate-template.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { InstantiateTemplateResponse } from "./types";
+import { type InstantiateTemplateResponse } from "./types";
 
 export const instantiateTemplateAPI = (
   id: string,

--- a/src/entities/template/api/types.ts
+++ b/src/entities/template/api/types.ts
@@ -1,7 +1,7 @@
-import type {
-  EdgeDefinitionResponse,
-  NodeDefinitionResponse,
-  WorkflowResponse,
+import {
+  type EdgeDefinitionResponse,
+  type NodeDefinitionResponse,
+  type WorkflowResponse,
 } from "@/entities/workflow";
 
 export interface TemplateSummary {

--- a/src/entities/template/model/useInstantiateTemplateMutation.ts
+++ b/src/entities/template/model/useInstantiateTemplateMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 
-import type { WorkflowResponse } from "@/entities/workflow";
+import { type WorkflowResponse } from "@/entities/workflow";
 import { type MutationPolicyOptions, toMutationMeta } from "@/shared/api";
 import { syncWorkflowCache } from "@/entities/workflow";
 

--- a/src/entities/workflow/api/add-workflow-node.api.ts
+++ b/src/entities/workflow/api/add-workflow-node.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { NodeAddRequest, WorkflowResponse } from "./types";
+import { type NodeAddRequest, type WorkflowResponse } from "./types";
 
 export const addWorkflowNodeAPI = (
   workflowId: string,

--- a/src/entities/workflow/api/create-workflow.api.ts
+++ b/src/entities/workflow/api/create-workflow.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { CreateWorkflowRequest, WorkflowResponse } from "./types";
+import { type CreateWorkflowRequest, type WorkflowResponse } from "./types";
 
 export const createWorkflowAPI = (
   body: CreateWorkflowRequest,

--- a/src/entities/workflow/api/delete-workflow-node.api.ts
+++ b/src/entities/workflow/api/delete-workflow-node.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { WorkflowResponse } from "./types";
+import { type WorkflowResponse } from "./types";
 
 export const deleteWorkflowNodeAPI = (
   workflowId: string,

--- a/src/entities/workflow/api/generate-workflow.api.ts
+++ b/src/entities/workflow/api/generate-workflow.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { WorkflowGenerateRequest, WorkflowResponse } from "./types";
+import { type WorkflowGenerateRequest, type WorkflowResponse } from "./types";
 
 export const generateWorkflowAPI = (
   body: WorkflowGenerateRequest,

--- a/src/entities/workflow/api/get-workflow-choices.api.ts
+++ b/src/entities/workflow/api/get-workflow-choices.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { ChoiceResponse } from "./types";
+import { type ChoiceResponse } from "./types";
 
 export const getWorkflowChoicesAPI = (
   workflowId: string,

--- a/src/entities/workflow/api/get-workflow-list.api.ts
+++ b/src/entities/workflow/api/get-workflow-list.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { WorkflowListResponse } from "./types";
+import { type WorkflowListResponse } from "./types";
 
 export const getWorkflowListAPI = (
   page = 0,

--- a/src/entities/workflow/api/get-workflow.api.ts
+++ b/src/entities/workflow/api/get-workflow.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { WorkflowResponse } from "./types";
+import { type WorkflowResponse } from "./types";
 
 export const getWorkflowAPI = (id: string): Promise<WorkflowResponse> =>
   request<WorkflowResponse>({

--- a/src/entities/workflow/api/select-workflow-choice.api.ts
+++ b/src/entities/workflow/api/select-workflow-choice.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { NodeChoiceSelectRequest, NodeSelectionResult } from "./types";
+import { type NodeChoiceSelectRequest, type NodeSelectionResult } from "./types";
 
 export const selectWorkflowChoiceAPI = (
   workflowId: string,

--- a/src/entities/workflow/api/share-workflow.api.ts
+++ b/src/entities/workflow/api/share-workflow.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { ShareRequest } from "./types";
+import { type ShareRequest } from "./types";
 
 export const shareWorkflowAPI = (
   workflowId: string,

--- a/src/entities/workflow/api/types.ts
+++ b/src/entities/workflow/api/types.ts
@@ -1,6 +1,6 @@
-import type { PageResponse, ValidationWarning } from "@/shared";
+import { type PageResponse, type ValidationWarning } from "@/shared";
 
-import type { TriggerConfig, Workflow } from "../model";
+import { type TriggerConfig, type Workflow } from "../model";
 
 export type WorkflowListResponse = PageResponse<WorkflowResponse>;
 

--- a/src/entities/workflow/api/update-workflow-node.api.ts
+++ b/src/entities/workflow/api/update-workflow-node.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { NodeUpdateRequest, WorkflowResponse } from "./types";
+import { type NodeUpdateRequest, type WorkflowResponse } from "./types";
 
 export const updateWorkflowNodeAPI = (
   workflowId: string,

--- a/src/entities/workflow/api/update-workflow.api.ts
+++ b/src/entities/workflow/api/update-workflow.api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/shared/api/core";
 
-import type { UpdateWorkflowRequest, WorkflowResponse } from "./types";
+import { type UpdateWorkflowRequest, type WorkflowResponse } from "./types";
 
 export const updateWorkflowAPI = (
   id: string,

--- a/src/entities/workflow/lib/workflow-node-adapter.ts
+++ b/src/entities/workflow/lib/workflow-node-adapter.ts
@@ -1,17 +1,17 @@
-import type { Edge, Node } from "@xyflow/react";
+import { type Edge, type Node } from "@xyflow/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
-import type {
-  DataType,
-  FlowNodeData,
-  NodeConfig,
-  NodeType,
+import {
+  type DataType,
+  type FlowNodeData,
+  type NodeConfig,
+  type NodeType,
 } from "@/entities/node";
 
-import type {
-  EdgeDefinitionResponse,
-  NodeAddRequest,
-  NodeDefinitionResponse,
+import {
+  type EdgeDefinitionResponse,
+  type NodeAddRequest,
+  type NodeDefinitionResponse,
 } from "../api";
 
 const DATA_TYPE_MAP = {

--- a/src/entities/workflow/model/types.ts
+++ b/src/entities/workflow/model/types.ts
@@ -1,7 +1,7 @@
-import type { Edge, Node } from "@xyflow/react";
+import { type Edge, type Node } from "@xyflow/react";
 
-import type { FlowNodeData } from "@/entities/node";
-import type { ValidationWarning } from "@/shared";
+import { type FlowNodeData } from "@/entities/node";
+import { type ValidationWarning } from "@/shared";
 
 export type WorkflowStatus = "active" | "inactive";
 

--- a/src/entities/workflow/model/workflow-cache-utils.ts
+++ b/src/entities/workflow/model/workflow-cache-utils.ts
@@ -1,13 +1,13 @@
 import { executionKeys } from "@/shared/constants";
 import { queryClient } from "@/shared/libs";
-import type {
-  WorkflowSummary,
+import {
+  type WorkflowSummary,
 } from "./types";
 import { getWorkflowStatus } from "./types";
-import type {
-  ChoiceResponse,
-  NodeSelectionResult,
-  WorkflowResponse,
+import {
+  type ChoiceResponse,
+  type NodeSelectionResult,
+  type WorkflowResponse,
 } from "../api";
 
 import { workflowKeys } from "./query-keys";

--- a/src/features/add-node/model/serviceMap.ts
+++ b/src/features/add-node/model/serviceMap.ts
@@ -1,4 +1,4 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 import {
   MdCalendarMonth,
   MdEmail,
@@ -15,7 +15,7 @@ import {
   SiSlack,
 } from "react-icons/si";
 
-import type { NodeType } from "@/entities/node";
+import { type NodeType } from "@/entities/node";
 
 /**
  * 카테고리(NodeType) 내 실제 서비스 정의.

--- a/src/features/add-node/model/serviceRequirements.ts
+++ b/src/features/add-node/model/serviceRequirements.ts
@@ -1,4 +1,4 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 import {
   MdDescription,
   MdDriveFileMove,
@@ -13,7 +13,7 @@ import {
   MdUploadFile,
 } from "react-icons/md";
 
-import type { NodeType } from "@/entities/node";
+import { type NodeType } from "@/entities/node";
 
 /**
  * 서비스 선택 후 보여줄 요구사항(use-case) 옵션.

--- a/src/features/add-node/model/useAddNode.ts
+++ b/src/features/add-node/model/useAddNode.ts
@@ -1,10 +1,10 @@
 import { useRef } from "react";
 
-import type { Node } from "@xyflow/react";
+import { type Node } from "@xyflow/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
-import type { DataType } from "@/entities/node";
-import type { FlowNodeData, NodeType } from "@/entities/node";
+import { type DataType } from "@/entities/node";
+import { type FlowNodeData, type NodeType } from "@/entities/node";
 import { useWorkflowStore } from "@/features/workflow-editor";
 
 const BASE_POSITION = { x: 250, y: 250 };

--- a/src/features/add-node/ui/NodeCategoryDrawer.tsx
+++ b/src/features/add-node/ui/NodeCategoryDrawer.tsx
@@ -18,8 +18,8 @@ import {
 } from "@chakra-ui/react";
 
 import { getNodesByCategory } from "@/entities/node";
-import type { NodeCategory } from "@/entities/node";
-import type { NodeType } from "@/entities/node";
+import { type NodeCategory } from "@/entities/node";
+import { type NodeType } from "@/entities/node";
 
 import { useAddNode } from "../model/useAddNode";
 

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 import { MdArrowBack, MdCancel, MdSearch } from "react-icons/md";
 
 import { Box, Grid, Icon, Input, Text, VStack } from "@chakra-ui/react";
@@ -19,11 +19,11 @@ import {
   useAddWorkflowNodeMutation,
   useDeleteWorkflowNodeMutation,
 } from "@/entities/workflow";
-import type { FlowNodeData, NodeMeta } from "@/entities/node";
+import { type FlowNodeData, type NodeMeta } from "@/entities/node";
 import { useWorkflowStore } from "@/features/workflow-editor";
 
 import { CATEGORY_SERVICE_MAP } from "../model/serviceMap";
-import type { ServiceOption } from "../model/serviceMap";
+import { type ServiceOption } from "../model/serviceMap";
 import {
   SERVICE_REQUIREMENTS,
   type ServiceRequirement,

--- a/src/features/choice-panel/model/dataTypeKeyMap.ts
+++ b/src/features/choice-panel/model/dataTypeKeyMap.ts
@@ -1,7 +1,7 @@
-import type { DataType } from "@/entities/node";
-import type { NodeType } from "@/entities/node";
+import { type DataType } from "@/entities/node";
+import { type NodeType } from "@/entities/node";
 
-import type { MappingDataTypeKey, MappingNodeType } from "./types";
+import { type MappingDataTypeKey, type MappingNodeType } from "./types";
 
 // ─── DataType ↔ MappingDataTypeKey 변환 ─────────────────────
 

--- a/src/features/choice-panel/model/mappingRules.ts
+++ b/src/features/choice-panel/model/mappingRules.ts
@@ -1,4 +1,4 @@
-import type { MappingRules } from "./types";
+import { type MappingRules } from "./types";
 
 /**
  * 1200개 시나리오에서 추출한 선택지 매핑 규칙.

--- a/src/features/choice-panel/model/wizardSummary.ts
+++ b/src/features/choice-panel/model/wizardSummary.ts
@@ -1,7 +1,7 @@
-import type { DataType } from "@/entities/node";
+import { type DataType } from "@/entities/node";
 
 import { MAPPING_RULES } from "./mappingRules";
-import type { MappingAction } from "./types";
+import { type MappingAction } from "./types";
 
 export const OUTPUT_DATA_LABELS: Record<DataType, string> = {
   "file-list": "파일 목록",

--- a/src/features/configure-node/model/panelRegistry.ts
+++ b/src/features/configure-node/model/panelRegistry.ts
@@ -1,6 +1,6 @@
 import { CommunicationPanel } from "../ui/panels";
 
-import type { NodePanelRegistry } from "./types";
+import { type NodePanelRegistry } from "./types";
 
 /**
  * 각 노드 타입별 설정 패널을 연결하는 registry입니다.

--- a/src/features/configure-node/model/types.ts
+++ b/src/features/configure-node/model/types.ts
@@ -1,6 +1,6 @@
-import type { ComponentType } from "react";
+import { type ComponentType } from "react";
 
-import type { FlowNodeData, NodeType } from "@/entities/node";
+import { type FlowNodeData, type NodeType } from "@/entities/node";
 
 export interface NodePanelProps {
   nodeId: string;

--- a/src/features/configure-node/ui/PanelRenderer.tsx
+++ b/src/features/configure-node/ui/PanelRenderer.tsx
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import type { ErrorInfo, ReactNode } from "react";
+import { type ErrorInfo, type ReactNode } from "react";
 
 import { Box, Text } from "@chakra-ui/react";
 

--- a/src/features/configure-node/ui/panels/CommunicationPanel.tsx
+++ b/src/features/configure-node/ui/panels/CommunicationPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/entities/node";
 import { useWorkflowStore } from "@/features/workflow-editor";
 
-import type { NodePanelProps } from "../../model";
+import { type NodePanelProps } from "../../model";
 
 import { NodePanelShell } from "./NodePanelShell";
 

--- a/src/features/configure-node/ui/panels/GenericNodePanel.tsx
+++ b/src/features/configure-node/ui/panels/GenericNodePanel.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "@chakra-ui/react";
 import { getNodePresentation } from "@/entities/node";
 import { useWorkflowStore } from "@/features/workflow-editor";
 
-import type { NodePanelProps } from "../../model";
+import { type NodePanelProps } from "../../model";
 
 import { NodePanelShell } from "./NodePanelShell";
 

--- a/src/features/configure-node/ui/panels/NodePanelShell.tsx
+++ b/src/features/configure-node/ui/panels/NodePanelShell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 
 import { Box, Heading, Text } from "@chakra-ui/react";
 

--- a/src/features/workflow-editor/model/useSaveWorkflowMutation.ts
+++ b/src/features/workflow-editor/model/useSaveWorkflowMutation.ts
@@ -6,7 +6,7 @@ import {
 } from "@/entities/workflow";
 import { type MutationPolicyOptions, toMutationMeta } from "@/shared/api";
 
-import type { WorkflowEditorStoreState } from "./workflow-editor-adapter";
+import { type WorkflowEditorStoreState } from "./workflow-editor-adapter";
 import { toWorkflowUpdateRequest } from "./workflow-editor-adapter";
 
 type SaveWorkflowVariables = {

--- a/src/features/workflow-editor/model/workflow-editor-adapter.ts
+++ b/src/features/workflow-editor/model/workflow-editor-adapter.ts
@@ -1,9 +1,9 @@
-import type { Edge, Node } from "@xyflow/react";
+import { type Edge, type Node } from "@xyflow/react";
 
-import type { FlowNodeData } from "@/entities/node";
-import type {
-  UpdateWorkflowRequest,
-  WorkflowResponse,
+import { type FlowNodeData } from "@/entities/node";
+import {
+  type UpdateWorkflowRequest,
+  type WorkflowResponse,
 } from "@/entities/workflow/api";
 import {
   toEdgeDefinition,

--- a/src/features/workflow-editor/model/workflow-editor-adapter.ts
+++ b/src/features/workflow-editor/model/workflow-editor-adapter.ts
@@ -4,13 +4,11 @@ import { type FlowNodeData } from "@/entities/node";
 import {
   type UpdateWorkflowRequest,
   type WorkflowResponse,
-} from "@/entities/workflow/api";
-import {
   toEdgeDefinition,
   toFlowEdge,
   toFlowNode,
   toNodeDefinition,
-} from "@/entities/workflow/lib";
+} from "@/entities/workflow";
 
 export interface WorkflowEditorStoreState {
   workflowName: string;

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -1,19 +1,19 @@
 import { addEdge, applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
-import type {
-  Connection,
-  Edge,
-  EdgeChange,
-  Node,
-  NodeChange,
+import {
+  type Connection,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
 } from "@xyflow/react";
 import { current } from "immer";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
-import type { FlowNodeData } from "@/entities/node";
+import { type FlowNodeData } from "@/entities/node";
 import { collectDescendantIds } from "@/shared/libs/graph";
 
-import type { WorkflowHydratedState } from "./workflow-editor-adapter";
+import { type WorkflowHydratedState } from "./workflow-editor-adapter";
 
 export type ExecutionStatus = "idle" | "running" | "success" | "failed";
 

--- a/src/pages/templates/model/template-list.ts
+++ b/src/pages/templates/model/template-list.ts
@@ -1,4 +1,4 @@
-import type { TemplateSummary } from "@/entities/template";
+import { type TemplateSummary } from "@/entities/template";
 import { getRelativeTimeLabel } from "@/shared";
 
 export const getRelativeCreatedLabel = (createdAt: string) =>

--- a/src/pages/templates/ui/TemplateRow.tsx
+++ b/src/pages/templates/ui/TemplateRow.tsx
@@ -1,9 +1,9 @@
-import type { KeyboardEvent, MouseEvent } from "react";
+import { type KeyboardEvent, type MouseEvent } from "react";
 import { MdMoreHoriz } from "react-icons/md";
 
 import { Box, Flex, HStack, IconButton, Text, VStack } from "@chakra-ui/react";
 
-import type { TemplateSummary } from "@/entities/template";
+import { type TemplateSummary } from "@/entities/template";
 
 import {
   getRelativeCreatedLabel,

--- a/src/pages/workflows/model/types.ts
+++ b/src/pages/workflows/model/types.ts
@@ -1,6 +1,6 @@
-import type { ServiceBadgeKey } from "@/shared";
+import { type ServiceBadgeKey } from "@/shared";
 
-import { WORKFLOW_FILTERS } from "./constants";
+import { type WORKFLOW_FILTERS } from "./constants";
 
 export type WorkflowFilterKey = (typeof WORKFLOW_FILTERS)[number]["key"];
 export type { ServiceBadgeKey };

--- a/src/pages/workflows/model/workflow-list.ts
+++ b/src/pages/workflows/model/workflow-list.ts
@@ -3,9 +3,9 @@ import {
   getRelativeTimeLabel,
   getServiceBadgeKeyFromService,
 } from "@/shared";
-import type {
-  NodeDefinitionResponse,
-  WorkflowResponse,
+import {
+  type NodeDefinitionResponse,
+  type WorkflowResponse,
 } from "@/entities/workflow";
 
 import { type ServiceBadgeKey, type WorkflowFilterKey } from "./types";

--- a/src/pages/workflows/ui/WorkflowRow.tsx
+++ b/src/pages/workflows/ui/WorkflowRow.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, MouseEvent } from "react";
+import { type KeyboardEvent, type MouseEvent } from "react";
 import {
   MdErrorOutline,
   MdMoreHoriz,
@@ -17,7 +17,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
-import type { WorkflowResponse } from "@/entities/workflow";
+import { type WorkflowResponse } from "@/entities/workflow";
 
 import {
   getBuildProgressLabel,

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import type { AxiosError, InternalAxiosRequestConfig } from "axios";
+import { type AxiosError, type InternalAxiosRequestConfig } from "axios";
 
 import {
   clearAuthSession,

--- a/src/shared/api/core/api-error.ts
+++ b/src/shared/api/core/api-error.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from "axios";
 
-import type { ApiResponse } from "../../types";
+import { type ApiResponse } from "../../types";
 
 export class ApiError extends Error {
   public readonly errorCode: string | null;

--- a/src/shared/api/core/request.ts
+++ b/src/shared/api/core/request.ts
@@ -1,6 +1,6 @@
-import type { AxiosInstance, AxiosRequestConfig } from "axios";
+import { type AxiosInstance, type AxiosRequestConfig } from "axios";
 
-import type { ApiResponse } from "../../types";
+import { type ApiResponse } from "../../types";
 import { apiClient } from "../client";
 
 import {

--- a/src/shared/api/query-policy.ts
+++ b/src/shared/api/query-policy.ts
@@ -1,12 +1,12 @@
-import type {
-  InfiniteData,
-  QueryKey,
-  UseInfiniteQueryOptions,
-  UseMutationOptions,
-  UseQueryOptions,
+import {
+  type InfiniteData,
+  type QueryKey,
+  type UseInfiniteQueryOptions,
+  type UseMutationOptions,
+  type UseQueryOptions,
 } from "@tanstack/react-query";
 
-import type { ApiError } from "../api/core";
+import { type ApiError } from "../api/core";
 
 type MetaPolicyOptions = {
   showErrorToast?: boolean;

--- a/src/shared/libs/graph.ts
+++ b/src/shared/libs/graph.ts
@@ -1,4 +1,4 @@
-import type { Edge } from "@xyflow/react";
+import { type Edge } from "@xyflow/react";
 
 /**
  * 시작 노드에서 엣지를 따라 하위 방향(source → target)으로 탐색하여

--- a/src/shared/ui/ServiceBadge.tsx
+++ b/src/shared/ui/ServiceBadge.tsx
@@ -1,4 +1,4 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 import {
   MdAutoAwesome,
   MdBolt,

--- a/src/widgets/app-shell/index.ts
+++ b/src/widgets/app-shell/index.ts
@@ -1,1 +1,2 @@
+export * from "./model/useSidebarState";
 export * from "./ui";

--- a/src/widgets/app-shell/model/sidebarItems.ts
+++ b/src/widgets/app-shell/model/sidebarItems.ts
@@ -1,4 +1,4 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 import {
   MdAdd,
   MdHelpOutline,

--- a/src/widgets/app-shell/ui/SidebarNavItem.tsx
+++ b/src/widgets/app-shell/ui/SidebarNavItem.tsx
@@ -1,4 +1,4 @@
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 
 import { Box, Button, Icon, Text } from "@chakra-ui/react";
 

--- a/src/widgets/app-shell/ui/SidebarUserMenu.tsx
+++ b/src/widgets/app-shell/ui/SidebarUserMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { IconType } from "react-icons";
+import { type IconType } from "react-icons";
 import { useNavigate } from "react-router";
 
 import { Box, Button, VStack } from "@chakra-ui/react";

--- a/src/widgets/canvas/ui/Canvas.tsx
+++ b/src/widgets/canvas/ui/Canvas.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
-import type { MouseEvent } from "react";
+import { type MouseEvent } from "react";
 
 import {
   Background,
@@ -9,12 +9,12 @@ import {
   ReactFlow,
   useReactFlow,
 } from "@xyflow/react";
-import type {
-  DefaultEdgeOptions,
-  EdgeTypes,
-  Node,
-  NodeChange,
-  NodeTypes,
+import {
+  type DefaultEdgeOptions,
+  type EdgeTypes,
+  type Node,
+  type NodeChange,
+  type NodeTypes,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
@@ -39,7 +39,7 @@ import {
   TriggerNode,
   WebScrapingNode,
 } from "@/entities/node";
-import type { NodeType } from "@/entities/node";
+import { type NodeType } from "@/entities/node";
 import { isDataTypeCompatible } from "@/entities/node";
 import { useAddNode } from "@/features/add-node";
 import { useWorkflowStore } from "@/features/workflow-editor";

--- a/src/widgets/editor-layout/ui/EditorLayout.tsx
+++ b/src/widgets/editor-layout/ui/EditorLayout.tsx
@@ -2,8 +2,7 @@ import { Outlet } from "react-router";
 
 import { Box, Flex } from "@chakra-ui/react";
 
-import { useSidebarState } from "@/widgets/app-shell/model/useSidebarState";
-import { AppSidebar } from "@/widgets/app-shell/ui/AppSidebar";
+import { AppSidebar, useSidebarState } from "@/widgets/app-shell";
 
 export const EditorLayout = () => {
   const {

--- a/src/widgets/editor-toolbar/ui/EditorToolbar.tsx
+++ b/src/widgets/editor-toolbar/ui/EditorToolbar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 import { MdCheck, MdPlayArrow, MdRefresh, MdSave } from "react-icons/md";
 
 import {

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -3,7 +3,7 @@ import { MdCancel } from "react-icons/md";
 import { Box, Icon, Text } from "@chakra-ui/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
-import type { FlowNodeData } from "@/entities/node";
+import { type FlowNodeData } from "@/entities/node";
 import {
   OUTPUT_DATA_LABELS,
   findActionById,

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -4,7 +4,7 @@ import { MdCancel } from "react-icons/md";
 import { Box, Icon, Spinner, Text, VStack } from "@chakra-ui/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
-import type { DataType, NodeMeta, NodeType } from "@/entities/node";
+import { type DataType, type NodeMeta, type NodeType } from "@/entities/node";
 import {
   type ChoiceBranchConfig,
   type ChoiceFollowUp,
@@ -26,11 +26,11 @@ import {
   toDataType,
   toMappingKey,
 } from "@/features/choice-panel";
-import type {
-  BranchConfig,
-  FollowUp,
-  MappingAction,
-  MappingDataTypeKey,
+import {
+  type BranchConfig,
+  type FollowUp,
+  type MappingAction,
+  type MappingDataTypeKey,
 } from "@/features/choice-panel";
 import { PanelRenderer } from "@/features/configure-node";
 import { useWorkflowStore } from "@/features/workflow-editor";

--- a/src/widgets/output-panel/ui/WizardStepContent.tsx
+++ b/src/widgets/output-panel/ui/WizardStepContent.tsx
@@ -3,10 +3,10 @@ import { MdArrowBack } from "react-icons/md";
 
 import { Box, Button, Icon, Input, Text, VStack } from "@chakra-ui/react";
 
-import type {
-  ChoiceBranchConfig,
-  ChoiceFollowUp,
-  ChoiceOption,
+import {
+  type ChoiceBranchConfig,
+  type ChoiceFollowUp,
+  type ChoiceOption,
 } from "@/entities/workflow";
 
 interface SelectableOption extends ChoiceOption {


### PR DESCRIPTION
## 📝 요약 (Summary)

워크플로우 에디터 쪽에 남아 있던 구조 결합을 정리하고, import/export 컨벤션을 문서와 코드 양쪽에서 맞췄습니다.  
핵심은 `shared`가 editor/application 역할을 대신하던 구조를 정리하고, 슬라이스 공개 API 규칙과 type import 규칙을 실제 코드베이스에 강제한 점입니다.

## ✅ 주요 변경 사항 (Key Changes)

- `BaseNode`의 editor store 직접 의존 제거
- `workflowStore`를 `shared`에서 `features/workflow-editor`로 이동
- `useSaveWorkflowMutation`를 `entities/workflow`에서 `features/workflow-editor`로 이동
- `shared/libs/workflow-adapter` 제거 및 역할 분리
- FSD import 규칙과 inline `type` import 규칙을 문서/ESLint에 반영
- 위젯 내부 경로 직접 참조와 커스텀 노드 props 타입 혼재 정리

## 💻 상세 구현 내용 (Implementation Details)

### 1. 워크플로우 에디터 구조 정리

기존에는 workflow editor 전용 상태와 변환 로직이 `shared`에 남아 있어, `shared`가 사실상 application/editor 계층 역할을 하고 있었습니다.

이번 PR에서는 아래 흐름으로 정리했습니다.

- `BaseNode`는 더 이상 `useWorkflowStore`를 직접 참조하지 않도록 변경
- `NodeEditorContext` / `NodeEditorProvider`를 도입해 `Canvas`가 필요한 editor 상태와 액션을 주입
- `workflowStore`를 `shared/model`에서 `features/workflow-editor/model`로 이동
- `useSaveWorkflowMutation`를 `entities/workflow`에서 `features/workflow-editor/model`로 이동
- `shared/libs/workflow-adapter`를 제거하고
  - `entities/workflow/lib/workflow-node-adapter.ts`
  - `features/workflow-editor/model/workflow-editor-adapter.ts`
  로 분리

적용 커밋:
- `74fd8e8` `refactor: 노드 베이스 컴포넌트 의존 정리`
- `1ec9f34` `refactor: 워크플로우 에디터 스토어 위치 정리`
- `3f016e0` `refactor: 워크플로우 저장 로직 계층 정리`
- `78e1c97` `refactor: 워크플로우 어댑터 책임 분리`

### 2. FSD import / type import 규칙 정리

문서와 실제 코드가 어긋나 있던 import 규칙을 정리했습니다.

- `CONVENTION.md`에
  - 같은 슬라이스 내부: 상대경로
  - 다른 슬라이스: 공개 API(`index.ts`) 경유
  - `shared`: segment 단위 deep import 허용
  규칙을 명시
- inline `type` import 규칙과 일괄 정리 절차를 문서에 추가
- ESLint에 `@typescript-eslint/consistent-type-imports` + 별도 `import type` 금지 가드를 추가
- `pnpm lint:fix`로 기존 `import type` 선언 0건으로 정리

적용 커밋:
- `5ab685f` `docs: 슬라이스 공개 API import 규칙 정리`
- `b9081fd` `chore: import type lint 규칙 정리`
- `3922670` `chore: type import lint 가드 정리`

### 3. 공개 API 경계 / 커스텀 노드 타입 정리

추가로 실제 코드 위반 2종을 정리했습니다.

- `EditorLayout`의 `@/widgets/app-shell/model/*`, `@/widgets/app-shell/ui/*` 직접 참조 제거
- `workflow-editor-adapter`의 `@/entities/workflow/api`, `@/entities/workflow/lib` 직접 참조를 `@/entities/workflow` 공개 API로 정리
- 커스텀 노드 props 타입을 전부 `NodeProps<Node<FlowNodeData>>`로 통일

적용 커밋:
- `1e5cbc9` `refactor: 위젯 공개 API 경계 정리`
- `069a9c0` `refactor: 커스텀 노드 props 타입 정리`

## 🚀 트러블 슈팅 (Trouble Shooting)

이번 작업에서 중요한 포인트는 "문서 수정만으로 끝내지 않고, 실제로 다시 흐트러지지 않게 막는 것"이었습니다.

특히 `import type` 문제는 단순 스타일 차이가 아니라, IDE 자동 import로 계속 누적될 수 있는 drift라서 다음 방식으로 닫았습니다.

1. 문서에 슬라이스 공개 API 규칙 / inline `type` 규칙 명시
2. ESLint에 `consistent-type-imports` 추가
3. 별도 `import type` 선언 자체를 금지하는 가드 추가
4. `pnpm lint:fix`로 기존 코드를 정리

또 `workflow-editor` 관련 구조는 큰 파일 이동 한 번에 밀어붙이지 않고, `BaseNode -> workflowStore -> save mutation -> adapter` 순서로 작은 단계 커밋으로 분리해 중간 상태도 항상 빌드 가능하게 유지했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- `docker-compose.local.yml`, `docker-compose-fastapi.local.yml`는 이번 PR 범위에서 제외했습니다.
- 빌드는 통과하지만 기존과 동일하게 번들 chunk size 경고는 남아 있습니다.
- 이번 PR은 editor/application 구조 정리와 import 규칙 정비가 중심이며, 스타일 토큰 정리(`LoginPage` 등)는 포함하지 않았습니다.

## 📸 스크린샷 (Screenshots)

- 구조 및 컨벤션 리팩토링 중심 PR이라 별도 스크린샷은 생략했습니다.

## #️⃣ 관련 이슈 (Related Issues)

- FSD 아키텍처 후속 이슈
