### PR TITLE
[PR] workflow list 응답 shape mismatch 대응 및 목록/대시보드 로딩 복구

### DIFF
--- a/src/entities/workflow/api/get-workflow-list.api.ts
+++ b/src/entities/workflow/api/get-workflow-list.api.ts
@@ -1,12 +1,12 @@
 import { request } from "@/shared/api/core";
 
-import { type WorkflowListResponse } from "./types";
+import { type RawWorkflowListResponse } from "./types";
 
 export const getWorkflowListAPI = (
   page = 0,
   size = 20,
-): Promise<WorkflowListResponse> =>
-  request<WorkflowListResponse>({
+): Promise<RawWorkflowListResponse> =>
+  request<RawWorkflowListResponse>({
     url: "/workflows",
     method: "GET",
     params: { page, size },

--- a/src/entities/workflow/api/types.ts
+++ b/src/entities/workflow/api/types.ts
@@ -175,6 +175,8 @@ export interface WorkflowResponse extends Omit<Workflow, "nodes" | "edges"> {
   nodeStatuses?: WorkflowNodeStatusResponse[];
 }
 
+export type RawWorkflowListResponse = WorkflowListResponse | WorkflowResponse[];
+
 export interface WorkflowNodeStatusResponse {
   nodeId: string;
   configured: boolean;

--- a/src/entities/workflow/model/index.ts
+++ b/src/entities/workflow/model/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./query-keys";
+export * from "./normalize-workflow-list-response";
 export * from "./useAddWorkflowNodeMutation";
 export * from "./useCreateWorkflowMutation";
 export * from "./useDeleteWorkflowMutation";

--- a/src/entities/workflow/model/normalize-workflow-list-response.ts
+++ b/src/entities/workflow/model/normalize-workflow-list-response.ts
@@ -1,0 +1,87 @@
+import { type PageResponse } from "@/shared";
+
+import {
+  type RawWorkflowListResponse,
+  type WorkflowListResponse,
+  type WorkflowResponse,
+} from "../api";
+
+const isWorkflowRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isWorkflowResponse = (value: unknown): value is WorkflowResponse =>
+  isWorkflowRecord(value) && typeof value.id === "string";
+
+const isWorkflowResponseArray = (
+  value: RawWorkflowListResponse,
+): value is WorkflowResponse[] =>
+  Array.isArray(value) && value.every(isWorkflowResponse);
+
+const isWorkflowListPageResponse = (
+  value: RawWorkflowListResponse,
+): value is WorkflowListResponse => {
+  if (!isWorkflowRecord(value)) {
+    return false;
+  }
+
+  return (
+    Array.isArray(value.content) &&
+    typeof value.page === "number" &&
+    typeof value.size === "number" &&
+    typeof value.totalElements === "number" &&
+    typeof value.totalPages === "number"
+  );
+};
+
+const toWorkflowListPageResponse = (
+  content: WorkflowResponse[],
+  page: number,
+  size: number,
+  totalElements: number,
+): WorkflowListResponse => ({
+  content,
+  page,
+  size,
+  totalElements,
+  totalPages: totalElements === 0 ? 0 : Math.ceil(totalElements / size),
+});
+
+const getWorkflowPageSlice = (
+  workflows: WorkflowResponse[],
+  page: number,
+  size: number,
+) => {
+  const startIndex = page * size;
+  const endIndex = startIndex + size;
+  return workflows.slice(startIndex, endIndex);
+};
+
+export const createEmptyWorkflowListResponse = (
+  page = 0,
+  size = 20,
+): WorkflowListResponse => toWorkflowListPageResponse([], page, size, 0);
+
+export const normalizeWorkflowListResponse = (
+  response: RawWorkflowListResponse,
+  page = 0,
+  size = 20,
+): WorkflowListResponse => {
+  if (isWorkflowListPageResponse(response)) {
+    return response;
+  }
+
+  if (isWorkflowResponseArray(response)) {
+    return toWorkflowListPageResponse(
+      getWorkflowPageSlice(response, page, size),
+      page,
+      size,
+      response.length,
+    );
+  }
+
+  return createEmptyWorkflowListResponse(page, size);
+};
+
+export const getWorkflowListContent = (
+  response: PageResponse<WorkflowResponse> | null | undefined,
+) => response?.content ?? [];

--- a/src/entities/workflow/model/useInfiniteWorkflowListQuery.ts
+++ b/src/entities/workflow/model/useInfiniteWorkflowListQuery.ts
@@ -8,6 +8,7 @@ import {
 
 import { type WorkflowListResponse, workflowApi } from "../api";
 
+import { normalizeWorkflowListResponse } from "./normalize-workflow-list-response";
 import { workflowKeys } from "./query-keys";
 
 export const useInfiniteWorkflowListQuery = (
@@ -18,7 +19,12 @@ export const useInfiniteWorkflowListQuery = (
 
   return useInfiniteQuery({
     queryKey: workflowKeys.infiniteList(size),
-    queryFn: ({ pageParam }) => workflowApi.getList(pageParam, size),
+    queryFn: async ({ pageParam }) =>
+      normalizeWorkflowListResponse(
+        await workflowApi.getList(pageParam, size),
+        pageParam,
+        size,
+      ),
     enabled: options?.enabled ?? true,
     initialPageParam: 0,
     getNextPageParam: (lastPage: WorkflowListResponse) => {
@@ -32,4 +38,3 @@ export const useInfiniteWorkflowListQuery = (
     throwOnError: false,
   });
 };
-

--- a/src/entities/workflow/model/useWorkflowListQuery.ts
+++ b/src/entities/workflow/model/useWorkflowListQuery.ts
@@ -6,22 +6,26 @@ import {
   toQueryMeta,
 } from "@/shared/api";
 
-import { workflowApi } from "../api";
+import { type WorkflowListResponse, workflowApi } from "../api";
 
+import { normalizeWorkflowListResponse } from "./normalize-workflow-list-response";
 import { workflowKeys } from "./query-keys";
 
 export const useWorkflowListQuery = (
   page = 0,
   size = 20,
-  enabledOrOptions?:
-    | boolean
-    | QueryPolicyOptions<Awaited<ReturnType<typeof workflowApi.getList>>>,
+  enabledOrOptions?: boolean | QueryPolicyOptions<WorkflowListResponse>,
 ) => {
   const options = resolveQueryPolicyOptions(enabledOrOptions);
 
   return useQuery({
     queryKey: workflowKeys.list({ page, size }),
-    queryFn: () => workflowApi.getList(page, size),
+    queryFn: async () =>
+      normalizeWorkflowListResponse(
+        await workflowApi.getList(page, size),
+        page,
+        size,
+      ),
     enabled: options?.enabled ?? true,
     select: options?.select,
     retry: options?.retry,
@@ -32,4 +36,3 @@ export const useWorkflowListQuery = (
     throwOnError: false,
   });
 };
-

--- a/src/entities/workflow/model/workflow-cache-utils.ts
+++ b/src/entities/workflow/model/workflow-cache-utils.ts
@@ -1,9 +1,12 @@
+import { type InfiniteData } from "@tanstack/react-query";
+
 import { executionKeys } from "@/shared/constants";
 import { queryClient } from "@/shared/libs";
 
 import {
   type ChoiceResponse,
   type NodeSelectionResult,
+  type WorkflowListResponse,
   type WorkflowResponse,
   workflowApi,
 } from "../api";
@@ -20,6 +23,128 @@ export const invalidateWorkflowLists = async () => {
   await queryClient.invalidateQueries({
     queryKey: workflowKeys.lists(),
   });
+};
+
+type WorkflowInfiniteListResponse = InfiniteData<WorkflowListResponse, number>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isWorkflowListResponse = (
+  value: unknown,
+): value is WorkflowListResponse => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    Array.isArray(value.content) &&
+    typeof value.page === "number" &&
+    typeof value.size === "number" &&
+    typeof value.totalElements === "number" &&
+    typeof value.totalPages === "number"
+  );
+};
+
+const isWorkflowInfiniteListResponse = (
+  value: unknown,
+): value is WorkflowInfiniteListResponse => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    Array.isArray(value.pages) &&
+    Array.isArray(value.pageParams) &&
+    value.pages.every(isWorkflowListResponse)
+  );
+};
+
+const toTotalPages = (totalElements: number, size: number) => {
+  if (totalElements === 0) {
+    return 0;
+  }
+
+  return Math.ceil(totalElements / Math.max(size, 1));
+};
+
+const removeWorkflowFromListPage = (
+  page: WorkflowListResponse,
+  workflowId: string,
+): WorkflowListResponse => {
+  const nextContent = page.content.filter(
+    (workflow) => workflow.id !== workflowId,
+  );
+  const totalElements = Math.max(page.totalElements - 1, 0);
+
+  return {
+    ...page,
+    content:
+      nextContent.length === page.content.length ? page.content : nextContent,
+    totalElements,
+    totalPages: toTotalPages(totalElements, page.size),
+  };
+};
+
+const removeWorkflowFromInfiniteList = (
+  data: WorkflowInfiniteListResponse,
+  workflowId: string,
+): WorkflowInfiniteListResponse => {
+  const currentTotalElements = data.pages[0]?.totalElements ?? 0;
+  const totalElements = Math.max(currentTotalElements - 1, 0);
+  const flattenedWorkflows = data.pages.flatMap((page) => page.content);
+  const nextWorkflows = flattenedWorkflows.filter(
+    (workflow) => workflow.id !== workflowId,
+  );
+
+  if (nextWorkflows.length === flattenedWorkflows.length) {
+    return {
+      ...data,
+      pages: data.pages.map((page) => ({
+        ...page,
+        totalElements,
+        totalPages: toTotalPages(totalElements, page.size),
+      })),
+    };
+  }
+
+  const pages = data.pages
+    .map((page, index) => {
+      const startIndex = index * page.size;
+      const content = nextWorkflows.slice(startIndex, startIndex + page.size);
+
+      return {
+        ...page,
+        content,
+        totalElements,
+        totalPages: toTotalPages(totalElements, page.size),
+      };
+    })
+    .filter((page, index) => index === 0 || page.content.length > 0);
+
+  return {
+    ...data,
+    pages,
+  };
+};
+
+export const pruneWorkflowListCaches = (workflowId: string) => {
+  queryClient.setQueriesData(
+    {
+      queryKey: workflowKeys.lists(),
+    },
+    (currentData: unknown) => {
+      if (isWorkflowInfiniteListResponse(currentData)) {
+        return removeWorkflowFromInfiniteList(currentData, workflowId);
+      }
+
+      if (isWorkflowListResponse(currentData)) {
+        return removeWorkflowFromListPage(currentData, workflowId);
+      }
+
+      return currentData;
+    },
+  );
 };
 
 export const syncWorkflowCache = async (workflow: WorkflowResponse) => {

--- a/src/entities/workflow/model/workflow-cache-utils.ts
+++ b/src/entities/workflow/model/workflow-cache-utils.ts
@@ -180,6 +180,7 @@ export const removeWorkflowDomainCache = async (workflowId: string) => {
   queryClient.removeQueries({
     queryKey: executionKeys.workflow(workflowId),
   });
+  pruneWorkflowListCaches(workflowId);
   await invalidateWorkflowLists();
 };
 

--- a/src/pages/dashboard/model/useDashboardData.ts
+++ b/src/pages/dashboard/model/useDashboardData.ts
@@ -6,7 +6,10 @@ import {
   useDisconnectOAuthTokenMutation,
   useOAuthTokensQuery,
 } from "@/entities/oauth-token";
-import { useWorkflowListQuery } from "@/entities/workflow";
+import {
+  getWorkflowListContent,
+  useWorkflowListQuery,
+} from "@/entities/workflow";
 import { getCurrentRelativeUrl, storeOAuthConnectReturnPath } from "@/shared";
 
 import {
@@ -31,7 +34,8 @@ export const useDashboardData = () => {
   );
 
   const workflows = useMemo(
-    () => sortWorkflowsByUpdatedAtDesc(workflowQuery.data?.content ?? []),
+    () =>
+      sortWorkflowsByUpdatedAtDesc(getWorkflowListContent(workflowQuery.data)),
     [workflowQuery.data],
   );
 

--- a/src/pages/workflows/model/workflow-list.ts
+++ b/src/pages/workflows/model/workflow-list.ts
@@ -1,5 +1,6 @@
 import {
   type NodeDefinitionResponse,
+  type WorkflowListResponse,
   type WorkflowResponse,
 } from "@/entities/workflow";
 import {
@@ -10,21 +11,9 @@ import {
 
 import { type ServiceBadgeKey, type WorkflowFilterKey } from "./types";
 
-const isWorkflowRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
-
-export const isWorkflowListItem = (value: unknown): value is WorkflowResponse =>
-  isWorkflowRecord(value) && typeof value.id === "string";
-
 export const getWorkflowListPageContent = (page: {
-  content?: unknown;
-}): WorkflowResponse[] => {
-  if (!Array.isArray(page.content)) {
-    return [];
-  }
-
-  return page.content.filter(isWorkflowListItem);
-};
+  content?: WorkflowListResponse["content"];
+}): WorkflowResponse[] => page.content ?? [];
 
 export const sortWorkflowsByUpdatedAtDesc = (workflows: WorkflowResponse[]) =>
   [...workflows].sort(


### PR DESCRIPTION
## 📌 요약 (Summary)

backend `/workflows` 목록 응답이 배열로 내려오는 현재 계약에 맞춰 FE 목록 로딩 로직을 정리하고, 삭제 후에도 워크플로우 리스트/대시보드에 stale 항목이 남는 문제를 함께 수정했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- workflow list 응답을 FE entity 계층에서 정규화하도록 adapter 추가
- workflow list / dashboard가 normalized workflow 목록만 소비하도록 정리
- workflow 삭제 후 list / infinite list cache에서 항목을 즉시 제거하도록 수정

## 🔧 상세 구현 내용 (Implementation Details)

### 1. Workflow list 응답 정규화
- `entities/workflow/model`에 workflow list response normalizer를 추가했습니다.
- backend가 `WorkflowResponse[]`를 반환해도 FE 내부에서는 `PageResponse<WorkflowResponse>`처럼 다룰 수 있도록 변환합니다.
- 이후 `pages/*`는 raw response shape를 몰라도 되도록 정리했습니다.

### 2. Workflow list query 계층 정리
- `useWorkflowListQuery`, `useInfiniteWorkflowListQuery`가 raw backend 응답을 직접 노출하지 않도록 변경했습니다.
- query 단계에서 normalize를 적용해 consumer는 항상 정규화된 response를 받도록 했습니다.

### 3. Workflow list / Dashboard 소비 로직 복구
- workflow list 페이지의 목록 파싱 로직을 정규화 응답 기준으로 단순화했습니다.
- dashboard의 최근 workflow 목록도 같은 normalized contract를 사용하도록 맞췄습니다.
- 결과적으로 저장된 workflow가 list / dashboard에서 다시 정상적으로 노출됩니다.

### 4. 삭제 후 stale 목록 문제 수정
- 기존에는 workflow 삭제 후 detail/choice/execution cache만 제거하고, list cache는 invalidate만 하고 있었습니다.
- 전역 query 기본 설정이 `refetchOnMount: false`인 상태라, 삭제 후 리스트 화면 재진입 시 stale cache가 그대로 보일 수 있었습니다.
- `workflow-cache-utils.ts`에 finite list / infinite list cache pruning helper를 추가해, 삭제 성공 시 해당 workflow를 list cache에서 즉시 제거하도록 수정했습니다.
- 이후 background invalidation은 그대로 유지해 서버 상태와 재동기화합니다.

## 🧩 트러블 슈팅 (Trouble Shooting)

- **워크플로우 리스트가 비어 보이는 문제**
  - 처음에는 저장 로직 문제도 의심했지만, 실제로는 FE가 `PageResponse`를 기대하고 backend는 `List<WorkflowResponse>`를 반환하는 shape mismatch가 원인이었습니다.
  - 페이지/대시보드에서 개별적으로 예외 처리하지 않고, `entities/workflow` 경계에서 normalize하도록 정리했습니다.

- **삭제 후 리스트에 workflow가 계속 남는 문제**
  - 삭제 mutation은 성공했지만, list cache는 stale 처리만 되고 재진입 시 refetch가 발생하지 않아 기존 캐시가 그대로 렌더되고 있었습니다.
  - 전역 React Query 설정은 건드리지 않고, workflow 도메인 cache util에서 직접 cache pruning하도록 수정했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 이번 PR은 FE가 현재 backend `/workflows` 배열 응답 계약을 수용하도록 정리한 작업입니다.
- backend가 이후 다시 실제 페이지네이션 응답으로 변경되더라도, FE는 entity adapter 경계에서 대응할 수 있는 구조로 맞췄습니다.
- docker compose 관련 로컬 파일은 이번 PR 범위에 포함하지 않습니다.

## 📷 스크린샷 (Screenshots)

- 워크플로우 저장 후 리스트 페이지 정상 노출
- 대시보드 최근 workflow 목록 정상 노출
- workflow 삭제 후 리스트/대시보드에서 즉시 제거 확인

## #️⃣ 관련 이슈 (Related Issues)

- #110
