### PR TITLE
[PR] canvas_lms source 및 direct-connect workflow 정합

### DIFF
--- a/docs/CANVAS_LMS_DIRECT_CONNECT_SYNC_DESIGN.md
+++ b/docs/CANVAS_LMS_DIRECT_CONNECT_SYNC_DESIGN.md
@@ -1,0 +1,686 @@
+# Canvas LMS / Direct Connect Sync Design
+
+> 작성일: 2026-04-28
+> 대상 브랜치: `feat#108-canvas-lms-direct-connect-sync`
+> 목적: backend 최신 상태에 맞춰 `canvas_lms` source 노출, direct-connect OAuth UX, service key 기반 restore/presentation 정합을 FE에서 어떻게 수용할지 설계한다.
+
+---
+
+## 1. 배경
+
+source/sink editor 1차 전환은 이미 완료되었다.
+
+- 시작 노드: source service picker
+- 중간 처리: `mapping_rules` 기반 wizard
+- 도착 노드: sink service picker
+- lifecycle: backend `nodeStatuses` 기준 반영
+
+이번 이슈는 이 구조를 다시 바꾸는 작업이 아니다.
+
+대신 backend 최신 구현에서 새로 드러난 아래 세 가지를 FE가 수용하도록 정렬하는 작업이다.
+
+1. Spring source catalog에 `canvas_lms`가 추가되었다.
+2. OAuth connect 응답이 `redirect`만 있는 것이 아니라 `directly connected`도 존재한다.
+3. FastAPI runtime에서 `canvas_lms` source가 실제로 실행되지만, payload 의미는 기존 `google_drive`/`slack`와 다르다.
+
+즉 이번 이슈의 본질은 `source/sink editor 2차 리디자인`이 아니라
+`새 source + 새 connect 방식 + service presentation 정합`이다.
+
+---
+
+## 2. Backend 기준 사실
+
+## 2.1 Spring public contract
+
+### 2.1.1 `canvas_lms` source catalog
+
+Spring `source_catalog.json` 기준 `canvas_lms`는 이미 public catalog에 포함되어 있다.
+
+- service key: `canvas_lms`
+- `auth_required: true`
+- source modes:
+  - `course_files` -> `FILE_LIST`
+  - `course_new_file` -> `SINGLE_FILE`
+  - `term_all_files` -> `FILE_LIST`
+- target schema:
+  - 전부 `text_input`
+  - 예시 placeholder:
+    - 과목 ID
+    - 학기명
+
+정리하면 FE는 `canvas_lms`를 위해 새 picker control을 만들 필요가 없다.
+기존 `text_input` target step을 그대로 재사용하면 된다.
+
+### 2.1.2 OAuth connect 결과가 2종류다
+
+`POST /api/oauth-tokens/{service}/connect`는 connector에 따라 서로 다른 결과를 돌려준다.
+
+- redirect required:
+  - 예: Slack, Google Drive
+  - 응답 shape: `{ "authUrl": "..." }`
+- directly connected:
+  - 예: Notion, GitHub, Canvas LMS
+  - 응답 shape: `{ "connected": "true", "service": "<serviceKey>" }`
+
+중요한 점:
+
+- backend 응답에는 `kind` 같은 판별자가 없다.
+- FE가 응답 shape를 보고 분기해야 한다.
+
+### 2.1.3 backend connector 지원 범위
+
+현재 FE가 connectable로 볼 수 있는 서비스는 backend connector 기준으로 다음과 같다.
+
+- `slack`
+- `google_drive`
+- `notion`
+- `github`
+- `canvas_lms`
+
+반대로 아래 서비스들은 catalog에 보여도 현재 이 이슈 범위에서는 connectable로 간주하지 않는다.
+
+- `gmail`
+- `google_sheets`
+- `google_calendar`
+
+즉 FE는 `auth_required === true`만으로 "연결 시작 가능"을 판단하면 안 된다.
+
+## 2.2 FastAPI runtime semantics
+
+### 2.2.1 `canvas_lms` source 실행은 이미 존재한다
+
+FastAPI `InputNodeStrategy` 기준 `canvas_lms`는 실제 실행 대상이다.
+
+- `course_files` -> `FILE_LIST`
+- `course_new_file` -> `SINGLE_FILE`
+- `term_all_files` -> `FILE_LIST`
+
+### 2.2.2 payload 의미
+
+`canvas_lms` source가 내려주는 payload는 대체로 `url` 중심이다.
+
+- `course_files` / `term_all_files`
+  - `items[*].filename`
+  - `items[*].mime_type`
+  - `items[*].size`
+  - `items[*].url`
+- `course_new_file`
+  - `filename`
+  - `mime_type`
+  - `url`
+  - `content: null`
+
+즉 FE가 기대할 것은 다음이다.
+
+- source/sink editor 단계에서 canonical type은 맞게 연결됨
+- runtime에서 실제 파일 바이너리 handoff 여부는 FE가 보장하지 않음
+
+### 2.2.3 이번 FE 이슈의 비책임 범위
+
+현재 backend runtime에는 아래 의미 차이가 남아 있다.
+
+- `FILE_LIST` + `url only` item
+- `SINGLE_FILE` + `content: null`
+
+이것이 Google Drive sink에서 실제 파일 다운로드/업로드로 완전히 이어지는지는 backend runtime 책임이다.
+
+FE는 이번 이슈에서 이 동작을 추론하거나 보정하지 않는다.
+
+---
+
+## 3. 현재 FE 갭
+
+현재 프론트 구조에서 실제로 비어 있는 지점은 다음이다.
+
+## 3.1 source rollout
+
+`source-rollout.ts`에 `canvas_lms`가 없다.
+
+결과:
+
+- catalog에 있어도 시작 노드 picker에 노출되지 않는다.
+
+## 3.2 connect response model
+
+현재 connect 응답 타입은 `authUrl`만 가정한다.
+
+- `OAuthConnectResponse = { authUrl: string }`
+- `window.location.assign(result.authUrl)`를 전제로 함
+
+결과:
+
+- `DirectlyConnected` 응답을 FE가 처리할 수 없다.
+
+## 3.3 connect support matrix
+
+현재 connectable service allowlist는 사실상 `slack`만 지원한다.
+
+결과:
+
+- `canvas_lms`
+- `google_drive`
+- `notion`
+- `github`
+
+모두 backend는 connect 가능해도 FE는 unsupported처럼 동작한다.
+
+## 3.4 service key -> visual node mapping
+
+현재 `workflow-node-adapter`는 `canvas_lms`를 모른다.
+
+결과:
+
+- start node 생성 시 visual node type을 찾지 못한다.
+- backend에서 저장된 `type = canvas_lms` node를 hydrate할 때도 presentation이 안정적이지 않다.
+
+## 3.5 presentation / badge / icon layer
+
+현재 FE는 `canvas_lms` 전용 label/icon/badge가 없다.
+
+결과:
+
+- picker, account, workflow list, dashboard, node title에서 일관된 서비스 표현이 어렵다.
+
+## 3.6 `web-scraping` node config 의미
+
+현재 `web-scraping` config는 사실상 URL scraping 전제다.
+
+- `targetUrl`
+- `selector`
+- `outputFields`
+
+그런데 `canvas_lms`는 같은 visual node carrier를 쓰더라도
+실제 config 의미는 `service/source_mode/target`에 가깝다.
+
+즉 FE는 "visual node type"과 "persisted service semantics"를 더 명확히 분리해야 한다.
+
+---
+
+## 4. 설계 원칙
+
+## 4.1 새 editor를 만들지 않는다
+
+`canvas_lms`는 source/sink editor 1차 구조 위에 얹는다.
+
+- 시작 노드 flow 재사용
+- auth step 재사용
+- source mode step 재사용
+- target step 재사용
+
+## 4.2 새 visual node type은 이번 이슈 범위가 아니다
+
+이번 이슈에서는 `canvas_lms` 전용 `NodeType`을 만들지 않는다.
+
+이유:
+
+- 현재 editor는 generic domain node type 위에 service key를 얹는 구조다.
+- `canvas_lms` 추가만으로 taxonomy를 다시 나누기 시작하면 범위가 커진다.
+- backend persisted contract는 service key가 본체이고, visual type은 FE 표현 레이어다.
+
+따라서 이번 이슈에서 `canvas_lms`는 기존 `web-scraping` visual node를 carrier로 사용한다.
+
+## 4.3 connectability는 catalog가 아니라 verified support matrix로 판단한다
+
+`auth_required`는 "인증이 필요하다"를 뜻할 뿐,
+"지금 FE에서 연결 시작이 가능하다"를 뜻하지 않는다.
+
+FE는 별도 support matrix를 유지한다.
+
+- connectable:
+  - `slack`
+  - `google_drive`
+  - `notion`
+  - `github`
+  - `canvas_lms`
+- not yet connectable:
+  - `gmail`
+  - `google_sheets`
+  - `google_calendar`
+
+이 allowlist는 backend가 capability endpoint를 내려주기 전까지 유지하는
+임시 FE 정책이다.
+
+## 4.4 direct connect는 redirect flow의 예외가 아니라 같은 connect flow의 한 종류다
+
+FE는 connect를 다음 두 가지 중 하나로 처리한다.
+
+- `redirect`
+- `direct`
+
+직접 연결은 별도 임시 UX가 아니라 동일한 service auth step 안에서 처리한다.
+
+## 4.5 FE는 runtime payload 의미를 과대추론하지 않는다
+
+`canvas_lms -> google_drive`가 editor에서 연결 가능하다는 사실과
+"실제 파일이 바이트 단위로 업로드된다"는 사실은 다르다.
+
+이번 이슈에서 FE는 다음까지만 책임진다.
+
+- source 선택 가능
+- connect 가능
+- mode/target 설정 가능
+- node 저장/복원 가능
+- canonical data type 흐름 연결 가능
+
+---
+
+## 5. 상세 설계
+
+## 5.1 Source rollout 설계
+
+`canvas_lms`를 source rollout allowlist에 추가한다.
+
+추가 mode:
+
+- `course_files`
+- `course_new_file`
+- `term_all_files`
+
+### UX 동작
+
+- 시작 노드 service picker에서 `Canvas LMS` 노출
+- auth state 표시
+- mode 선택 진입
+- target step에서 기존 `text_input` 사용
+
+### target 입력 규칙
+
+- `course_files`
+  - 과목 ID 문자열
+- `course_new_file`
+  - 과목 ID 문자열
+- `term_all_files`
+  - 학기명 문자열
+
+이 입력값은 FE가 의미를 해석하지 않고 backend contract string으로 저장한다.
+
+## 5.2 OAuth connect domain model 설계
+
+### 5.2.1 Raw response
+
+backend raw response는 다음 union이다.
+
+```ts
+type RawOAuthConnectResponse =
+  | { authUrl: string }
+  | { connected: "true"; service: string };
+```
+
+### 5.2.2 FE normalized response
+
+FE 내부에서는 판별 가능한 union으로 정규화한다.
+
+```ts
+type OAuthConnectResult =
+  | { kind: "redirect"; authUrl: string }
+  | { kind: "direct"; service: string; connected: true };
+```
+
+정규화 책임은 API layer 또는 entity adapter에 둔다.
+UI는 raw map을 직접 해석하지 않는다.
+
+### 5.2.3 connect action 처리
+
+#### redirect result
+
+- 기존대로 `window.location.assign(authUrl)`
+
+#### direct result
+
+- 현재 화면에 남아 있음
+- `useOAuthTokensQuery` refetch
+- connected state 반영
+- 현재 wizard step을 다음 단계로 진행
+
+즉 direct connect는 callback 페이지를 거치지 않는다.
+
+## 5.3 Auth step UX 설계
+
+## 5.3.1 ServiceSelectionPanel
+
+start/end auth step에서 `연결 시작` 클릭 시:
+
+- `redirect`면 외부로 이동
+- `direct`면 같은 panel 안에서 연결 완료 처리
+
+### direct connect 성공 시 next step
+
+- start node
+  - `auth -> mode`
+- end node
+  - `auth -> confirm`
+
+즉 사용자는 `Canvas LMS`를 선택하고 연결 시작을 누른 뒤
+브라우저 이동 없이 바로 다음 단계로 간다.
+
+## 5.3.2 Account page
+
+Account page의 connect 버튼도 동일한 normalized result를 사용한다.
+
+- `redirect`면 외부 이동
+- `direct`면 토큰 refetch 후 badge 상태를 `CONNECTED`로 전환
+
+## 5.4 connect support matrix 설계
+
+현재 FE support matrix는 backend verified connector 범위에 맞춰 확장한다.
+
+```ts
+const OAUTH_CONNECT_SUPPORTED_SERVICES = [
+  "slack",
+  "google_drive",
+  "notion",
+  "github",
+  "canvas_lms",
+] as const;
+```
+
+이 값은 "OAuth only"가 아니라 "FE connect action supported" 의미로 해석한다.
+이름이 오해를 만든다면 후속 리팩터링에서 `CONNECT_SUPPORTED_SERVICES`로 일반화한다.
+또한 backend가 connect capability metadata를 별도로 제공하기 전까지는
+FE가 직접 유지하는 임시 allowlist로 둔다.
+
+## 5.5 workflow node mapping 설계
+
+## 5.5.1 persisted service key -> visual node type
+
+`workflow-node-adapter`에 다음 mapping을 추가한다.
+
+```ts
+canvas_lms -> web-scraping
+```
+
+의도:
+
+- backend persisted type은 계속 `canvas_lms`
+- FE visual node는 기존 `web-scraping` node shell 재사용
+
+## 5.5.2 persisted start/end node 저장 규칙
+
+현재 구조와 동일하게:
+
+- persisted `type`은 service key
+- visual node는 FE가 hydrate 시 mapping
+
+즉 `canvas_lms`도 다른 source/sink service와 동일 규칙을 따른다.
+
+## 5.5.3 config shape 보강
+
+`web-scraping` visual node가 `canvas_lms`를 담을 수 있도록
+service-backed source config 필드를 허용한다.
+
+최소 필요 필드:
+
+- `service`
+- `source_mode`
+- `target`
+- `canonical_input_type`
+
+구체적으로는 `entities/node/model/types.ts`의 `WebScrapingNodeConfig`에
+아래 optional 필드를 추가하는 방식으로 확장한다.
+
+```ts
+service?: "canvas_lms" | "coupang" | "github" | "naver_news" | "youtube" | null;
+source_mode?: string | null;
+target?: string | null;
+canonical_input_type?: string | null;
+```
+
+즉 이번 변경은 `web-scraping`을 새 node taxonomy로 바꾸는 것이 아니라,
+기존 visual carrier가 service-backed source도 담을 수 있게 typed config를 보강하는 작업이다.
+
+기존 `targetUrl` 전용 가정은 presentation layer에서 fallback으로만 남긴다.
+
+## 5.5.4 hydrate 시 service backfill 규칙
+
+현재 FE는 일부 start/end service node만 hydrate 시 `config.service = node.type`을 보정한다.
+
+이번 이슈에서는 `web-scraping` carrier에도 같은 규칙을 확장한다.
+
+- 조건:
+  - `node.role`이 `start` 또는 `end`
+  - frontend visual node type이 `web-scraping`
+  - `config.service`가 비어 있음
+- 동작:
+  - `config.service = node.type`
+
+이 규칙이 있어야 backend persisted `type = canvas_lms` node를 reload한 뒤에도
+title / badge / summary가 안정적으로 복원된다.
+
+## 5.6 node presentation 설계
+
+## 5.6.1 제목
+
+`web-scraping` node presentation에서:
+
+1. `config.service`가 `canvas_lms`면 `Canvas LMS`
+2. 그 외 service-backed source면 service label
+3. 둘 다 없으면 기존 `targetUrl`
+
+순서로 제목을 정한다.
+
+## 5.6.2 helper text / summary
+
+`canvas_lms` node는 URL scraping helper를 쓰지 않는다.
+
+대신 다음 우선순위로 summary를 보여준다.
+
+1. source mode label
+2. target 값
+3. 기존 generic helper
+
+예:
+
+- `특정 과목 강의자료 전체`
+- `과목 ID: 12345`
+
+## 5.6.3 custom node surface
+
+`WebScrapingNode`가 `targetUrl ?? "URL 미설정"`만 보여주지 않도록 수정 방향을 잡는다.
+
+`config.service`가 있는 경우:
+
+- service label
+- source mode / target 중심 summary
+
+를 우선 렌더한다.
+
+## 5.7 badge / icon 설계
+
+## 5.7.1 service picker / account icon
+
+`canvas_lms` 전용 아이콘을 추가한다.
+
+이번 이슈에서는 새 asset 제작보다 기존 icon set의 학교/학습 계열 아이콘을 우선 사용한다.
+
+## 5.7.2 service badge surfaces
+
+workflow list / dashboard / template icon surfaces는 service badge key를 사용한다.
+
+여기에는 `canvas-lms` 전용 badge key를 추가하는 쪽을 우선한다.
+
+이유:
+
+- visual node type은 `web-scraping` carrier일 수 있어도
+- 서비스 배지는 `Canvas LMS`라는 실제 integration identity를 보여줘야 하기 때문이다.
+
+즉:
+
+- node shell: `web-scraping`
+- backend service key: `canvas_lms`
+- FE badge key: `canvas-lms`
+
+로 역할을 분리한다.
+
+`getServiceBadgeKeyFromService()`는 backend service key `canvas_lms`를 받아
+FE 표현 키 `canvas-lms`로 변환한다.
+
+## 5.8 sink 및 runtime guard 설계
+
+이번 이슈에서 FE는 `canvas_lms -> google_drive` 경로를 editor 수준에서 막지 않는다.
+
+단, 아래를 분명히 유지한다.
+
+- sink accepted input type 기준 filtering
+- backend `nodeStatuses` / save / execute guard 기준 동작
+- runtime file handoff 의미는 FE가 보정하지 않음
+
+즉 FE는 "연결 가능한 graph를 만들 수 있는가"까지만 책임진다.
+
+---
+
+## 6. 구현 단계 제안
+
+구현은 아래 4단계로 끊는다.
+각 단계는 **작게 머지 가능한 단위**로 유지하고, 단계 종료 시 커밋을 남긴다.
+
+커밋 스타일은 현재 브랜치 히스토리에 맞춰 다음 prefix를 사용한다.
+
+- 기능 추가/지원 범위 확장: `feat:`
+- 동작 보정/회귀 수정: `fix:`
+- 구조 정리/의미 정리: `refactor:`
+- 문서: `docs:`
+
+## 단계 1. OAuth connect contract 정규화
+
+### 목표
+
+- backend raw connect 응답을 FE domain model로 안전하게 정규화한다.
+- direct-connect와 redirect-connect를 같은 action 흐름 안에서 다룰 준비를 끝낸다.
+
+### 권장 커밋 스타일
+
+- `feat: OAuth connect 응답 정규화 및 지원 범위 확장`
+
+### 체크리스트
+
+- [ ] `entities/oauth-token/api/types.ts`에 raw connect 응답 union 추가
+- [ ] FE 내부에서 사용할 normalized `OAuthConnectResult` union 정의
+- [ ] API layer 또는 entity adapter에서 raw -> normalized 변환 구현
+- [ ] `authUrl`만 가정한 호출부가 새 normalized 결과를 받도록 API surface 정리
+- [ ] connect support matrix를 `slack`, `google_drive`, `notion`, `github`, `canvas_lms`로 확장
+- [ ] `gmail`, `google_sheets`, `google_calendar`는 계속 unsupported로 남는다는 점 유지
+- [ ] barrel export가 깨지지 않도록 `index.ts` 공개 API 정리
+
+### 빠지면 안 되는 확인 포인트
+
+- [ ] backend raw 응답에 `kind` discriminator가 없다는 전제를 코드에 반영했는가
+- [ ] direct-connect 응답의 `connected: "true"`를 boolean `true`로 정규화했는가
+- [ ] UI layer가 raw map shape를 직접 해석하지 않게 막았는가
+
+## 단계 2. Canvas LMS source rollout + direct-connect UX
+
+### 목표
+
+- 시작 노드 picker에서 `canvas_lms`를 실제 선택 가능하게 연다.
+- direct-connect 서비스를 브라우저 이동 없이 처리한다.
+
+### 권장 커밋 스타일
+
+- `feat: canvas_lms source rollout 및 direct-connect UX 반영`
+
+### 체크리스트
+
+- [ ] `source-rollout.ts`에 `canvas_lms` 3개 mode 추가
+- [ ] source picker icon map에 `canvas_lms` 추가
+- [ ] ServiceSelectionPanel이 direct/redirect 결과를 분기 처리하도록 수정
+- [ ] start node auth step에서 direct-connect 성공 시 `auth -> mode`로 진행
+- [ ] end node auth step에서 direct-connect 성공 시 `auth -> confirm`로 진행
+- [ ] Account page connect 버튼도 같은 normalized connect 결과 사용
+- [ ] direct-connect 성공 후 `useOAuthTokensQuery` refetch로 connected 상태 재동기화
+- [ ] auth error UX가 redirect/direct 두 경우 모두 유지되는지 확인
+
+### 빠지면 안 되는 확인 포인트
+
+- [ ] `canvas_lms` target step은 기존 `text_input`을 그대로 재사용하는가
+- [ ] direct-connect 성공 시 `window.location.assign()`가 호출되지 않는가
+- [ ] redirect-connect 서비스(`slack`, `google_drive`) 회귀가 없는가
+
+## 단계 3. Node mapping / restore / presentation 정합
+
+### 목표
+
+- persisted `type = canvas_lms`와 FE visual `web-scraping` carrier를 정렬한다.
+- reload 이후에도 service identity가 title/badge/summary에 안정적으로 남게 한다.
+
+### 권장 커밋 스타일
+
+- `feat: canvas_lms node mapping 및 presentation 정렬`
+
+### 체크리스트
+
+- [ ] `workflow-node-adapter`에 `canvas_lms -> web-scraping` mapping 추가
+- [ ] `WebScrapingNodeConfig`에 service-backed source optional 필드 추가
+- [ ] hydrate 시 `web-scraping` carrier에도 `config.service = node.type` backfill 규칙 추가
+- [ ] start node 생성 시 persisted `type = canvas_lms` 저장 확인
+- [ ] `nodePresentation`에서 `canvas_lms` title / helper / summary 규칙 반영
+- [ ] `WebScrapingNode`가 `targetUrl` 전용 UI에 묶이지 않도록 보강
+- [ ] picker / account / workflow list / dashboard용 서비스 아이콘 반영
+- [ ] `ServiceBadgeKey`에 `canvas-lms` 추가
+- [ ] `getServiceBadgeKeyFromService()`가 `canvas_lms -> canvas-lms` 변환하도록 보강
+
+### 빠지면 안 되는 확인 포인트
+
+- [ ] 새 `NodeType`를 만들지 않고 기존 `web-scraping` shell만 재사용하는가
+- [ ] reload 시 `canvas_lms` node가 fallback title이나 generic web label로 무너지지 않는가
+- [ ] service badge key와 backend service key를 혼동하지 않도록 분리했는가
+
+## 단계 4. Smoke test 및 회귀 보정
+
+### 목표
+
+- editor 기준 주요 흐름을 실제로 통과시키고, 발견된 회귀를 작은 수정으로 닫는다.
+
+### 권장 커밋 스타일
+
+- 회귀/보정 발생 시 `fix:` prefix 사용
+- 코드 변경이 없다면 빈 커밋은 만들지 않는다
+
+### 체크리스트
+
+- [ ] `Canvas LMS`가 시작 노드 picker에 노출되는지 확인
+- [ ] `Canvas LMS` direct-connect 성공 여부 확인
+- [ ] start node 생성 후 persisted `type = canvas_lms` 저장 확인
+- [ ] reload 후 `canvas_lms` node title / badge / summary 복원 확인
+- [ ] `google_drive` sink와 연결 가능한 graph 구성 확인
+- [ ] save 후 `nodeStatuses` 재동기화 확인
+- [ ] execute guard가 기존 규칙대로 동작하는지 확인
+- [ ] `slack`, `google_drive` redirect-connect 회귀 확인
+- [ ] `pnpm build` 통과 확인
+
+### 최소 확인 경로
+
+1. `Canvas LMS` source picker 노출
+2. direct connect 성공
+3. start node 생성 / 저장
+4. reload 후 `canvas_lms` node 복원
+5. `google_drive` sink 연결
+6. save / execute guard 동작 확인
+
+---
+
+## 7. 범위 제외
+
+- `canvas_lms` 전용 새 visual node type 설계
+- runtime에서 Canvas URL을 실제 바이너리 파일로 변환하는 로직
+- Gmail / Google Sheets / Google Calendar connector 추가
+- capability endpoint 기반 동적 connectability 계산
+
+---
+
+## 8. 완료 조건
+
+- FE source picker에서 `canvas_lms`가 노출된다
+- `canvas_lms`는 direct-connect 서비스로 FE에서 정상 연결된다
+- start node 생성 시 `type = canvas_lms`로 저장된다
+- reload 후 `canvas_lms` node가 의도한 visual node와 title로 복원된다
+- account / workflow list / dashboard에서 `canvas_lms` service identity가 일관되게 보인다
+- FE가 direct-connect와 redirect-connect를 모두 지원한다
+- runtime file handoff 의미는 FE에서 과대추론하지 않는다
+
+---
+
+## 9. 한 줄 요약
+
+이번 이슈의 FE 설계는
+`canvas_lms`를 새 editor 구조로 다시 만드는 것이 아니라,
+**기존 source/sink editor 위에 `canvas_lms` source와 direct-connect contract를 정확히 얹고, service key 기반 restore/presentation까지 정렬하는 작업**이다.

