### PR TITLE
[PR[ graph sync 중 unsaved local position preserve

### DIFF
--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -19,6 +19,11 @@ type PlaceholderInfo = {
   position: { x: number; y: number };
 };
 
+type NodePosition = {
+  x: number;
+  y: number;
+};
+
 export interface WorkflowEditorCapabilities {
   canViewEditor: boolean;
   canEditNodes: boolean;
@@ -37,6 +42,7 @@ interface WorkflowEditorState {
   workflowId: string;
   workflowName: string;
   editorCapabilities: WorkflowEditorCapabilities;
+  unsavedNodePositions: Record<string, NodePosition>;
   isDirty: boolean;
   _isSyncing: boolean;
 }
@@ -67,6 +73,10 @@ interface WorkflowEditorActions {
   setEndNodeId: (id: string | null) => void;
   setCreationMethod: (method: "manual" | null) => void;
   setActivePlaceholder: (placeholder: PlaceholderInfo | null) => void;
+  applyLayoutPositions: (
+    updates: Array<{ nodeId: string; position: NodePosition }>,
+  ) => void;
+  clearUnsavedNodePositions: (nodeIds?: string[]) => void;
   markClean: () => void;
   resetEditor: () => void;
 }
@@ -87,6 +97,7 @@ const initialState: WorkflowEditorState = {
     canSaveWorkflow: true,
     canRunWorkflow: true,
   },
+  unsavedNodePositions: {},
   isDirty: false,
   _isSyncing: false,
 };
@@ -111,6 +122,23 @@ export const useWorkflowStore = create<
         );
 
         if (!state._isSyncing) {
+          changes.forEach((change) => {
+            if (
+              change.type === "position" &&
+              change.position &&
+              "id" in change
+            ) {
+              state.unsavedNodePositions[change.id] = {
+                x: change.position.x,
+                y: change.position.y,
+              };
+            }
+
+            if (change.type === "remove" && "id" in change) {
+              delete state.unsavedNodePositions[change.id];
+            }
+          });
+
           const hasDirtyChange = changes.some(
             (change) => change.type === "position" || change.type === "replace",
           );
@@ -197,6 +225,41 @@ export const useWorkflowStore = create<
         state.activePlaceholder = placeholder;
       }),
 
+    applyLayoutPositions: (updates) =>
+      set((state) => {
+        if (updates.length === 0) {
+          return;
+        }
+
+        const nextPositionMap = Object.fromEntries(
+          updates.map(({ nodeId, position }) => [nodeId, position]),
+        );
+
+        state.nodes = state.nodes.map((node) => {
+          const nextPosition = nextPositionMap[node.id];
+          if (!nextPosition) {
+            return node;
+          }
+
+          state.unsavedNodePositions[node.id] = {
+            x: nextPosition.x,
+            y: nextPosition.y,
+          };
+
+          return {
+            ...node,
+            position: {
+              x: nextPosition.x,
+              y: nextPosition.y,
+            },
+          };
+        });
+
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
+      }),
+
     setWorkflowMeta: (id, name) =>
       set((state) => {
         state.workflowId = id;
@@ -254,6 +317,18 @@ export const useWorkflowStore = create<
     setEditorCapabilities: (capabilities) =>
       set((state) => {
         state.editorCapabilities = capabilities;
+      }),
+
+    clearUnsavedNodePositions: (nodeIds) =>
+      set((state) => {
+        if (!nodeIds || nodeIds.length === 0) {
+          state.unsavedNodePositions = {};
+          return;
+        }
+
+        nodeIds.forEach((nodeId) => {
+          delete state.unsavedNodePositions[nodeId];
+        });
       }),
 
     markClean: () =>

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -296,6 +296,7 @@ export const useWorkflowStore = create<
         state.creationMethod = payload.creationMethod;
         state.activePanelNodeId = null;
         state.activePlaceholder = null;
+        state.unsavedNodePositions = {};
         state.isDirty = false;
         state._isSyncing = false;
       }),
@@ -362,6 +363,7 @@ export const useWorkflowStore = create<
 
     markClean: () =>
       set((state) => {
+        state.unsavedNodePositions = {};
         state.isDirty = false;
       }),
 

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -108,6 +108,25 @@ const hasNode = (
 ): nodeId is string =>
   Boolean(nodeId && nodes.some((node) => node.id === nodeId));
 
