### PR TITLE
[PR] useAddNode 로컬 경로 정합성 보강과 실행 전 저장 가드 추가

### DIFF
--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -12,6 +12,7 @@ import { Box, Grid, Icon, Input, Text, VStack } from "@chakra-ui/react";
 import { useReactFlow, useViewport } from "@xyflow/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
+import { type FlowNodeData, type NodeMeta } from "@/entities/node";
 import {
   findAddedNodeId,
   toFlowNode,
@@ -19,7 +20,6 @@ import {
   useAddWorkflowNodeMutation,
   useDeleteWorkflowNodeMutation,
 } from "@/entities/workflow";
-import { type FlowNodeData, type NodeMeta } from "@/entities/node";
 import { useWorkflowStore } from "@/features/workflow-editor";
 
 import { CATEGORY_SERVICE_MAP } from "../model/serviceMap";
@@ -326,6 +326,7 @@ export const ServiceSelectionPanel = () => {
   const setEndNodeId = useWorkflowStore((state) => state.setEndNodeId);
   const onConnect = useWorkflowStore((state) => state.onConnect);
   const removeNode = useWorkflowStore((state) => state.removeNode);
+  const batchServerSync = useWorkflowStore((state) => state.batchServerSync);
   const updateNodeConfig = useWorkflowStore((state) => state.updateNodeConfig);
   const { mutateAsync: addWorkflowNode, isPending: isAddNodePending } =
     useAddWorkflowNodeMutation();
@@ -449,22 +450,24 @@ export const ServiceSelectionPanel = () => {
         return null;
       }
 
-      addNode(toFlowNode(addedNode));
+      batchServerSync(() => {
+        addNode(toFlowNode(addedNode));
 
-      if (activePlaceholder.id === "placeholder-start") {
-        setStartNodeId(addedNodeId);
-      } else if (activePlaceholder.id === "placeholder-end") {
-        setEndNodeId(addedNodeId);
-      }
+        if (activePlaceholder.id === "placeholder-start") {
+          setStartNodeId(addedNodeId);
+        } else if (activePlaceholder.id === "placeholder-end") {
+          setEndNodeId(addedNodeId);
+        }
 
-      if (sourceNodeId) {
-        onConnect({
-          source: sourceNodeId,
-          target: addedNodeId,
-          sourceHandle: null,
-          targetHandle: null,
-        });
-      }
+        if (sourceNodeId) {
+          onConnect({
+            source: sourceNodeId,
+            target: addedNodeId,
+            sourceHandle: null,
+            targetHandle: null,
+          });
+        }
+      });
 
       return addedNodeId;
     },
@@ -472,6 +475,7 @@ export const ServiceSelectionPanel = () => {
       activePlaceholder,
       addNode,
       addWorkflowNode,
+      batchServerSync,
       nodes,
       onConnect,
       setEndNodeId,
@@ -572,7 +576,9 @@ export const ServiceSelectionPanel = () => {
           nodeId: placedNodeId,
         });
         setPlacedNodeId(null);
-        removeNode(placedNodeId);
+        batchServerSync(() => {
+          removeNode(placedNodeId);
+        });
       } else if (placedNodeId) {
         removeNode(placedNodeId);
         setPlacedNodeId(null);

--- a/src/features/workflow-editor/model/useSaveWorkflowMutation.ts
+++ b/src/features/workflow-editor/model/useSaveWorkflowMutation.ts
@@ -1,13 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 
-import {
-  syncWorkflowCache,
-  workflowApi,
-} from "@/entities/workflow";
+import { syncWorkflowCache, workflowApi } from "@/entities/workflow";
 import { type MutationPolicyOptions, toMutationMeta } from "@/shared/api";
 
 import { type WorkflowEditorStoreState } from "./workflow-editor-adapter";
 import { toWorkflowUpdateRequest } from "./workflow-editor-adapter";
+import { useWorkflowStore } from "./workflowStore";
 
 type SaveWorkflowVariables = {
   workflowId: string;
@@ -27,6 +25,7 @@ export const useSaveWorkflowMutation = (
     meta: toMutationMeta(options),
     onSuccess: async (workflow, variables, onMutateResult, context) => {
       await syncWorkflowCache(workflow);
+      useWorkflowStore.getState().markClean();
       await options?.onSuccess?.(workflow, variables, onMutateResult, context);
     },
     onError: async (error, variables, onMutateResult, context) => {

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -32,6 +32,8 @@ interface WorkflowEditorState {
   workflowId: string;
   workflowName: string;
   executionStatus: ExecutionStatus;
+  isDirty: boolean;
+  _isSyncing: boolean;
 }
 
 interface WorkflowEditorActions {
@@ -54,6 +56,8 @@ interface WorkflowEditorActions {
   setEndNodeId: (id: string | null) => void;
   setCreationMethod: (method: "manual" | null) => void;
   setActivePlaceholder: (placeholder: PlaceholderInfo | null) => void;
+  batchServerSync: (fn: () => void) => void;
+  markClean: () => void;
   resetEditor: () => void;
 }
 
@@ -68,6 +72,8 @@ const initialState: WorkflowEditorState = {
   workflowId: "",
   workflowName: "",
   executionStatus: "idle",
+  isDirty: false,
+  _isSyncing: false,
 };
 
 export const useWorkflowStore = create<
@@ -82,21 +88,45 @@ export const useWorkflowStore = create<
           changes as NodeChange<Node<FlowNodeData>>[],
           current(state.nodes),
         );
+
+        if (!state._isSyncing) {
+          const hasDirtyChange = changes.some(
+            (change) => change.type === "position" || change.type === "replace",
+          );
+          if (hasDirtyChange) {
+            state.isDirty = true;
+          }
+        }
       }),
 
     onEdgesChange: (changes) =>
       set((state) => {
         state.edges = applyEdgeChanges(changes, current(state.edges));
+
+        if (!state._isSyncing) {
+          const hasDirtyChange = changes.some(
+            (change) => change.type === "remove" || change.type === "replace",
+          );
+          if (hasDirtyChange) {
+            state.isDirty = true;
+          }
+        }
       }),
 
     onConnect: (connection) =>
       set((state) => {
         state.edges = addEdge(connection, current(state.edges));
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     addNode: (node) =>
       set((state) => {
         state.nodes.push(node);
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     removeNode: (id) =>
@@ -126,6 +156,10 @@ export const useWorkflowStore = create<
         if (state.endNodeId && removeTargets.has(state.endNodeId)) {
           state.endNodeId = null;
         }
+
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     updateNodeConfig: (id, config) =>
@@ -138,6 +172,10 @@ export const useWorkflowStore = create<
           ...config,
           isConfigured: true,
         } as FlowNodeData["config"];
+
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     openPanel: (nodeId) =>
@@ -153,16 +191,25 @@ export const useWorkflowStore = create<
     setStartNodeId: (id) =>
       set((state) => {
         state.startNodeId = id;
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     setEndNodeId: (id) =>
       set((state) => {
         state.endNodeId = id;
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     setCreationMethod: (method) =>
       set((state) => {
         state.creationMethod = method;
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
       }),
 
     setActivePlaceholder: (placeholder) =>
@@ -187,16 +234,38 @@ export const useWorkflowStore = create<
         state.creationMethod = payload.creationMethod;
         state.activePanelNodeId = null;
         state.activePlaceholder = null;
+        state.isDirty = false;
+        state._isSyncing = false;
       }),
 
     setWorkflowName: (name) =>
       set((state) => {
         state.workflowName = name;
+        state.isDirty = true;
       }),
 
     setExecutionStatus: (status) =>
       set((state) => {
         state.executionStatus = status;
+      }),
+
+    batchServerSync: (fn) => {
+      set((state) => {
+        state._isSyncing = true;
+      });
+
+      try {
+        fn();
+      } finally {
+        set((state) => {
+          state._isSyncing = false;
+        });
+      }
+    },
+
+    markClean: () =>
+      set((state) => {
+        state.isDirty = false;
       }),
 
     resetEditor: () => set(() => ({ ...initialState })),

--- a/src/widgets/editor-remote-bar/ui/EditorRemoteBar.tsx
+++ b/src/widgets/editor-remote-bar/ui/EditorRemoteBar.tsx
@@ -43,6 +43,7 @@ export const EditorRemoteBar = () => {
   const edges = useWorkflowStore((state) => state.edges);
   const startNodeId = useWorkflowStore((state) => state.startNodeId);
   const endNodeId = useWorkflowStore((state) => state.endNodeId);
+  const isDirty = useWorkflowStore((state) => state.isDirty);
   const setExecutionStatus = useWorkflowStore(
     (state) => state.setExecutionStatus,
   );
@@ -91,6 +92,15 @@ export const EditorRemoteBar = () => {
 
   const handleRun = async () => {
     if (!workflowId || !canRun) {
+      return;
+    }
+
+    if (isDirty) {
+      toaster.create({
+        title: "저장되지 않은 변경이 있습니다",
+        description: "실행 전에 워크플로우를 저장해주세요.",
+        type: "warning",
+      });
       return;
     }
 

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -214,6 +214,7 @@ export const OutputPanel = () => {
   const onConnect = useWorkflowStore((state) => state.onConnect);
   const addNode = useWorkflowStore((state) => state.addNode);
   const removeNode = useWorkflowStore((state) => state.removeNode);
+  const batchServerSync = useWorkflowStore((state) => state.batchServerSync);
   const updateNodeConfig = useWorkflowStore((state) => state.updateNodeConfig);
   const openPanel = useWorkflowStore((state) => state.openPanel);
   const closePanel = useWorkflowStore((state) => state.closePanel);
@@ -462,23 +463,26 @@ export const OutputPanel = () => {
         return null;
       }
 
-      addNode(toFlowNode(addedNode));
-      onConnect({
-        source: sourceNodeId,
-        target: addedNodeId,
-        sourceHandle: null,
-        targetHandle: null,
-      });
+      batchServerSync(() => {
+        addNode(toFlowNode(addedNode));
+        onConnect({
+          source: sourceNodeId,
+          target: addedNodeId,
+          sourceHandle: null,
+          targetHandle: null,
+        });
 
-      if (label) {
-        updateNodeConfig(addedNodeId, {});
-      }
+        if (label) {
+          updateNodeConfig(addedNodeId, {});
+        }
+      });
 
       return addedNodeId;
     },
     [
       addNode,
       addWorkflowNode,
+      batchServerSync,
       createLocalNode,
       onConnect,
       updateNodeConfig,
@@ -493,11 +497,15 @@ export const OutputPanel = () => {
           workflowId,
           nodeId,
         });
+        batchServerSync(() => {
+          removeNode(nodeId);
+        });
+        return;
       }
 
       removeNode(nodeId);
     },
-    [deleteWorkflowNode, removeNode, workflowId],
+    [batchServerSync, deleteWorkflowNode, removeNode, workflowId],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## 📝 요약 (Summary)

로컬 임시 노드가 서버와 불일치한 상태에서 실행되는 문제를 막기 위해 dirty/sync 계약을 추가하고, 실행 전 저장 가드를 정리했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- `workflowStore`에 `isDirty`, `_isSyncing`, `batchServerSync`, `markClean` 추가
- `onNodesChange` / `onEdgesChange`를 구조 변경만 dirty로 보도록 정리
- API 성공 후 로컬 동기화 경로를 `batchServerSync`로 감싸 false positive dirty 방지
- dirty 상태에서 `Run` 클릭 시 warning toast 후 실행 차단
- 저장 성공 시 dirty 초기화

## 💻 상세 구현 내용 (Implementation Details)

### 1. 워크플로우 에디터 dirty/sync 계약 추가

`src/features/workflow-editor/model/workflowStore.ts`

- `isDirty`: 서버 상태와 다른 로컬 변경 추적
- `_isSyncing`: API 성공 후 로컬 동기화 맥락 구분
- `batchServerSync(fn)`: API 성공 후 store 반영 시 dirty 억제
- `markClean()`: 저장 성공 후 clean 상태로 복귀

추가로:
- `addNode`, `removeNode`, `updateNodeConfig`, `onConnect`, `setWorkflowName` 등은 dirty trigger
- `onNodesChange`는 `position`, `replace`만 dirty
- `onEdgesChange`는 `remove`, `replace`만 dirty

### 2. API 성공 후 동기화 경계 정리

- `src/features/add-node/ui/ServiceSelectionPanel.tsx`
- `src/widgets/output-panel/ui/OutputPanel.tsx`

`addWorkflowNode`, `deleteWorkflowNode` 성공 후의 로컬 `addNode`, `removeNode`, `onConnect`, `setStartNodeId`, `setEndNodeId`, `updateNodeConfig`는 `batchServerSync` 안에서 처리하도록 변경했습니다.

즉:
- Canvas의 로컬 임시 노드 경로는 dirty를 켜고
- API 성공 후 동기화 경로는 dirty를 켜지 않도록 구분했습니다.

### 3. 실행 전 저장 가드 추가

`src/widgets/editor-remote-bar/ui/EditorRemoteBar.tsx`

- dirty 상태에서 `Run` 클릭 시
  - `"저장되지 않은 변경이 있습니다"` warning toast 노출
  - 실행 차단

저장되지 않은 Canvas 임시 노드가 서버에 반영되지 않은 상태로 실행되는 문제를 여기서 막습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 이번 PR은 `useAddNode` 자체를 API 경로로 전환하지 않습니다.
- `Canvas`의 임시 노드 생성 구조는 유지하고, 실행 전 저장 가드로 위험만 차단합니다.
- `NodeCategoryDrawer`, `AddNodeButton` 정리는 이번 범위에 포함하지 않았습니다.
- 검증: `pnpm run lint`, `pnpm run tsc` 통과

- #95 