--- a/docs/SINK_PANEL_SAVE_BUTTON_DESIGN.md
+++ b/docs/SINK_PANEL_SAVE_BUTTON_DESIGN.md
@@ -1,0 +1,339 @@
+# Sink Panel Save Button Design
+
+## 1. 목적
+
+Google Drive 등 sink 상세 설정 패널에서 사용자가 값을 입력하는 즉시 설정이 반영되는 현재 동작을 중단하고,
+**반드시 패널 내부 저장 버튼을 눌렀을 때만 sink 설정이 editor store에 반영되도록** 구조를 재설계한다.
+
+이번 설계는 `features/configure-node`의 편집 책임과 `features/workflow-editor`의 저장 책임을 분리하고,
+컨벤션의 상태 관리 원칙에 맞게 panel local draft와 global store를 다시 정렬하는 것을 목표로 한다.
+
+---
+
+## 2. 현재 구현 상태
+
+### 2.1 현재 sink 패널 동작
+
+현재 [SinkNodePanel.tsx](/d:/flowify-fe/src/features/configure-node/ui/panels/SinkNodePanel.tsx) 는 다음 흐름으로 동작한다.
+
+1. 각 입력 필드가 local `draftValues`를 가진다.
+2. 입력 필드에서 포커스가 빠질 때 `onBlur`로 `commitFieldChange()`가 호출된다.
+3. `commitFieldChange()`는 즉시 `updateNodeConfig()`를 호출한다.
+4. `updateNodeConfig()`는 workflow store의 해당 node config를 바로 수정하고 `isDirty = true`를 만든다.
+5. required field가 모두 채워졌다면 sink node의 `config.isConfigured`도 같이 갱신된다.
+
+즉 지금은 **편집 중인 값(draft)** 과 **editor에 반영된 값(committed config)** 사이에 중간 단계가 없다.
+
+### 2.2 현재 구조의 문제
+
+이 구조 때문에 사용자는 다음과 같이 느낀다.
+
+- 다른 필드를 클릭하는 순간 현재 필드 blur가 발생한다.
+- blur 시점에 config가 store에 반영된다.
+- required field가 모두 충족되면 완료 상태도 같이 바뀐다.
+- 결과적으로 "입력 중"과 "설정 저장 완료"가 구분되지 않는다.
+
+특히 Google Drive sink는 backend schema 기준 required field가 `folder_id` 하나뿐이어서,
+`folder_id`가 들어가는 순간 사용자는 "저장 버튼도 없는데 저장돼 버린다"고 느끼게 된다.
+
+관련 코드:
+
+- [SinkNodePanel.tsx](/d:/flowify-fe/src/features/configure-node/ui/panels/SinkNodePanel.tsx)
+- [workflowStore.ts](/d:/flowify-fe/src/features/workflow-editor/model/workflowStore.ts)
+- backend schema: [sink_catalog.json](/d:/flowify-be/flowify-BE-spring/src/main/resources/catalog/sink_catalog.json)
+
+---
+
+## 3. 문제 정의
+
+현재 문제는 단순히 blur 이벤트가 불편한 수준이 아니라, 아래 두 책임이 섞여 있다는 점이다.
+
+1. **패널 내부 편집 상태**
+   - 사용자가 지금 입력 중인 임시 값
+   - 아직 확정되지 않은 값
+
+2. **editor global state**
+   - 캔버스/노드 요약/저장 payload에 반영되는 값
+   - workflow dirty state를 변경하는 값
+
+컨벤션 기준으로 보면 panel 내부 편집 상태는 `Zustand` global store가 아니라 **로컬 state** 여야 하고,
+global store는 **명시적 사용자 액션 이후에만** 갱신되는 편이 맞다.
+
+참고:
+- `docs/CONVENTION.md` 4.4 관사 분리 기준
+- `docs/CONVENTION.md` 7.2 Zustand 사용 규칙
+
+---
+
+## 4. 설계 원칙
+
+### 4.1 panel draft와 editor store를 분리한다
+
+- 입력 중 값은 `SinkNodePanel` 내부 local state로 유지한다.
+- workflow store는 저장 버튼을 눌렀을 때만 갱신한다.
+
+### 4.2 저장 버튼은 panel 수준의 "설정 반영"이다
+
+이번에 추가하는 버튼은 **워크플로우 전체를 서버에 저장하는 버튼이 아니다.**
+
+정확한 의미는 다음과 같다.
+
+- panel draft -> workflow editor store 반영
+- 이후 상단 remote bar의 저장 버튼을 눌러야 서버 저장
+
+즉 저장 단계는 2단계다.
+
+1. sink panel 저장 버튼: local draft를 editor graph에 반영
+2. workflow 저장 버튼: editor graph를 backend에 저장
+
+### 4.3 완료 상태는 저장 버튼 이후에만 계산한다
+
+- 타이핑 중에는 `config.isConfigured`를 바꾸지 않는다.
+- 저장 버튼 클릭 시점에 required field 충족 여부를 검사한다.
+- required field가 모두 채워졌을 때만 committed config와 `isConfigured`를 함께 반영한다.
+
+### 4.4 빈 값은 `null`이 아니라 config에서 제거한다
+
+- sink field를 비웠을 때 `key: null` 형태로 저장하지 않는다.
+- `buildCommittedConfigFromDraft()`는 schema field를 순회하면서 **값이 있는 field만** committed config에 포함한다.
+- optional field를 비우면 committed config에서 해당 key를 제거한다.
+- required field가 비어 있으면 local validation에서 저장을 막고, backend payload에도 key를 넣지 않는다.
+
+이 규칙이 필요한 이유는 backend sink lifecycle이 required field를 볼 때
+값 자체보다 **config key 존재 여부**를 기준으로 판단하기 때문이다.
+
+### 4.5 backend lifecycle는 계속 authoritative source로 유지한다
+
+- 최종 실행 가능 여부, missing fields, executable 판단은 여전히 `nodeStatuses`가 authoritative다.
+- panel 저장 버튼은 local committed state만 바꾼다.
+- backend lifecycle 반영은 workflow save 후 detail refetch로 맞춘다.
+- `config.isConfigured`는 panel/canvas의 즉시 UX 힌트로만 사용하고,
+  실행 가능 여부나 최종 configured 판정은 계속 `nodeStatuses`를 따른다.
+
+---
+
+## 5. 목표 UX
+
+### 5.1 입력 중
+
+- 사용자가 텍스트를 입력해도 다른 필드로 이동하는 순간 store가 바로 바뀌지 않는다.
+- 캔버스 노드 요약이나 완료 상태가 입력 중간에 흔들리지 않는다.
+
+### 5.2 저장 전
+
+- panel 안에 `설정 저장` 버튼이 보인다.
+- draft가 store와 달라졌으면 버튼이 활성화된다.
+- required field가 비어 있으면 버튼 클릭 시 로컬 validation 메시지를 보여준다.
+
+### 5.3 저장 후
+
+- 버튼을 누른 뒤에만 node config가 store에 반영된다.
+- 이 시점에 `isDirty`가 true가 된다.
+- required field 충족 시 local `config.isConfigured`도 true가 된다.
+- optional field를 비운 경우 committed config에서 해당 key가 제거된다.
+
+### 5.4 workflow 저장 후
+
+- 상단 remote bar 저장 후 detail refetch
+- backend `nodeStatuses.configured / missingFields / executable`가 최신화된다
+
+---
+
+## 6. 구체적 변경 설계
+
+## 6.1 `SinkNodePanel`를 draft-driven panel로 재구성
+
+### 현재
+
+- `onBlur` 즉시 `commitFieldChange()`
+- field 단위 store 반영
+
+### 변경
+
+- `draftValues`는 유지
+- `committedConfigSnapshot` 또는 현재 `sinkConfig`와 비교해 dirty 여부 계산
+- 각 입력은 `draftValues`만 갱신
+- `설정 저장` 버튼 클릭 시 `applyDraftToNode()` 호출
+
+### 패널 내부 함수 제안
+
+- `getDraftStringValue(fieldKey)`
+- `validateDraft(draftValues, sinkSchema)`
+- `buildCommittedConfigFromDraft(draftValues, sinkSchema, sinkConfig)`
+- `handleSaveDraft()`
+- `handleResetDraft()` 또는 `handleDiscardChanges()`
+
+## 6.2 blur 커밋 제거
+
+다음 동작은 제거한다.
+
+- 입력 필드 `onBlur -> updateNodeConfig()`
+- select/button 클릭 즉시 store 반영
+
+select의 경우에도 동일하게 local draft만 바꾸고,
+저장 버튼을 눌렀을 때 최종 반영한다.
+
+## 6.3 `updateNodeConfig()` 사용 위치 축소
+
+`updateNodeConfig()`는 "편집 중 intermediate state"가 아니라
+"사용자 의도로 확정된 config mutation"에만 쓰이도록 의미를 좁힌다.
+
+다만 sink panel은 optional field 제거가 필요하므로
+부분 merge 기반 `updateNodeConfig()`만으로는 충분하지 않다.
+이번 단계에서는 **전체 config를 명시적으로 교체하는 action (`replaceNodeConfig()`)** 을 추가하고,
+sink panel 저장 버튼은 이 action을 사용한다.
+
+즉 panel에서의 호출 시점은:
+
+- communication panel처럼 single-click selection이 곧 확정인 경우
+- sink panel에서 저장 버튼을 눌렀을 경우 (`replaceNodeConfig()`)
+
+로 제한한다.
+
+## 6.4 panel local validation 추가
+
+`SinkNodePanel`에 local validation state를 추가한다.
+
+예:
+
+- `validationErrors: Record<string, string>`
+- required field 미입력
+- number 타입 파싱 실패
+
+validation은 저장 버튼 클릭 시 보여주고,
+입력 중에는 공격적으로 완료 상태를 바꾸지 않는다.
+
+## 6.5 버튼 UI 추가
+
+`NodePanelShell` 하단 또는 `SinkNodePanel` 내부에 action row를 추가한다.
+
+임시 설계:
+
+- 좌측: 변경 사항 안내 (`저장되지 않은 변경 사항`)
+- 우측:
+  - `초기화` 또는 `되돌리기`
+  - `설정 저장`
+
+버튼 정책:
+
+- 변경 사항이 없으면 `설정 저장` 비활성화
+- readOnly면 둘 다 비활성화
+- validation 실패 시 저장 차단
+
+## 6.6 local completed state와 backend completed state 구분
+
+### local
+
+- panel 저장 버튼 클릭 후
+- required field 충족 시 `config.isConfigured = true`
+
+이 값은 **local committed state** 이며,
+아직 backend detail refetch를 거치지 않은 상태일 수 있다.
+
+### backend authoritative
+
+- workflow save + detail refetch 후
+- `nodeStatuses[nodeId].configured`
+
+표시 우선순위는 계속 다음을 유지한다.
+
+- 실행 가능 여부/필수 누락 안내: `nodeStatuses`
+- panel 편집 완료 여부/도우미 텍스트: local `config.isConfigured`
+
+---
+
+## 7. 파일별 변경 범위
+
+### 7.1 [src/features/configure-node/ui/panels/SinkNodePanel.tsx](/d:/flowify-fe/src/features/configure-node/ui/panels/SinkNodePanel.tsx)
+
+주요 변경:
+
+- blur 저장 제거
+- field edit = local draft only
+- validation state 추가
+- `설정 저장` 버튼 추가
+- `설정 저장` 클릭 시에만 `updateNodeConfig()` 호출
+
+### 7.2 [src/features/configure-node/ui/panels/NodePanelShell.tsx](/d:/flowify-fe/src/features/configure-node/ui/panels/NodePanelShell.tsx)
+
+선택 변경:
+
+- shell에 action slot 추가 가능
+- 또는 sink panel 내부에만 action row를 둘 수도 있음
+
+현재 변경 범위를 작게 가져가려면
+**shell 공통화보다 SinkNodePanel 내부 배치가 우선**이다.
+
+### 7.3 [src/features/workflow-editor/model/workflowStore.ts](/d:/flowify-fe/src/features/workflow-editor/model/workflowStore.ts)
+
+주요 변경:
+
+- `updateNodeConfig()`는 지금처럼 "부분 config 반영" API로 유지
+- `replaceNodeConfig()`를 추가해 전체 committed config 교체를 지원
+- sink panel 저장 버튼은 `replaceNodeConfig()`를 사용
+- panel draft 편집 단계에서는 어떤 store action도 호출하지 않는다
+
+### 7.4 [src/features/configure-node/ui/panels/CommunicationPanel.tsx](/d:/flowify-fe/src/features/configure-node/ui/panels/CommunicationPanel.tsx)
+
+이 패널은 single action이 곧 확정이라 즉시 반영 유지 가능.
+
+즉 sink panel과 다르게:
+
+- select = commit
+- 별도 저장 버튼 없음
+
+으로 남겨도 된다.
+
+---
+
+## 8. 구현 단계 제안
+
+### 단계 1. sink panel 저장 방식 전환
+
+- blur commit 제거
+- draft-only 입력 구조로 변경
+- `설정 저장` 버튼 추가
+- local validation 추가
+
+### 단계 2. 완료 상태 전환 시점 정리
+
+- 저장 버튼 클릭 시에만 `config.isConfigured` 변경
+- 캔버스/패널 helper text 재검토
+
+### 단계 3. 회귀 검토
+
+- Google Drive sink
+- Notion sink
+- select field / text field 혼합 케이스
+- workflow save 후 nodeStatuses 재동기화
+
+---
+
+## 9. 체크리스트
+
+### 설계 체크리스트
+
+- [ ] panel draft와 store mutation 책임이 분리된다
+- [ ] blur는 저장 트리거가 아니다
+- [ ] 저장 버튼 클릭만이 sink config commit 트리거다
+- [ ] required field validation은 local panel에서 먼저 수행된다
+- [ ] nodeStatuses는 backend authoritative source로 유지된다
+
+### 구현 체크리스트
+
+- [ ] `SinkNodePanel` 입력이 local state만 갱신한다
+- [ ] `설정 저장` 버튼이 추가된다
+- [ ] 저장 버튼 클릭 시 `replaceNodeConfig()`가 한 번만 호출된다
+- [ ] select field도 즉시 commit하지 않고 draft만 바꾼다
+- [ ] validation 실패 시 config 반영이 차단된다
+- [ ] 비운 optional field가 committed config에서 제거된다
+- [ ] `pnpm run build` 통과
+
+---
+
+## 10. 완료 조건
+
+- sink 상세 설정 입력 중에는 다른 필드를 클릭해도 자동 저장되지 않는다
+- required field를 모두 채워도 저장 버튼 전에는 완료 상태가 바뀌지 않는다
+- 저장 버튼을 눌렀을 때만 sink config가 editor store에 반영된다
+- workflow 서버 저장은 기존 remote bar 저장 흐름을 그대로 따른다

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -31,6 +31,10 @@ export const Router = () => {
           path={ROUTE_PATHS.AUTH_CALLBACK}
           element={<AuthCallbackPage />}
         />
+        <Route
+          path={ROUTE_PATHS.OAUTH_CALLBACK}
+          element={<AuthCallbackPage />}
+        />
 
         <Route element={<ProtectedRoute />}>
           <Route element={<AppShellLayout />}>

--- a/src/entities/node/model/nodePresentation.ts
+++ b/src/entities/node/model/nodePresentation.ts
@@ -6,6 +6,7 @@ import {
   type CommunicationNodeConfig,
   type FlowNodeData,
   type StorageNodeConfig,
+  type WebScrapingNodeConfig,
 } from "./types";
 
 export type NodeRole = "source" | "process" | "destination";
@@ -46,6 +47,17 @@ const COMMUNICATION_SERVICE_TITLE: Record<
 > = {
   gmail: "Gmail",
   slack: "Slack",
+};
+
+const WEB_SCRAPING_SERVICE_TITLE: Record<
+  NonNullable<WebScrapingNodeConfig["service"]>,
+  string
+> = {
+  canvas_lms: "Canvas LMS",
+  coupang: "Coupang",
+  github: "GitHub",
+  naver_news: "Naver News",
+  youtube: "YouTube",
 };
 
 export const getNodeRole = ({
@@ -92,6 +104,10 @@ const getConfiguredTitle = (data: FlowNodeData): string | null => {
     }
     case "web-scraping": {
       const config = getTypedConfig("web-scraping", data.config);
+      if (config.service) {
+        return WEB_SCRAPING_SERVICE_TITLE[config.service] ?? config.targetUrl;
+      }
+
       return config.targetUrl ?? null;
     }
     case "filter":

--- a/src/entities/node/model/types.ts
+++ b/src/entities/node/model/types.ts
@@ -62,6 +62,16 @@ export interface SpreadsheetNodeConfig extends BaseNodeConfig {
 }
 
 export interface WebScrapingNodeConfig extends BaseNodeConfig {
+  service?:
+    | "canvas_lms"
+    | "coupang"
+    | "github"
+    | "naver_news"
+    | "youtube"
+    | null;
+  source_mode?: string | null;
+  target?: string | null;
+  canonical_input_type?: string | null;
   targetUrl: string | null;
   selector: string | null;
   outputFields: string[];

--- a/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
+++ b/src/entities/node/ui/custom-nodes/WebScrapingNode.tsx
@@ -5,15 +5,44 @@ import { getTypedConfig } from "../../model";
 import { type FlowNodeData } from "../../model/types";
 import { BaseNode } from "../BaseNode";
 
+const WEB_SCRAPING_SOURCE_MODE_LABELS: Record<string, string> = {
+  course_files: "특정 과목 강의자료 전체",
+  course_new_file: "과목의 새 강의자료",
+  term_all_files: "학기 전체 과목 자료",
+};
+
+const getWebScrapingSummary = (config: FlowNodeData["config"]) => {
+  const typedConfig = getTypedConfig("web-scraping", config);
+
+  if (typedConfig.service) {
+    const parts = [
+      typedConfig.source_mode
+        ? (WEB_SCRAPING_SOURCE_MODE_LABELS[typedConfig.source_mode] ??
+          typedConfig.source_mode)
+        : null,
+      typedConfig.target ? `대상: ${typedConfig.target}` : null,
+    ].filter((value): value is string => Boolean(value));
+
+    if (parts.length > 0) {
+      return parts.join(" / ");
+    }
+  }
+
+  if (typedConfig.targetUrl) {
+    return typedConfig.targetUrl;
+  }
+
+  return "URL 미설정";
+};
+
 export const WebScrapingNode = ({
   id,
   data,
   selected,
 }: NodeProps<Node<FlowNodeData>>) => {
-  const config = getTypedConfig("web-scraping", data.config);
   return (
     <BaseNode id={id} data={data} selected={selected}>
-      <Text>{config.targetUrl ?? "URL 미설정"}</Text>
+      <Text>{getWebScrapingSummary(data.config)}</Text>
     </BaseNode>
   );
 };

--- a/src/entities/oauth-token/api/connect-oauth-token.api.ts
+++ b/src/entities/oauth-token/api/connect-oauth-token.api.ts
@@ -1,11 +1,28 @@
 import { request } from "@/shared/api/core";
 
-import { type OAuthConnectResponse } from "./types";
+import { type OAuthConnectResult, type RawOAuthConnectResponse } from "./types";
+
+const normalizeOAuthConnectResponse = (
+  response: RawOAuthConnectResponse,
+): OAuthConnectResult => {
+  if ("authUrl" in response) {
+    return {
+      kind: "redirect",
+      authUrl: response.authUrl,
+    };
+  }
+
+  return {
+    kind: "direct",
+    service: response.service,
+    connected: true,
+  };
+};
 
 export const connectOAuthTokenAPI = (
   service: string,
-): Promise<OAuthConnectResponse> =>
-  request<OAuthConnectResponse>({
+): Promise<OAuthConnectResult> =>
+  request<RawOAuthConnectResponse>({
     url: `/oauth-tokens/${service}/connect`,
     method: "POST",
-  });
+  }).then(normalizeOAuthConnectResponse);

--- a/src/entities/oauth-token/api/types.ts
+++ b/src/entities/oauth-token/api/types.ts
@@ -5,6 +5,10 @@ export interface OAuthTokenSummary {
   expiresAt: string | null;
 }
 
-export interface OAuthConnectResponse {
-  authUrl: string;
-}
+export type RawOAuthConnectResponse =
+  | { authUrl: string }
+  | { connected: "true"; service: string };
+
+export type OAuthConnectResult =
+  | { kind: "redirect"; authUrl: string }
+  | { kind: "direct"; service: string; connected: true };

--- a/src/entities/oauth-token/model/oauth-connect-support.ts
+++ b/src/entities/oauth-token/model/oauth-connect-support.ts
@@ -1,4 +1,10 @@
-export const OAUTH_CONNECT_SUPPORTED_SERVICES = ["slack"] as const;
+export const OAUTH_CONNECT_SUPPORTED_SERVICES = [
+  "slack",
+  "google_drive",
+  "notion",
+  "github",
+  "canvas_lms",
+] as const;
 
 export const isOAuthConnectSupported = (serviceKey: string) =>
   OAUTH_CONNECT_SUPPORTED_SERVICES.includes(

--- a/src/entities/workflow/lib/workflow-node-adapter.ts
+++ b/src/entities/workflow/lib/workflow-node-adapter.ts
@@ -54,6 +54,7 @@ const BACKEND_TYPE_TO_NODE_TYPE = Object.fromEntries(
 ) as Record<string, NodeType>;
 
 const SERVICE_KEY_TO_NODE_TYPE = {
+  canvas_lms: "web-scraping",
   coupang: "web-scraping",
   github: "web-scraping",
   gmail: "communication",
@@ -71,6 +72,7 @@ const NODE_TYPES_WITH_SERVICE_CONFIG = new Set<NodeType>([
   "communication",
   "spreadsheet",
   "storage",
+  "web-scraping",
 ]);
 
 type NodeDraftOptions = {

--- a/src/features/add-node/model/source-rollout.ts
+++ b/src/features/add-node/model/source-rollout.ts
@@ -1,4 +1,5 @@
 export const SOURCE_SERVICE_ROLLOUT_ALLOWLIST = {
+  canvas_lms: ["course_files", "course_new_file", "term_all_files"],
   google_drive: [
     "single_file",
     "file_changed",

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -47,7 +47,12 @@ import {
   useSourceCatalogQuery,
 } from "@/entities/workflow";
 import { hydrateStore, useWorkflowStore } from "@/features/workflow-editor";
-import { getApiErrorMessage, getLeafNodeIds } from "@/shared";
+import {
+  getApiErrorMessage,
+  getCurrentRelativeUrl,
+  getLeafNodeIds,
+  storeOAuthConnectReturnPath,
+} from "@/shared";
 
 import { isSinkServiceInRollout } from "../model/sink-rollout";
 import { isSourceModeInRollout } from "../model/source-rollout";
@@ -913,6 +918,7 @@ export const ServiceSelectionPanel = () => {
         setAuthErrorMessage(null);
         const result = await connectOAuthToken(serviceKey);
         if (result.kind === "redirect") {
+          storeOAuthConnectReturnPath(getCurrentRelativeUrl());
           window.location.assign(result.authUrl);
           return;
         }

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -13,6 +13,7 @@ import {
   MdArticle,
   MdCancel,
   MdFolder,
+  MdSchool,
   MdSearch,
 } from "react-icons/md";
 import {
@@ -62,6 +63,7 @@ const START_END_NODE_HEIGHT = 176;
 const EMPTY_TARGET_SENTINEL = "";
 
 const CATALOG_SERVICE_ICON_MAP: Record<string, IconType> = {
+  canvas_lms: MdSchool,
   gmail: SiGmail,
   google_calendar: SiGooglecalendar,
   google_drive: SiGoogledrive,

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -615,6 +615,7 @@ export const ServiceSelectionPanel = () => {
     data: oauthTokens,
     isError: isOAuthTokensError,
     isLoading: isOAuthTokensLoading,
+    refetch: refetchOAuthTokens,
   } = useOAuthTokensQuery({
     enabled: Boolean(activePlaceholder),
   });
@@ -909,7 +910,20 @@ export const ServiceSelectionPanel = () => {
       try {
         setAuthErrorMessage(null);
         const result = await connectOAuthToken(serviceKey);
-        window.location.assign(result.authUrl);
+        if (result.kind === "redirect") {
+          window.location.assign(result.authUrl);
+          return;
+        }
+
+        await refetchOAuthTokens();
+
+        if (selectedSourceService?.key === result.service) {
+          setStartStep("mode");
+        }
+
+        if (selectedSinkService?.key === result.service) {
+          setEndStep("confirm");
+        }
       } catch (error) {
         setAuthErrorMessage(getApiErrorMessage(error));
       }

--- a/src/features/configure-node/ui/panels/CommunicationPanel.tsx
+++ b/src/features/configure-node/ui/panels/CommunicationPanel.tsx
@@ -38,7 +38,7 @@ export const CommunicationPanel = ({
   const handleServiceChange = (
     service: NonNullable<CommunicationNodeConfig["service"]>,
   ) => {
-    updateNodeConfig(nodeId, { service });
+    updateNodeConfig(nodeId, { service, isConfigured: true });
   };
 
   return (

--- a/src/features/configure-node/ui/panels/SinkNodePanel.tsx
+++ b/src/features/configure-node/ui/panels/SinkNodePanel.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Box, Button, Input, Spinner, Text } from "@chakra-ui/react";
 
 import { type FlowNodeData } from "@/entities/node";
 import {
+  type SinkSchemaFieldResponse,
   getNodeStatusMissingFieldLabel,
   toBackendDataType,
   toEdgeDefinition,
@@ -42,6 +43,279 @@ const getFieldInputType = (fieldType: string) => {
   return "text";
 };
 
+const getInitialDraftValues = (
+  fields: SinkSchemaFieldResponse[],
+  sinkConfig: Record<string, unknown>,
+) =>
+  Object.fromEntries(
+    fields.map((field) => {
+      const rawValue = sinkConfig[field.key];
+      const stringValue =
+        typeof rawValue === "string" || typeof rawValue === "number"
+          ? String(rawValue)
+          : "";
+
+      return [field.key, stringValue];
+    }),
+  );
+
+const normalizeDraftValue = (
+  field: SinkSchemaFieldResponse,
+  value: string,
+): string | number | undefined => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    return undefined;
+  }
+
+  if (field.type === "number") {
+    const parsedValue = Number(value);
+    return Number.isFinite(parsedValue) ? parsedValue : undefined;
+  }
+
+  return value;
+};
+
+const validateDraft = (
+  draftValues: Record<string, string>,
+  fields: SinkSchemaFieldResponse[],
+) => {
+  const nextValidationErrors: Record<string, string> = {};
+
+  fields.forEach((field) => {
+    const rawValue = draftValues[field.key] ?? "";
+    const trimmedValue = rawValue.trim();
+
+    if (field.required && trimmedValue.length === 0) {
+      nextValidationErrors[field.key] = `${field.label} 항목을 입력해 주세요.`;
+      return;
+    }
+
+    if (field.type === "number" && trimmedValue.length > 0) {
+      const parsedValue = Number(rawValue);
+      if (!Number.isFinite(parsedValue)) {
+        nextValidationErrors[field.key] =
+          `${field.label} 항목에는 올바른 숫자를 입력해 주세요.`;
+      }
+    }
+  });
+
+  return nextValidationErrors;
+};
+
+const buildCommittedConfigFromDraft = ({
+  draftValues,
+  fields,
+  sinkConfig,
+}: {
+  draftValues: Record<string, string>;
+  fields: SinkSchemaFieldResponse[];
+  sinkConfig: Record<string, unknown>;
+}) => {
+  const schemaFieldKeys = new Set(fields.map((field) => field.key));
+  const preservedConfigEntries = Object.entries(sinkConfig).filter(
+    ([key]) => !schemaFieldKeys.has(key) && key !== "isConfigured",
+  );
+  const nextConfig = Object.fromEntries(preservedConfigEntries) as Record<
+    string,
+    unknown
+  >;
+
+  fields.forEach((field) => {
+    const normalizedValue = normalizeDraftValue(
+      field,
+      draftValues[field.key] ?? "",
+    );
+    if (normalizedValue !== undefined) {
+      nextConfig[field.key] = normalizedValue;
+    }
+  });
+
+  const isConfigured = fields
+    .filter((field) => field.required)
+    .every((field) =>
+      Object.prototype.hasOwnProperty.call(nextConfig, field.key),
+    );
+
+  return {
+    ...nextConfig,
+    isConfigured,
+  } as FlowNodeData["config"];
+};
+
+type SinkSchemaEditorProps = {
+  fields: SinkSchemaFieldResponse[];
+  nodeId: string;
+  onSaveConfig: (config: FlowNodeData["config"]) => void;
+  readOnly: boolean;
+  sinkConfig: Record<string, unknown>;
+};
+
+const SinkSchemaEditor = ({
+  fields,
+  nodeId,
+  onSaveConfig,
+  readOnly,
+  sinkConfig,
+}: SinkSchemaEditorProps) => {
+  const initialDraftValues = useMemo(
+    () => getInitialDraftValues(fields, sinkConfig),
+    [fields, sinkConfig],
+  );
+  const [draftValues, setDraftValues] =
+    useState<Record<string, string>>(initialDraftValues);
+  const [validationErrors, setValidationErrors] = useState<
+    Record<string, string>
+  >({});
+
+  const hasChanges = useMemo(
+    () =>
+      fields.some(
+        (field) =>
+          (draftValues[field.key] ?? "") !==
+          (initialDraftValues[field.key] ?? ""),
+      ),
+    [draftValues, fields, initialDraftValues],
+  );
+
+  const handleFieldChange = (fieldKey: string, value: string) => {
+    setDraftValues((current) => ({
+      ...current,
+      [fieldKey]: value,
+    }));
+    setValidationErrors((current) => {
+      if (!(fieldKey in current)) {
+        return current;
+      }
+
+      const nextValidationErrors = { ...current };
+      delete nextValidationErrors[fieldKey];
+      return nextValidationErrors;
+    });
+  };
+
+  const handleResetDraft = () => {
+    setDraftValues(initialDraftValues);
+    setValidationErrors({});
+  };
+
+  const handleSaveDraft = () => {
+    const nextValidationErrors = validateDraft(draftValues, fields);
+    if (Object.keys(nextValidationErrors).length > 0) {
+      setValidationErrors(nextValidationErrors);
+      return;
+    }
+
+    const nextConfig = buildCommittedConfigFromDraft({
+      draftValues,
+      fields,
+      sinkConfig,
+    });
+
+    onSaveConfig(nextConfig);
+    setValidationErrors({});
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={4}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        gap={4}
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        {fields.map((field) => {
+          const stringValue = draftValues[field.key] ?? "";
+          const validationError = validationErrors[field.key] ?? null;
+
+          return (
+            <Box
+              key={`${nodeId}-${field.key}`}
+              display="flex"
+              flexDirection="column"
+              gap={2}
+            >
+              <Text fontSize="sm" fontWeight="medium">
+                {field.label}
+                {field.required ? " *" : ""}
+              </Text>
+
+              {field.type === "select" && field.options ? (
+                <Box display="flex" flexWrap="wrap" gap={2}>
+                  {field.options.map((option) => (
+                    <Button
+                      key={option}
+                      disabled={readOnly}
+                      size="sm"
+                      variant={stringValue === option ? "solid" : "outline"}
+                      onClick={() => handleFieldChange(field.key, option)}
+                    >
+                      {option}
+                    </Button>
+                  ))}
+                </Box>
+              ) : (
+                <Input
+                  disabled={readOnly}
+                  placeholder={`${FIELD_LABELS[field.type] ?? field.type} 입력`}
+                  type={getFieldInputType(field.type)}
+                  value={stringValue}
+                  onChange={(event) =>
+                    handleFieldChange(field.key, event.target.value)
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                    }
+                  }}
+                />
+              )}
+
+              {validationError ? (
+                <Text color="red.500" fontSize="xs">
+                  {validationError}
+                </Text>
+              ) : null}
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box
+        alignItems={{ base: "stretch", md: "center" }}
+        display="flex"
+        flexDirection={{ base: "column", md: "row" }}
+        gap={3}
+        justifyContent="space-between"
+      >
+        <Text color="text.secondary" fontSize="xs">
+          {hasChanges
+            ? "저장되지 않은 변경 사항이 있습니다."
+            : "현재 패널에 표시된 값이 editor store에 반영된 상태입니다."}
+        </Text>
+
+        <Box display="flex" gap={2} justifyContent="flex-end">
+          <Button
+            disabled={readOnly || !hasChanges}
+            size="sm"
+            variant="outline"
+            onClick={handleResetDraft}
+          >
+            되돌리기
+          </Button>
+          <Button
+            disabled={readOnly || !hasChanges}
+            size="sm"
+            onClick={handleSaveDraft}
+          >
+            설정 저장
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
 export const SinkNodePanel = ({
   data,
   nodeId,
@@ -51,8 +325,10 @@ export const SinkNodePanel = ({
   const endNodeId = useWorkflowStore((state) => state.endNodeId);
   const nodeStatuses = useWorkflowStore((state) => state.nodeStatuses);
   const nodes = useWorkflowStore((state) => state.nodes);
+  const replaceNodeConfig = useWorkflowStore(
+    (state) => state.replaceNodeConfig,
+  );
   const startNodeId = useWorkflowStore((state) => state.startNodeId);
-  const updateNodeConfig = useWorkflowStore((state) => state.updateNodeConfig);
   const workflowId = useWorkflowStore((state) => state.workflowId);
   const { data: sinkCatalog } = useSinkCatalogQuery();
   const {
@@ -94,24 +370,24 @@ export const SinkNodePanel = ({
     previewSchema(previewRequest);
   }, [previewRequest, previewSchema, workflowId]);
 
-  const handleFieldChange = (
-    fieldKey: string,
-    fieldType: string,
-    value: string,
-  ) => {
-    const nextValue =
-      value === "" ? null : fieldType === "number" ? Number(value) : value;
+  const sinkEditorKey = useMemo(() => {
+    if (!sinkSchema || !serviceKey) {
+      return null;
+    }
 
-    updateNodeConfig(nodeId, {
-      [fieldKey]: nextValue,
-    } as Partial<FlowNodeData["config"]>);
-  };
+    const snapshot = sinkSchema.fields.map((field) => [
+      field.key,
+      sinkConfig[field.key] ?? "",
+    ]);
+
+    return `${nodeId}:${serviceKey}:${JSON.stringify(snapshot)}`;
+  }, [nodeId, serviceKey, sinkConfig, sinkSchema]);
 
   return (
     <NodePanelShell
+      description="현재 결과를 어디로 보낼지 정한 뒤 마지막 단계에서 상세 설정을 채워넣습니다."
       eyebrow="도착 설정"
       title={selectedSinkService?.label ?? "Destination"}
-      description="현재 결과를 어디로 보낼지 정한 뒤 마지막 단계에서 상세 설정을 채웁니다."
     >
       <Box display="flex" flexDirection="column" gap={6}>
         {nodeStatus ? (
@@ -186,63 +462,14 @@ export const SinkNodePanel = ({
           </Text>
 
           {selectedSinkService && sinkSchema ? (
-            <Box display="flex" flexDirection="column" gap={4}>
-              {sinkSchema.fields.map((field) => {
-                const rawValue = sinkConfig[field.key];
-                const stringValue =
-                  typeof rawValue === "string" || typeof rawValue === "number"
-                    ? String(rawValue)
-                    : "";
-
-                return (
-                  <Box
-                    key={field.key}
-                    display="flex"
-                    flexDirection="column"
-                    gap={2}
-                  >
-                    <Text fontSize="sm" fontWeight="medium">
-                      {field.label}
-                      {field.required ? " *" : ""}
-                    </Text>
-
-                    {field.type === "select" && field.options ? (
-                      <Box display="flex" flexWrap="wrap" gap={2}>
-                        {field.options.map((option) => (
-                          <Button
-                            key={option}
-                            disabled={readOnly}
-                            size="sm"
-                            variant={
-                              stringValue === option ? "solid" : "outline"
-                            }
-                            onClick={() =>
-                              handleFieldChange(field.key, field.type, option)
-                            }
-                          >
-                            {option}
-                          </Button>
-                        ))}
-                      </Box>
-                    ) : (
-                      <Input
-                        disabled={readOnly}
-                        placeholder={`${FIELD_LABELS[field.type] ?? field.type} 입력`}
-                        type={getFieldInputType(field.type)}
-                        value={stringValue}
-                        onChange={(event) =>
-                          handleFieldChange(
-                            field.key,
-                            field.type,
-                            event.target.value,
-                          )
-                        }
-                      />
-                    )}
-                  </Box>
-                );
-              })}
-            </Box>
+            <SinkSchemaEditor
+              key={sinkEditorKey ?? nodeId}
+              fields={sinkSchema.fields}
+              nodeId={nodeId}
+              readOnly={readOnly}
+              sinkConfig={sinkConfig}
+              onSaveConfig={(config) => replaceNodeConfig(nodeId, config)}
+            />
           ) : (
             <Text color="text.secondary" fontSize="sm">
               sink 서비스를 먼저 선택하면 상세 설정을 채울 수 있습니다.

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -59,6 +59,7 @@ interface WorkflowEditorActions {
     id: string,
     config: Partial<FlowNodeData["config"]>,
   ) => void;
+  replaceNodeConfig: (id: string, config: FlowNodeData["config"]) => void;
   openPanel: (nodeId: string) => void;
   closePanel: () => void;
   setWorkflowMeta: (id: string, name: string) => void;
@@ -199,11 +200,28 @@ export const useWorkflowStore = create<
         const node = state.nodes.find((currentNode) => currentNode.id === id);
         if (!node) return;
 
+        const nextIsConfigured =
+          typeof config.isConfigured === "boolean"
+            ? config.isConfigured
+            : node.data.config.isConfigured;
+
         node.data.config = {
           ...node.data.config,
           ...config,
-          isConfigured: true,
+          isConfigured: nextIsConfigured,
         } as FlowNodeData["config"];
+
+        if (!state._isSyncing) {
+          state.isDirty = true;
+        }
+      }),
+
+    replaceNodeConfig: (id, config) =>
+      set((state) => {
+        const node = state.nodes.find((currentNode) => currentNode.id === id);
+        if (!node) return;
+
+        node.data.config = config;
 
         if (!state._isSyncing) {
           state.isDirty = true;

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -122,7 +122,12 @@ export default function AccountPage() {
 
     try {
       const result = await connectToken(service);
-      window.location.assign(result.authUrl);
+      if (result.kind === "redirect") {
+        window.location.assign(result.authUrl);
+        return;
+      }
+
+      await refetchOAuthTokens();
     } catch {
       // 화면의 기본 상태 문구로 충분히 안내한다.
     }

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -22,7 +22,12 @@ import {
   useSinkCatalogQuery,
   useSourceCatalogQuery,
 } from "@/entities";
-import { ROUTE_PATHS, getAuthUser } from "@/shared";
+import {
+  ROUTE_PATHS,
+  getAuthUser,
+  getCurrentRelativeUrl,
+  storeOAuthConnectReturnPath,
+} from "@/shared";
 
 type OAuthServiceItem = {
   key: string;
@@ -123,6 +128,7 @@ export default function AccountPage() {
     try {
       const result = await connectToken(service);
       if (result.kind === "redirect") {
+        storeOAuthConnectReturnPath(getCurrentRelativeUrl());
         window.location.assign(result.authUrl);
         return;
       }

--- a/src/pages/auth-callback/AuthCallbackPage.tsx
+++ b/src/pages/auth-callback/AuthCallbackPage.tsx
@@ -3,13 +3,15 @@ import { useLocation, useNavigate } from "react-router";
 
 import { Box, Button, Spinner, Text, VStack } from "@chakra-ui/react";
 
+import { authApi } from "@/entities";
 import {
   ROUTE_PATHS,
   clearAuthSession,
+  consumeOAuthConnectReturnPath,
   storeAuthUser,
   storeTokens,
 } from "@/shared";
-import { authApi } from "@/entities";
+
 import {
   authCallbackFallbackMessage,
   resolveAuthExchangeError,
@@ -27,10 +29,25 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     const exchangeCode = searchParams.get("exchange_code");
+    const connected = searchParams.get("connected");
+    const service = searchParams.get("service");
 
     let isMounted = true;
 
     const finalizeLogin = async () => {
+      if (service) {
+        if (connected === "true") {
+          navigate(consumeOAuthConnectReturnPath(), { replace: true });
+          return;
+        }
+
+        if (isMounted) {
+          setCallbackState("error");
+          setErrorMessage(resolveRedirectError(searchParams));
+        }
+        return;
+      }
+
       const redirectErrorMessage = resolveRedirectError(searchParams);
       if (redirectErrorMessage) {
         clearAuthSession();
@@ -112,7 +129,9 @@ export default function AuthCallbackPage() {
           <Text fontSize="lg" fontWeight="semibold">
             로그인 실패
           </Text>
-          <Text color="gray.600">{errorMessage ?? authCallbackFallbackMessage}</Text>
+          <Text color="gray.600">
+            {errorMessage ?? authCallbackFallbackMessage}
+          </Text>
           <Button
             bg="gray.900"
             color="white"

--- a/src/pages/dashboard/model/dashboard.ts
+++ b/src/pages/dashboard/model/dashboard.ts
@@ -1,4 +1,7 @@
-import { type OAuthTokenSummary } from "@/entities/oauth-token";
+import {
+  type OAuthTokenSummary,
+  isOAuthConnectSupported,
+} from "@/entities/oauth-token";
 import {
   type NodeDefinitionResponse,
   type WorkflowResponse,
@@ -27,15 +30,11 @@ type SupportedServiceKey =
   | "notion"
   | "slack";
 
-const DASHBOARD_SERVICE_PRIORITY: SupportedServiceKey[] = [
-  "calendar",
-  "canvas-lms",
-  "notion",
-  "google-drive",
-  "gmail",
-  "google-sheets",
-  "slack",
-];
+type RecommendedDashboardService = {
+  serviceKey: string;
+  badgeKey: SupportedServiceKey;
+  label: string;
+};
 
 const DASHBOARD_SERVICE_LABELS: Record<SupportedServiceKey, string> = {
   calendar: "Google Calendar",
@@ -46,6 +45,29 @@ const DASHBOARD_SERVICE_LABELS: Record<SupportedServiceKey, string> = {
   notion: "Notion",
   slack: "Slack",
 };
+
+const RECOMMENDED_DASHBOARD_SERVICES: RecommendedDashboardService[] = [
+  {
+    serviceKey: "canvas_lms",
+    badgeKey: "canvas-lms",
+    label: "Canvas LMS",
+  },
+  {
+    serviceKey: "google_drive",
+    badgeKey: "google-drive",
+    label: "Google Drive",
+  },
+  {
+    serviceKey: "notion",
+    badgeKey: "notion",
+    label: "Notion",
+  },
+  {
+    serviceKey: "slack",
+    badgeKey: "slack",
+    label: "Slack",
+  },
+];
 
 export const DASHBOARD_METRICS: DashboardMetric[] = [
   {
@@ -142,7 +164,7 @@ const getBuildProgressLabel = (workflow: WorkflowResponse) => {
     return isConfigured === true;
   }).length;
 
-  return `${configuredNodes}/${totalNodes} 구축`;
+  return `${configuredNodes}/${totalNodes} 구성`;
 };
 
 const getWorkflowWarningMessages = (workflow: WorkflowResponse) =>
@@ -220,25 +242,30 @@ export const getConnectedServiceCards = (tokens: OAuthTokenSummary[]) =>
             ? token.service
             : getServiceLabelFromBadgeKey(badgeKey),
         badgeKey,
+        serviceKey: token.service,
         statusLabel: "연결됨",
+        actionKind: "disconnect",
+        actionLabel: "연결 해제",
       };
     });
 
 export const getRecommendedServiceCards = (tokens: OAuthTokenSummary[]) => {
-  const connectedKeys = new Set(
-    tokens
-      .filter((token) => token.connected)
-      .map((token) => getServiceBadgeKeyFromService(token.service)),
+  const connectedServiceKeys = new Set(
+    tokens.filter((token) => token.connected).map((token) => token.service),
   );
 
-  return DASHBOARD_SERVICE_PRIORITY.filter((serviceKey) => {
-    return !connectedKeys.has(serviceKey);
-  })
-    .slice(0, 4)
-    .map<DashboardServiceCard>((serviceKey) => ({
-      id: `recommended-${serviceKey}`,
-      label: DASHBOARD_SERVICE_LABELS[serviceKey],
-      badgeKey: serviceKey,
-      statusLabel: "인증 전",
-    }));
+  return RECOMMENDED_DASHBOARD_SERVICES.filter(({ serviceKey }) => {
+    return (
+      isOAuthConnectSupported(serviceKey) &&
+      !connectedServiceKeys.has(serviceKey)
+    );
+  }).map<DashboardServiceCard>(({ serviceKey, badgeKey, label }) => ({
+    id: `recommended-${serviceKey}`,
+    label,
+    badgeKey,
+    serviceKey,
+    statusLabel: "인증 전",
+    actionKind: "connect",
+    actionLabel: "연결 시작",
+  }));
 };

--- a/src/pages/dashboard/model/dashboard.ts
+++ b/src/pages/dashboard/model/dashboard.ts
@@ -20,6 +20,7 @@ import {
 
 type SupportedServiceKey =
   | "calendar"
+  | "canvas-lms"
   | "gmail"
   | "google-drive"
   | "google-sheets"
@@ -28,6 +29,7 @@ type SupportedServiceKey =
 
 const DASHBOARD_SERVICE_PRIORITY: SupportedServiceKey[] = [
   "calendar",
+  "canvas-lms",
   "notion",
   "google-drive",
   "gmail",
@@ -37,6 +39,7 @@ const DASHBOARD_SERVICE_PRIORITY: SupportedServiceKey[] = [
 
 const DASHBOARD_SERVICE_LABELS: Record<SupportedServiceKey, string> = {
   calendar: "Google Calendar",
+  "canvas-lms": "Canvas LMS",
   gmail: "Gmail",
   "google-drive": "Google Drive",
   "google-sheets": "Google Sheets",
@@ -95,6 +98,11 @@ const getWorkflowServiceBadgeKey = (
     if (serviceBadgeKey !== "unknown") {
       return serviceBadgeKey;
     }
+  }
+
+  const typeBadgeKey = getServiceBadgeKeyFromService(node.type);
+  if (typeBadgeKey !== "unknown") {
+    return typeBadgeKey;
   }
 
   switch (node.type) {

--- a/src/pages/dashboard/model/types.ts
+++ b/src/pages/dashboard/model/types.ts
@@ -32,5 +32,8 @@ export type DashboardServiceCard = {
   id: string;
   label: string;
   badgeKey: ServiceBadgeKey;
+  serviceKey: string;
   statusLabel: string;
+  actionKind: "connect" | "disconnect";
+  actionLabel: string;
 };

--- a/src/pages/dashboard/model/useDashboardData.ts
+++ b/src/pages/dashboard/model/useDashboardData.ts
@@ -1,7 +1,13 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
-import { useOAuthTokensQuery } from "@/entities/oauth-token";
+import {
+  isOAuthConnectSupported,
+  useConnectOAuthTokenMutation,
+  useDisconnectOAuthTokenMutation,
+  useOAuthTokensQuery,
+} from "@/entities/oauth-token";
 import { useWorkflowListQuery } from "@/entities/workflow";
+import { getCurrentRelativeUrl, storeOAuthConnectReturnPath } from "@/shared";
 
 import {
   DASHBOARD_METRICS,
@@ -16,6 +22,13 @@ const DASHBOARD_WORKFLOW_PAGE_SIZE = 20;
 export const useDashboardData = () => {
   const workflowQuery = useWorkflowListQuery(0, DASHBOARD_WORKFLOW_PAGE_SIZE);
   const oauthTokenQuery = useOAuthTokensQuery();
+  const { mutateAsync: connectToken, isPending: isConnectPending } =
+    useConnectOAuthTokenMutation();
+  const { mutateAsync: disconnectToken, isPending: isDisconnectPending } =
+    useDisconnectOAuthTokenMutation();
+  const [pendingServiceKey, setPendingServiceKey] = useState<string | null>(
+    null,
+  );
 
   const workflows = useMemo(
     () => sortWorkflowsByUpdatedAtDesc(workflowQuery.data?.content ?? []),
@@ -42,6 +55,42 @@ export const useDashboardData = () => {
     void oauthTokenQuery.refetch();
   };
 
+  const handleConnectService = async (serviceKey: string) => {
+    if (!isOAuthConnectSupported(serviceKey)) {
+      return;
+    }
+
+    setPendingServiceKey(serviceKey);
+
+    try {
+      const result = await connectToken(serviceKey);
+      if (result.kind === "redirect") {
+        storeOAuthConnectReturnPath(getCurrentRelativeUrl());
+        window.location.assign(result.authUrl);
+        return;
+      }
+
+      await oauthTokenQuery.refetch();
+    } catch {
+      // 대시보드 카드 상태로 현재 연결 가능 여부를 다시 보여준다.
+    } finally {
+      setPendingServiceKey(null);
+    }
+  };
+
+  const handleDisconnectService = async (serviceKey: string) => {
+    setPendingServiceKey(serviceKey);
+
+    try {
+      await disconnectToken(serviceKey);
+      await oauthTokenQuery.refetch();
+    } catch {
+      // 대시보드 카드 상태로 현재 연결 가능 여부를 다시 보여준다.
+    } finally {
+      setPendingServiceKey(null);
+    }
+  };
+
   return {
     metrics: DASHBOARD_METRICS,
     issues,
@@ -51,7 +100,11 @@ export const useDashboardData = () => {
     isWorkflowsError: workflowQuery.isError,
     isServicesLoading: oauthTokenQuery.isLoading,
     isServicesError: oauthTokenQuery.isError,
+    isServiceActionPending: isConnectPending || isDisconnectPending,
+    pendingServiceKey,
     handleReloadWorkflows,
     handleReloadServices,
+    handleConnectService,
+    handleDisconnectService,
   };
 };

--- a/src/pages/dashboard/ui/ServiceConnectionCard.tsx
+++ b/src/pages/dashboard/ui/ServiceConnectionCard.tsx
@@ -1,4 +1,7 @@
-import { Flex, Text, VStack } from "@chakra-ui/react";
+import { type MouseEvent } from "react";
+import { MdClose } from "react-icons/md";
+
+import { Flex, IconButton, Spinner, Text, VStack } from "@chakra-ui/react";
 
 import { ServiceBadge } from "@/shared";
 
@@ -6,35 +9,85 @@ import { type DashboardServiceCard } from "../model";
 
 type Props = {
   service: DashboardServiceCard;
+  isPending?: boolean;
+  onAction?: () => void;
 };
 
-export const ServiceConnectionCard = ({ service }: Props) => {
+export const ServiceConnectionCard = ({
+  service,
+  isPending = false,
+  onAction,
+}: Props) => {
+  const isConnectCard = service.actionKind === "connect";
+
+  const handleDisconnectClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onAction?.();
+  };
+
   return (
     <Flex
+      as={isConnectCard ? "button" : "div"}
       w={{ base: "full", md: "252px" }}
       align="center"
+      justify="space-between"
       gap={3}
       p={4}
       bg="bg.surface"
       border="1px solid"
       borderColor="border.default"
       borderRadius="10px"
+      cursor={isConnectCard ? "pointer" : "default"}
+      transition="transform 180ms ease, box-shadow 180ms ease"
+      _hover={
+        isConnectCard
+          ? {
+              transform: "translateY(-1px)",
+              boxShadow: "0 12px 24px rgba(15, 23, 42, 0.06)",
+            }
+          : undefined
+      }
+      _disabled={{
+        cursor: "not-allowed",
+        opacity: 0.7,
+      }}
+      aria-disabled={isConnectCard ? isPending : undefined}
+      onClick={isConnectCard && !isPending ? onAction : undefined}
     >
-      <ServiceBadge type={service.badgeKey} />
+      <Flex align="center" gap={3} minW={0} flex={1}>
+        <ServiceBadge type={service.badgeKey} />
 
-      <VStack align="stretch" gap={0.5} minW={0}>
-        <Text
-          fontSize="sm"
-          fontWeight="medium"
-          color="text.primary"
-          lineClamp={1}
+        <VStack align="stretch" gap={0.5} minW={0}>
+          <Text
+            fontSize="sm"
+            fontWeight="medium"
+            color="text.primary"
+            lineClamp={1}
+          >
+            {service.label}
+          </Text>
+          <Text fontSize="xs" color="text.secondary" lineClamp={1}>
+            {service.statusLabel}
+          </Text>
+        </VStack>
+      </Flex>
+
+      {isConnectCard ? (
+        isPending ? (
+          <Spinner size="sm" flexShrink={0} />
+        ) : null
+      ) : (
+        <IconButton
+          aria-label={service.actionLabel}
+          variant="ghost"
+          size="sm"
+          flexShrink={0}
+          disabled={isPending}
+          onClick={handleDisconnectClick}
         >
-          {service.label}
-        </Text>
-        <Text fontSize="xs" color="text.secondary" lineClamp={1}>
-          {service.statusLabel}
-        </Text>
-      </VStack>
+          {isPending ? <Spinner size="xs" /> : <MdClose />}
+        </IconButton>
+      )}
     </Flex>
   );
 };

--- a/src/pages/dashboard/ui/section/DashboardSection.tsx
+++ b/src/pages/dashboard/ui/section/DashboardSection.tsx
@@ -111,8 +111,12 @@ export const DashboardSection = () => {
     isWorkflowsError,
     isServicesLoading,
     isServicesError,
+    isServiceActionPending,
+    pendingServiceKey,
     handleReloadWorkflows,
     handleReloadServices,
+    handleConnectService,
+    handleDisconnectService,
   } = useDashboardData();
   const {
     expandedIssueId,
@@ -203,7 +207,17 @@ export const DashboardSection = () => {
           connectedServices.length > 0 ? (
             <Flex wrap="wrap" gap={6}>
               {connectedServices.map((service) => (
-                <ServiceConnectionCard key={service.id} service={service} />
+                <ServiceConnectionCard
+                  key={service.id}
+                  service={service}
+                  isPending={
+                    isServiceActionPending &&
+                    pendingServiceKey === service.serviceKey
+                  }
+                  onAction={() =>
+                    void handleDisconnectService(service.serviceKey)
+                  }
+                />
               ))}
             </Flex>
           ) : (
@@ -223,7 +237,15 @@ export const DashboardSection = () => {
           recommendedServices.length > 0 ? (
             <Flex wrap="wrap" gap={6}>
               {recommendedServices.map((service) => (
-                <ServiceConnectionCard key={service.id} service={service} />
+                <ServiceConnectionCard
+                  key={service.id}
+                  service={service}
+                  isPending={
+                    isServiceActionPending &&
+                    pendingServiceKey === service.serviceKey
+                  }
+                  onAction={() => void handleConnectService(service.serviceKey)}
+                />
               ))}
             </Flex>
           ) : (

--- a/src/pages/workflows/model/workflow-list.ts
+++ b/src/pages/workflows/model/workflow-list.ts
@@ -92,6 +92,11 @@ export const getServiceBadgeKey = (
     }
   }
 
+  const typeBadgeKey = getServiceBadgeKeyFromService(node.type);
+  if (typeBadgeKey !== "unknown") {
+    return typeBadgeKey;
+  }
+
   switch (node.type) {
     case "calendar":
       return "calendar";

--- a/src/shared/constants/route-path.ts
+++ b/src/shared/constants/route-path.ts
@@ -4,6 +4,7 @@ export const ROUTE_PATHS = {
   DASHBOARD: "/dashboard",
   LOGIN: "/login",
   AUTH_CALLBACK: "/auth/callback",
+  OAUTH_CALLBACK: "/oauth/callback",
   ACCOUNT: "/account",
   SETTINGS: "/settings",
   TEMPLATES: "/templates",

--- a/src/shared/libs/index.ts
+++ b/src/shared/libs/index.ts
@@ -2,4 +2,5 @@ export * from "./auth-session";
 export * from "./auth-redirect";
 export * from "./dual-panel-layout";
 export * from "./graph";
+export * from "./oauth-connect-redirect";
 export * from "./query-client";

--- a/src/shared/libs/oauth-connect-redirect.ts
+++ b/src/shared/libs/oauth-connect-redirect.ts
@@ -1,0 +1,27 @@
+import { ROUTE_PATHS } from "@/shared/constants";
+
+const OAUTH_CONNECT_RETURN_PATH_KEY = "oauthConnectReturnPath";
+
+const normalizeReturnPath = (path: string | null) => {
+  if (!path || !path.startsWith("/")) {
+    return ROUTE_PATHS.ACCOUNT;
+  }
+
+  return path;
+};
+
+export const storeOAuthConnectReturnPath = (path: string) => {
+  sessionStorage.setItem(
+    OAUTH_CONNECT_RETURN_PATH_KEY,
+    normalizeReturnPath(path),
+  );
+};
+
+export const consumeOAuthConnectReturnPath = () => {
+  const storedPath = sessionStorage.getItem(OAUTH_CONNECT_RETURN_PATH_KEY);
+  sessionStorage.removeItem(OAUTH_CONNECT_RETURN_PATH_KEY);
+  return normalizeReturnPath(storedPath);
+};
+
+export const getCurrentRelativeUrl = () =>
+  `${window.location.pathname}${window.location.search}${window.location.hash}`;

--- a/src/shared/ui/ServiceBadge.tsx
+++ b/src/shared/ui/ServiceBadge.tsx
@@ -7,6 +7,7 @@ import {
   MdFolder,
   MdLanguage,
   MdNotifications,
+  MdSchool,
   MdSettings,
   MdTableChart,
 } from "react-icons/md";
@@ -21,6 +22,7 @@ type Props = {
 
 const FALLBACK_NODE_ICONS: Record<ServiceBadgeKey, IconType> = {
   calendar: MdCalendarMonth,
+  "canvas-lms": MdSchool,
   gmail: MdEmail,
   "google-drive": MdFolder,
   "google-sheets": MdTableChart,
@@ -60,6 +62,21 @@ export const ServiceBadge = ({ type }: Props) => {
               </Text>
             </Flex>
           </Box>
+        );
+      case "canvas-lms":
+        return (
+          <Flex
+            boxSize="30px"
+            align="center"
+            justify="center"
+            bg="blue.50"
+            borderRadius="lg"
+            border="1px solid"
+            borderColor="blue.100"
+            boxShadow="0 6px 12px rgba(59, 130, 246, 0.10)"
+          >
+            <Icon as={MdSchool} boxSize={4.5} color="blue.600" />
+          </Flex>
         );
       case "notion":
         return (

--- a/src/shared/utils/service-badge.ts
+++ b/src/shared/utils/service-badge.ts
@@ -1,5 +1,6 @@
 export type ServiceBadgeKey =
   | "calendar"
+  | "canvas-lms"
   | "gmail"
   | "google-drive"
   | "google-sheets"
@@ -23,6 +24,9 @@ export const getServiceBadgeKeyFromService = (
     case "google-calendar":
     case "google_calendar":
       return "calendar";
+    case "canvas-lms":
+    case "canvas_lms":
+      return "canvas-lms";
     case "gmail":
       return "gmail";
     case "google-drive":


### PR DESCRIPTION
## 📌 요약 (Summary)

Canvas LMS source를 FE source/sink editor 흐름에 실제로 연결하고, direct-connect OAuth / Google Drive sink 설정 / OAuth callback 복귀 / Dashboard 연결 액션까지 정리했습니다.

이번 PR로 `Canvas LMS -> Google Drive` 워크플로우를 FE에서 구성, 저장, 재인증, 실행까지 이어갈 수 있는 상태를 맞췄습니다.

## ✅ 주요 변경 사항 (Key Changes)

- Canvas LMS source rollout 및 direct-connect OAuth UX 반영
- Google Drive sink 상세 설정을 explicit 저장 버튼 기반으로 정리
- Dashboard에서 서비스 연결 시작 / 연결 해제 액션 추가

## 🔧 상세 구현 내용 (Implementation Details)

### 1. Canvas LMS source 연동
- `canvas_lms`를 source rollout에 추가하고, source picker에서 선택 가능하게 반영했습니다.
- `course_files`, `course_new_file`, `term_all_files` 모드를 backend catalog 기준으로 노출하도록 정리했습니다.
- `canvas_lms`는 새 OAuth redirect 페이지가 아니라 direct-connect 흐름으로 처리되도록 FE connect contract를 확장했습니다.

### 2. OAuth connect contract 정규화
- OAuth connect 응답을 `redirect | direct` 두 종류로 정규화했습니다.
- redirect 서비스와 direct-connect 서비스를 같은 UI 흐름 안에서 다룰 수 있도록 API/model 레이어를 정리했습니다.
- backend 지원 범위에 맞춰 connect support matrix를 정리했습니다.

### 3. Node mapping / restore / presentation 정합
- persisted service key `canvas_lms`를 FE visual carrier(`web-scraping`)에 매핑하되, restore 시 service identity가 유지되도록 보강했습니다.
- node title, badge, summary, dashboard/workflow list presentation에서도 `Canvas LMS`가 일관되게 보이도록 정리했습니다.
- `WebScrapingNodeConfig`를 service-backed source도 담을 수 있게 typed 확장했습니다.

### 4. Sink 상세 설정 UX 개선
- Sink 상세 설정이 blur/typing만으로 자동 반영되던 문제를 제거했습니다.
- `SinkNodePanel` 내부에 local draft state를 두고, `설정 저장` 버튼을 눌렀을 때만 workflow store에 반영되도록 변경했습니다.
- optional empty field는 `null`이 아니라 config에서 omit되도록 정리해 backend lifecycle 계산과 충돌하지 않게 했습니다.
- `config.isConfigured`는 로컬 UX 힌트로만 유지하고, authoritative lifecycle은 계속 `nodeStatuses`를 기준으로 보도록 정리했습니다.

### 5. Dashboard OAuth 액션 추가
- 기존 Dashboard의 connected/recommended service 카드가 display-only였던 구조를 개선했습니다.
- 연결된 서비스는 `X` 버튼으로 바로 disconnect 가능하게 했습니다.
- 추천 서비스는 카드 클릭 시 바로 connect flow를 시작하도록 변경했습니다.
- direct-connect 서비스(`canvas_lms`, `notion`)와 redirect 서비스(`google_drive`, `slack`)를 각각 올바른 방식으로 처리합니다.

### 6. OAuth callback 복귀 흐름 정리
- OAuth 완료 후 FE가 404로 떨어지지 않도록 `/oauth/callback` 라우트를 추가했습니다.
- OAuth 시작 전 현재 화면 경로를 저장하고, callback 처리 후 원래 화면으로 복귀하도록 보강했습니다.
- Account / service picker / dashboard에서 시작한 OAuth flow가 모두 동일한 복귀 흐름을 따르도록 정리했습니다.

## 🧩 트러블 슈팅 (Trouble Shooting)

- **Sink 상세 설정 자동 저장 문제**
  - 입력창 blur 또는 타이핑 중 store가 즉시 갱신되면서 sink가 너무 빨리 완료 상태로 전환되는 문제가 있었습니다.
  - panel local draft state + explicit `설정 저장` 버튼 구조로 바꿔 해결했습니다.

- **Google Drive 재인증/재설정 동선 부재**
  - Dashboard에서 연결된 서비스 해제나 추천 서비스 연결 시작이 불가능해서 재인증이 막혔습니다.
  - Dashboard 카드에 disconnect/connect 액션을 추가해 해결했습니다.

- **OAuth callback 이후 404 문제**
  - backend callback 이후 FE가 처리하지 않는 경로로 떨어져 인증은 되었지만 화면이 404가 되는 문제가 있었습니다.
  - `/oauth/callback` 라우트와 복귀 경로 저장/복원 로직을 추가해 해결했습니다.

- **Google Drive sink 실행 실패 오해**
  - FE/BE 연동 구조 문제처럼 보였지만, 실제 원인은 `folder_id`에 폴더 이름이 아니라 Google Drive 폴더 ID를 넣어야 한다는 점이었습니다.
  - 실제 folder ID 기준으로 재검증 후 `Canvas LMS -> Google Drive` 실행 흐름을 확인했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- Google Drive sink의 `folder_id`는 **폴더 이름이 아니라 실제 Google Drive folder ID**를 입력해야 합니다.
- 현재 범위에서는 `Canvas LMS -> Google Drive` 최소 경로를 우선 검증했습니다.
- 과목별 하위 폴더 자동 생성/분류는 아직 지원하지 않습니다.
- 문서에 등장하는 `PASSTHROUGH`는 현재 별도 no-op 런타임 전략이 아니라, 후속 확장 논의 대상입니다.
- runtime의 실제 파일 처리 semantics(예: metadata fallback 등)는 backend 구현 범위에 따르며, 본 PR은 FE 연동/구성/실행 흐름 정렬에 집중합니다.

## 📷 스크린샷 (Screenshots)

- Canvas LMS source picker / direct-connect flow
- Google Drive sink 상세 설정 (`설정 저장` 버튼 포함)
- Dashboard service connect / disconnect 액션
- OAuth callback 후 원래 화면 복귀
- `Canvas LMS -> Google Drive` workflow 구성/실행 화면

## #️⃣ 관련 이슈 (Related Issues)

- #108