+const mergeNodesWithUnsavedPositions = (
+  nodes: Node<FlowNodeData>[],
+  unsavedNodePositions: Record<string, NodePosition>,
+) =>
+  nodes.map((node) => {
+    const positionOverride = unsavedNodePositions[node.id];
+    if (!positionOverride) {
+      return node;
+    }
+
+    return {
+      ...node,
+      position: {
+        x: positionOverride.x,
+        y: positionOverride.y,
+      },
+    };
+  });
+
 export const useWorkflowStore = create<
   WorkflowEditorState & WorkflowEditorActions
 >()(
@@ -288,14 +307,24 @@ export const useWorkflowStore = create<
         const preserveActivePlaceholder =
           options?.preserveActivePlaceholder ?? true;
         const preserveDirty = options?.preserveDirty ?? true;
+        const nextNodeIds = new Set(payload.nodes.map((node) => node.id));
+        const preservedUnsavedNodePositions = Object.fromEntries(
+          Object.entries(state.unsavedNodePositions).filter(([nodeId]) =>
+            nextNodeIds.has(nodeId),
+          ),
+        );
 
         state.workflowId = payload.workflowId;
         state.workflowName = payload.workflowName;
-        state.nodes = payload.nodes;
+        state.nodes = mergeNodesWithUnsavedPositions(
+          payload.nodes,
+          preservedUnsavedNodePositions,
+        );
         state.edges = payload.edges;
         state.startNodeId = payload.startNodeId;
         state.endNodeId = payload.endNodeId;
         state.creationMethod = payload.creationMethod;
+        state.unsavedNodePositions = preservedUnsavedNodePositions;
         state.activePanelNodeId = preserveActivePanelNodeId
           ? hasNode(payload.nodes, state.activePanelNodeId)
             ? state.activePanelNodeId


### PR DESCRIPTION
## 📌 요약 (Summary)

server-authoritative graph sync 과정에서 저장 전 local node position이 유실되지 않도록 editor store를 보강했습니다.  
이번 PR은 `position`만 예외적으로 local override로 관리하고, mutation 응답의 `WorkflowResponse`와 merge되는 규칙을 추가하는 작업입니다.

## ✅ 주요 변경 사항 (Key Changes)

- `workflowStore`에 `unsavedNodePositions` 상태 추가
- drag 및 향후 auto-arrange를 위한 local position override 추적 구조 도입
- `syncWorkflowGraph(...)`가 서버 응답 graph 위에 local unsaved `position`만 merge하도록 변경
- save 성공 / hydrate / reset 시 position override clear lifecycle 정리

## 🔧 상세 구현 내용 (Implementation Details)

### 1. local position override 상태 모델 추가
- 대상 파일:
  - `src/features/workflow-editor/model/workflowStore.ts`
- 추가 내용:
  - `unsavedNodePositions: Record<string, { x: number; y: number }>`
  - `applyLayoutPositions(...)`
  - `clearUnsavedNodePositions(...)`
- 의도:
  - graph 구조와 저장 전 layout 임시 상태를 분리
  - drag와 향후 auto-arrange가 같은 상태 모델을 재사용할 수 있도록 기반 마련

### 2. graph sync merge 규칙 구현
- `syncWorkflowGraph(...)`가 mutation 응답을 단순 치환하지 않도록 변경했습니다.
- 처리 규칙:
  - 구조는 서버 응답 `WorkflowResponse` 기준
  - 살아 있는 기존 `nodeId`에 대해서만 local unsaved `position` 재적용
  - 서버에서 삭제된 node는 복원하지 않음
  - 새로 생긴 node는 서버 `position` 사용
  - `position` 외 `type/config/role/edge`는 merge하지 않음

### 3. lifecycle 정리
- save 성공 후 `markClean()`에서 `unsavedNodePositions`를 clear 하도록 정리했습니다.
- `hydrateWorkflow(...)` 시에도 stale local override가 남지 않도록 초기화합니다.
- `resetEditor()`는 기존 `initialState` 기반으로 clear되는 구조를 유지합니다.

### 4. 검증
- `pnpm run lint`
- `pnpm run tsc`
- `pnpm run build`

모두 통과했습니다.

## 🛠 트러블 슈팅 (Trouble Shooting)

- 처음에는 현재 `nodes`와 마지막 hydrate 상태를 비교해서 local unsaved position을 추론하는 방식도 고려했습니다.
- 하지만 이 방식은 drag와 향후 auto-arrange를 같은 규칙으로 다루기 어렵고, 디버깅도 불명확해질 수 있어 채택하지 않았습니다.
- 대신 `unsavedNodePositions`를 명시적 상태로 두고, `syncWorkflowGraph(...)`에서 server graph 위에 `position`만 merge하는 구조로 단순화했습니다.

## 📎 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 이번 PR은 `position preserve` 규칙만 다루며, auto-arrange 버튼의 실제 기능 연결은 포함하지 않습니다.
- 현재 backend 계약은 `position` 보정 없음 / mutation 응답 `WorkflowResponse.position` 신뢰 가능 / server-driven auto-layout 없음 전제에 맞춰 구현했습니다.
- 동시 수정 충돌 보호는 여전히 backend 기준 `last-write-wins`이며 이번 PR 범위 밖입니다.
- 수동 QA 시나리오는 별도 체크리스트 기준으로 추가 점검이 필요합니다.
  - drag 후 다른 mutation 응답이 와도 position 유지
  - save 성공 후 override clear
  - save 실패 시 override 유지
  - editor 재진입 시 stale override 없음

## 🖼 스크린샷 (Screenshots)

- 내부 상태 관리 및 graph sync 규칙 변경 중심이라 별도 UI 스크린샷은 없습니다.

## #️⃣ 관련 이슈 (Related Issues)

- #103
