### PR TITLE
[PR] execution 상태 계약 정리

### DIFF
--- a/src/entities/execution/api/types.ts
+++ b/src/entities/execution/api/types.ts
@@ -1,4 +1,6 @@
-export type ExecutionRunStatus = "pending" | "running" | "success" | "failed";
+import { type RemoteExecutionStatus } from "../model/types";
+
+export type ExecutionRunStatus = RemoteExecutionStatus;
 
 export interface ExecutionErrorDetail {
   code: string | null;
@@ -30,7 +32,7 @@ export interface ExecutionDetail {
   id: string;
   workflowId: string;
   userId?: string | null;
-  state: string;
+  state: ExecutionRunStatus;
   nodeLogs: ExecutionLog[];
   startedAt: string | null;
   finishedAt: string | null;

--- a/src/entities/execution/model/execution-utils.ts
+++ b/src/entities/execution/model/execution-utils.ts
@@ -1,4 +1,4 @@
-type ExecutionStatus = "idle" | "running" | "success" | "failed";
+import { type ExecutionStatus } from "./types";
 
 const POLL_INTERVAL_MS = Number(
   import.meta.env.VITE_EXECUTION_POLL_INTERVAL_MS ?? 3000,
@@ -9,35 +9,23 @@ export const executionPollInterval = POLL_INTERVAL_MS;
 export const normalizeExecutionStatus = (
   state: string | null | undefined,
 ): ExecutionStatus => {
-  const normalized = state?.toLowerCase() ?? "";
-
-  if (normalized.includes("success") || normalized.includes("complete")) {
-    return "success" as const;
+  switch (state?.toLowerCase()) {
+    case "pending":
+    case "running":
+    case "success":
+    case "failed":
+    case "rollback_available":
+    case "stopped":
+      return state.toLowerCase() as ExecutionStatus;
+    default:
+      return "idle";
   }
-
-  if (normalized.includes("fail") || normalized.includes("error")) {
-    return "failed" as const;
-  }
-
-  if (normalized.includes("run")) {
-    return "running" as const;
-  }
-
-  if (normalized.includes("pending") || normalized.includes("queue")) {
-    return "running" as const;
-  }
-
-  return "idle" as const;
 };
 
 export const isExecutionInFlight = (state: string | null | undefined) => {
-  const normalized = state?.toLowerCase() ?? "";
+  const normalized = normalizeExecutionStatus(state);
 
-  return (
-    normalized.includes("pending") ||
-    normalized.includes("queue") ||
-    normalized.includes("run")
-  );
+  return normalized === "pending" || normalized === "running";
 };
 
 export const getLatestExecution = <T extends { startedAt: string | null }>(

--- a/src/entities/execution/model/index.ts
+++ b/src/entities/execution/model/index.ts
@@ -1,3 +1,4 @@
+export * from "./types";
 export * from "./execution-utils";
 export * from "./query-keys";
 export * from "./useExecuteWorkflowMutation";

--- a/src/entities/execution/model/types.ts
+++ b/src/entities/execution/model/types.ts
@@ -1,0 +1,10 @@
+export type ExecutionStatus =
+  | "idle"
+  | "pending"
+  | "running"
+  | "success"
+  | "failed"
+  | "rollback_available"
+  | "stopped";
+
+export type RemoteExecutionStatus = Exclude<ExecutionStatus, "idle">;

--- a/src/entities/workflow/model/types.ts
+++ b/src/entities/workflow/model/types.ts
@@ -5,8 +5,6 @@ import { type ValidationWarning } from "@/shared";
 
 export type WorkflowStatus = "active" | "inactive";
 
-export type ExecutionStatus = "idle" | "running" | "success" | "failed";
-
 export interface TriggerConfig {
   type: "manual" | "schedule" | "event";
   schedule?: string;

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -10,12 +10,11 @@ import { current } from "immer";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
+import { type ExecutionStatus } from "@/entities/execution";
 import { type FlowNodeData } from "@/entities/node";
 import { collectDescendantIds } from "@/shared/libs/graph";
 
 import { type WorkflowHydratedState } from "./workflow-editor-adapter";
-
-export type ExecutionStatus = "idle" | "running" | "success" | "failed";
 
 type PlaceholderInfo = {
   id: string;

--- a/src/widgets/editor-toolbar/ui/EditorToolbar.tsx
+++ b/src/widgets/editor-toolbar/ui/EditorToolbar.tsx
@@ -34,11 +34,24 @@ type EditorToolbarProps = {
 
 const getRunButtonConfig = (status: ExecutionStatus): RunButtonConfig => {
   switch (status) {
+    case "pending":
     case "running":
       return {
         colorPalette: "yellow",
         icon: <Spinner size="xs" />,
         disabled: true,
+      };
+    case "rollback_available":
+      return {
+        colorPalette: "orange",
+        icon: <MdRefresh />,
+        disabled: false,
+      };
+    case "stopped":
+      return {
+        colorPalette: "gray",
+        icon: <MdPlayArrow />,
+        disabled: false,
       };
     case "failed":
       return {
@@ -59,12 +72,18 @@ const getRunButtonConfig = (status: ExecutionStatus): RunButtonConfig => {
 
 const getExecutionMessage = (status: ExecutionStatus | null) => {
   switch (status) {
+    case "pending":
+      return "최근 실행 대기 중";
     case "running":
       return "최근 실행 진행 중";
     case "success":
       return "최근 실행 성공";
     case "failed":
       return "최근 실행 실패";
+    case "rollback_available":
+      return "최근 실행 실패, 롤백 가능";
+    case "stopped":
+      return "최근 실행이 중지됨";
     case "idle":
     case null:
     default:
@@ -317,7 +336,7 @@ export const EditorToolbar = ({ variant = "bar" }: EditorToolbarProps) => {
           {isExecutePending ? <Spinner size="xs" /> : runConfig.icon}
         </IconButton>
 
-        {latestExecutionStatus === "failed" ? (
+        {latestExecutionStatus === "rollback_available" ? (
           <Button
             size="sm"
             variant="outline"


### PR DESCRIPTION
## 📝 요약 (Summary)

Execution 상태 모델을 백엔드 실제 계약에 맞게 정리했습니다.  
기존의 상태 왜곡 매핑을 제거하고, rollback 가능 상태가 UI에 정상 반영되도록 수정했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- `ExecutionStatus`를 `entities/execution` 단일 타입으로 통합
- `normalizeExecutionStatus()`가 `pending`, `rollback_available`, `stopped`를 소각하지 않도록 수정
- `isExecutionInFlight()`를 `pending`, `running`만 진행 중으로 판단하도록 정리
- `EditorToolbar`의 rollback 버튼 조건을 `failed` → `rollback_available`로 수정
- 툴바 상태 메시지/버튼 색상에 `pending`, `rollback_available`, `stopped` 추가

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 이번 PR은 execution 상태 계약 정리까지만 포함합니다.
- 중간발표 문서 재정의, 실행 가능 노드 화이트리스트, 데모 모드 팔레트 정책은 다음 이슈에서 진행합니다.
- 검증: `pnpm run lint`, `pnpm run tsc` 통과

- #88 