### PR TITLE
[PR] 템플릿 상세 페이지를 시각 프리뷰 중심 레이아웃으로 개편

### DIFF
--- a/src/pages/template-detail/TemplateDetailPage.tsx
+++ b/src/pages/template-detail/TemplateDetailPage.tsx
@@ -1,28 +1,15 @@
 import { useNavigate, useParams } from "react-router";
 
-import {
-  Box,
-  Button,
-  HStack,
-  Heading,
-  Spinner,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
+
+import { useInstantiateTemplateMutation, useTemplateQuery } from "@/entities";
+import { ROUTE_PATHS, buildPath } from "@/shared";
 
 import {
-  useInstantiateTemplateMutation,
-  useTemplateQuery,
-} from "@/entities";
-import {
-  ROUTE_PATHS,
-  buildPath,
-} from "@/shared";
-
-const getTemplateDescription = (description: string) =>
-  description?.trim().length > 0
-    ? description
-    : "설명이 아직 없는 템플릿입니다.";
+  TemplateInfoPanel,
+  TemplatePreviewLayout,
+  TemplateWorkflowPreview,
+} from "./ui";
 
 export default function TemplateDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -40,7 +27,7 @@ export default function TemplateDetailPage() {
       const workflow = await instantiateTemplate(id);
       navigate(buildPath.workflowEditor(workflow.id));
     } catch {
-      // 에러 상태는 화면 상단 안내로 충분하다.
+      return;
     }
   };
 
@@ -73,125 +60,16 @@ export default function TemplateDetailPage() {
   }
 
   return (
-    <Box maxW="960px" mx="auto">
-      <VStack align="stretch" gap={6}>
-        <Box
-          p={{ base: 6, md: 8 }}
-          bg="white"
-          border="1px solid"
-          borderColor="gray.200"
-          borderRadius="28px"
-          boxShadow="0 10px 30px rgba(15, 23, 42, 0.04)"
-        >
-          <Text fontSize="sm" fontWeight="semibold" color="gray.500" mb={2}>
-            TEMPLATE DETAIL
-          </Text>
-          <Heading size="xl" mb={3}>
-            {template.name}
-          </Heading>
-          <Text color="gray.600" mb={8}>
-            {getTemplateDescription(template.description)}
-          </Text>
-
-          <HStack gap={3} wrap="wrap" mb={6}>
-            <Text fontSize="sm" color="gray.500">
-              카테고리 {template.category ?? "미분류"}
-            </Text>
-            <Text fontSize="sm" color="gray.500">
-              노드 {template.nodes.length}개
-            </Text>
-            <Text fontSize="sm" color="gray.500">
-              엣지 {template.edges.length}개
-            </Text>
-            <Text fontSize="sm" color="gray.500">
-              사용 {template.useCount}회
-            </Text>
-          </HStack>
-
-          <HStack gap={3}>
-            <Button
-              onClick={() => void handleInstantiate()}
-              disabled={isPending}
-            >
-              {isPending ? "생성 중..." : "템플릿으로 시작"}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => navigate(ROUTE_PATHS.TEMPLATES)}
-            >
-              목록으로
-            </Button>
-          </HStack>
-        </Box>
-
-        <Box
-          p={{ base: 6, md: 8 }}
-          bg="white"
-          border="1px solid"
-          borderColor="gray.200"
-          borderRadius="28px"
-          boxShadow="0 10px 30px rgba(15, 23, 42, 0.04)"
-        >
-          <Heading size="md" mb={4}>
-            필요 서비스
-          </Heading>
-          {template.requiredServices.length === 0 ? (
-            <Text color="gray.600">
-              연결이 필요한 외부 서비스가 아직 표시되지 않았습니다.
-            </Text>
-          ) : (
-            <HStack gap={3} wrap="wrap">
-              {template.requiredServices.map((service) => (
-                <Box
-                  key={service}
-                  px={4}
-                  py={2}
-                  bg="gray.50"
-                  borderRadius="full"
-                  border="1px solid"
-                  borderColor="gray.200"
-                >
-                  <Text fontSize="sm" fontWeight="medium">
-                    {service}
-                  </Text>
-                </Box>
-              ))}
-            </HStack>
-          )}
-        </Box>
-
-        <Box
-          p={{ base: 6, md: 8 }}
-          bg="white"
-          border="1px solid"
-          borderColor="gray.200"
-          borderRadius="28px"
-          boxShadow="0 10px 30px rgba(15, 23, 42, 0.04)"
-        >
-          <Heading size="md" mb={4}>
-            구성 요약
-          </Heading>
-          <VStack align="stretch" gap={3}>
-            {template.nodes.map((node) => (
-              <Box
-                key={node.id}
-                display="flex"
-                justifyContent="space-between"
-                gap={4}
-                px={4}
-                py={3}
-                borderRadius="16px"
-                bg="gray.50"
-              >
-                <Text fontWeight="medium">{node.label ?? node.type}</Text>
-                <Text fontSize="sm" color="gray.500">
-                  {node.category ?? "unknown"} / {node.type}
-                </Text>
-              </Box>
-            ))}
-          </VStack>
-        </Box>
-      </VStack>
-    </Box>
+    <TemplatePreviewLayout
+      sidebar={
+        <TemplateInfoPanel
+          template={template}
+          isPending={isPending}
+          onInstantiate={() => void handleInstantiate()}
+          onBack={() => navigate(ROUTE_PATHS.TEMPLATES)}
+        />
+      }
+      preview={<TemplateWorkflowPreview />}
+    />
   );
 }

--- a/src/pages/template-detail/TemplateDetailPage.tsx
+++ b/src/pages/template-detail/TemplateDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router";
 
 import { Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
@@ -5,6 +6,7 @@ import { Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
 import { useInstantiateTemplateMutation, useTemplateQuery } from "@/entities";
 import { ROUTE_PATHS, buildPath } from "@/shared";
 
+import { buildTemplatePreviewGraph } from "./model";
 import {
   TemplateInfoPanel,
   TemplatePreviewLayout,
@@ -17,6 +19,10 @@ export default function TemplateDetailPage() {
   const { data: template, isLoading, isError, refetch } = useTemplateQuery(id);
   const { mutateAsync: instantiateTemplate, isPending } =
     useInstantiateTemplateMutation();
+  const previewGraph = useMemo(
+    () => (template ? buildTemplatePreviewGraph(template) : null),
+    [template],
+  );
 
   const handleInstantiate = async () => {
     if (!id) {
@@ -69,7 +75,7 @@ export default function TemplateDetailPage() {
           onBack={() => navigate(ROUTE_PATHS.TEMPLATES)}
         />
       }
-      preview={<TemplateWorkflowPreview />}
+      preview={<TemplateWorkflowPreview graph={previewGraph} />}
     />
   );
 }

--- a/src/pages/template-detail/model/index.ts
+++ b/src/pages/template-detail/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./template-detail";

--- a/src/pages/template-detail/model/template-detail.ts
+++ b/src/pages/template-detail/model/template-detail.ts
@@ -1,0 +1,57 @@
+import { type TemplateDetail } from "@/entities/template";
+
+type TemplateMetaItem = {
+  label: string;
+  value: string;
+};
+
+const formatCreatedAt = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+};
+
+export const getTemplateDescription = (description: string) =>
+  description?.trim().length > 0
+    ? description
+    : "설명이 아직 없는 템플릿입니다.";
+
+export const getTemplatePreviewSummary = (template: TemplateDetail) => {
+  if (template.description?.trim().length) {
+    return template.description.trim();
+  }
+
+  return "템플릿의 핵심 흐름과 연결에 필요한 서비스를 한눈에 확인할 수 있습니다.";
+};
+
+export const getTemplateMetaItems = (
+  template: TemplateDetail,
+): TemplateMetaItem[] => [
+  {
+    label: "카테고리",
+    value: template.category ?? "미분류",
+  },
+  {
+    label: "노드",
+    value: `${template.nodes.length}개`,
+  },
+  {
+    label: "연결",
+    value: `${template.edges.length}개`,
+  },
+  {
+    label: "사용",
+    value: `${template.useCount}회`,
+  },
+  {
+    label: "생성일",
+    value: formatCreatedAt(template.createdAt),
+  },
+];

--- a/src/pages/template-detail/model/template-detail.ts
+++ b/src/pages/template-detail/model/template-detail.ts
@@ -1,8 +1,19 @@
+import { type Edge, type Node } from "@xyflow/react";
+
+import { type FlowNodeData } from "@/entities/node";
 import { type TemplateDetail } from "@/entities/template";
+import { toFlowEdge, toFlowNode } from "@/entities/workflow";
 
 type TemplateMetaItem = {
   label: string;
   value: string;
+};
+
+export type TemplatePreviewGraph = {
+  edges: Edge[];
+  endNodeId: string | null;
+  nodes: Node<FlowNodeData>[];
+  startNodeId: string | null;
 };
 
 const formatCreatedAt = (value: string) => {
@@ -55,3 +66,21 @@ export const getTemplateMetaItems = (
     value: formatCreatedAt(template.createdAt),
   },
 ];
+
+export const buildTemplatePreviewGraph = (
+  template: TemplateDetail,
+): TemplatePreviewGraph => {
+  const nodes = template.nodes.map(toFlowNode);
+  const edges = template.edges.map(toFlowEdge);
+  const startNodeId =
+    template.nodes.find((node) => node.role === "start")?.id ?? null;
+  const endNodeId =
+    template.nodes.find((node) => node.role === "end")?.id ?? null;
+
+  return {
+    nodes,
+    edges,
+    startNodeId,
+    endNodeId,
+  };
+};

--- a/src/pages/template-detail/ui/TemplateInfoPanel.tsx
+++ b/src/pages/template-detail/ui/TemplateInfoPanel.tsx
@@ -1,0 +1,69 @@
+import { Box, Button, Heading, Text, VStack } from "@chakra-ui/react";
+
+import { type TemplateDetail } from "@/entities/template";
+import { TemplateServiceIcon } from "@/pages/templates/ui";
+
+type Props = {
+  template: TemplateDetail;
+  isPending: boolean;
+  onInstantiate: () => void;
+  onBack: () => void;
+};
+
+const getTemplateDescription = (description: string) =>
+  description?.trim().length > 0
+    ? description
+    : "설명이 아직 없는 템플릿입니다.";
+
+export const TemplateInfoPanel = ({
+  template,
+  isPending,
+  onInstantiate,
+  onBack,
+}: Props) => (
+  <Box
+    bg="bg.surface"
+    border="1px solid"
+    borderColor="border.default"
+    borderRadius="40px"
+    boxShadow="0 10px 30px rgba(15, 23, 42, 0.05)"
+    minH={{ base: "auto", lg: "calc(100vh - 128px)" }}
+    px={{ base: 6, lg: 10 }}
+    py={{ base: 6, lg: 10 }}
+  >
+    <VStack align="stretch" h="full" gap={8}>
+      <VStack align="stretch" gap={4}>
+        <TemplateServiceIcon
+          icon={template.icon}
+          requiredServices={template.requiredServices}
+        />
+        <VStack align="stretch" gap={2}>
+          <Heading size="xl" color="text.primary">
+            {template.name}
+          </Heading>
+          <Text fontSize="sm" color="text.secondary">
+            {getTemplateDescription(template.description)}
+          </Text>
+        </VStack>
+      </VStack>
+
+      <VStack align="stretch" gap={2}>
+        <Text fontSize="sm" fontWeight="semibold" color="text.primary">
+          템플릿 미리보기
+        </Text>
+        <Text fontSize="sm" color="text.secondary">
+          템플릿의 전체 구성과 흐름을 오른쪽 프리뷰에서 확인할 수 있습니다.
+        </Text>
+      </VStack>
+
+      <VStack align="stretch" mt="auto" gap={3}>
+        <Button onClick={onInstantiate} disabled={isPending} size="md">
+          {isPending ? "가져오는 중..." : "가져오기"}
+        </Button>
+        <Button variant="outline" onClick={onBack} size="md">
+          목록으로
+        </Button>
+      </VStack>
+    </VStack>
+  </Box>
+);

--- a/src/pages/template-detail/ui/TemplateInfoPanel.tsx
+++ b/src/pages/template-detail/ui/TemplateInfoPanel.tsx
@@ -3,6 +3,15 @@ import { Box, Button, Heading, Text, VStack } from "@chakra-ui/react";
 import { type TemplateDetail } from "@/entities/template";
 import { TemplateServiceIcon } from "@/pages/templates/ui";
 
+import {
+  getTemplateDescription,
+  getTemplateMetaItems,
+  getTemplatePreviewSummary,
+} from "../model";
+
+import { TemplateMetaSection } from "./TemplateMetaSection";
+import { TemplateRequiredServices } from "./TemplateRequiredServices";
+
 type Props = {
   template: TemplateDetail;
   isPending: boolean;
@@ -10,60 +19,73 @@ type Props = {
   onBack: () => void;
 };
 
-const getTemplateDescription = (description: string) =>
-  description?.trim().length > 0
-    ? description
-    : "설명이 아직 없는 템플릿입니다.";
-
 export const TemplateInfoPanel = ({
   template,
   isPending,
   onInstantiate,
   onBack,
-}: Props) => (
-  <Box
-    bg="bg.surface"
-    border="1px solid"
-    borderColor="border.default"
-    borderRadius="40px"
-    boxShadow="0 10px 30px rgba(15, 23, 42, 0.05)"
-    minH={{ base: "auto", lg: "calc(100vh - 128px)" }}
-    px={{ base: 6, lg: 10 }}
-    py={{ base: 6, lg: 10 }}
-  >
-    <VStack align="stretch" h="full" gap={8}>
-      <VStack align="stretch" gap={4}>
-        <TemplateServiceIcon
-          icon={template.icon}
-          requiredServices={template.requiredServices}
-        />
+}: Props) => {
+  const metaItems = getTemplateMetaItems(template);
+
+  return (
+    <Box
+      bg="bg.surface"
+      border="1px solid"
+      borderColor="border.default"
+      borderRadius="40px"
+      boxShadow="0 10px 30px rgba(15, 23, 42, 0.05)"
+      minH={{ base: "auto", lg: "calc(100vh - 128px)" }}
+      px={{ base: 6, lg: 10 }}
+      py={{ base: 6, lg: 10 }}
+    >
+      <VStack align="stretch" h="full" gap={8}>
+        <VStack align="stretch" gap={4}>
+          <TemplateServiceIcon
+            icon={template.icon}
+            requiredServices={template.requiredServices}
+          />
+          <VStack align="stretch" gap={2}>
+            <Heading size="xl" color="text.primary">
+              {template.name}
+            </Heading>
+            <Text fontSize="sm" color="text.secondary">
+              {getTemplateDescription(template.description)}
+            </Text>
+          </VStack>
+        </VStack>
+
         <VStack align="stretch" gap={2}>
-          <Heading size="xl" color="text.primary">
-            {template.name}
-          </Heading>
+          <Text fontSize="sm" fontWeight="semibold" color="text.primary">
+            뭘 하나요?
+          </Text>
           <Text fontSize="sm" color="text.secondary">
-            {getTemplateDescription(template.description)}
+            {getTemplatePreviewSummary(template)}
           </Text>
         </VStack>
-      </VStack>
 
-      <VStack align="stretch" gap={2}>
-        <Text fontSize="sm" fontWeight="semibold" color="text.primary">
-          템플릿 미리보기
-        </Text>
-        <Text fontSize="sm" color="text.secondary">
-          템플릿의 전체 구성과 흐름을 오른쪽 프리뷰에서 확인할 수 있습니다.
-        </Text>
-      </VStack>
+        <VStack align="stretch" gap={3}>
+          <Text fontSize="sm" fontWeight="semibold" color="text.primary">
+            템플릿 정보
+          </Text>
+          <TemplateMetaSection items={metaItems} />
+        </VStack>
 
-      <VStack align="stretch" mt="auto" gap={3}>
-        <Button onClick={onInstantiate} disabled={isPending} size="md">
-          {isPending ? "가져오는 중..." : "가져오기"}
-        </Button>
-        <Button variant="outline" onClick={onBack} size="md">
-          목록으로
-        </Button>
+        <VStack align="stretch" gap={3}>
+          <Text fontSize="sm" fontWeight="semibold" color="text.primary">
+            필요 서비스
+          </Text>
+          <TemplateRequiredServices services={template.requiredServices} />
+        </VStack>
+
+        <VStack align="stretch" mt="auto" gap={3}>
+          <Button onClick={onInstantiate} disabled={isPending} size="md">
+            {isPending ? "가져오는 중..." : "가져오기"}
+          </Button>
+          <Button variant="outline" onClick={onBack} size="md">
+            목록으로
+          </Button>
+        </VStack>
       </VStack>
-    </VStack>
-  </Box>
-);
+    </Box>
+  );
+};

--- a/src/pages/template-detail/ui/TemplateMetaSection.tsx
+++ b/src/pages/template-detail/ui/TemplateMetaSection.tsx
@@ -1,0 +1,38 @@
+import { Grid, GridItem, Text, VStack } from "@chakra-ui/react";
+
+type MetaItem = {
+  label: string;
+  value: string;
+};
+
+type Props = {
+  items: MetaItem[];
+};
+
+export const TemplateMetaSection = ({ items }: Props) => (
+  <Grid
+    templateColumns={{ base: "repeat(2, minmax(0, 1fr))", xl: "1fr" }}
+    gap={3}
+  >
+    {items.map((item) => (
+      <GridItem
+        key={item.label}
+        px={4}
+        py={3}
+        borderRadius="20px"
+        bg="bg.muted"
+        border="1px solid"
+        borderColor="border.muted"
+      >
+        <VStack align="stretch" gap={1}>
+          <Text fontSize="xs" fontWeight="medium" color="text.secondary">
+            {item.label}
+          </Text>
+          <Text fontSize="sm" fontWeight="semibold" color="text.primary">
+            {item.value}
+          </Text>
+        </VStack>
+      </GridItem>
+    ))}
+  </Grid>
+);

--- a/src/pages/template-detail/ui/TemplatePreviewLayout.tsx
+++ b/src/pages/template-detail/ui/TemplatePreviewLayout.tsx
@@ -1,0 +1,37 @@
+import { type ReactNode } from "react";
+
+import { Box, Grid, GridItem } from "@chakra-ui/react";
+
+type Props = {
+  sidebar: ReactNode;
+  preview: ReactNode;
+};
+
+export const TemplatePreviewLayout = ({ sidebar, preview }: Props) => (
+  <Grid
+    maxW="1600px"
+    mx="auto"
+    w="full"
+    minH="calc(100vh - 80px)"
+    templateColumns={{ base: "1fr", lg: "390px minmax(0, 1fr)" }}
+    gap={{ base: 6, lg: 8 }}
+    alignItems="stretch"
+  >
+    <GridItem>{sidebar}</GridItem>
+    <GridItem minW={0}>
+      <Box
+        position="relative"
+        minH={{ base: "420px", lg: "calc(100vh - 128px)" }}
+        borderRadius="40px"
+        border="1px solid"
+        borderColor="transparent"
+        overflow="hidden"
+        bgImage="radial-gradient(circle, rgba(157,163,177,0.32) 1px, transparent 1px)"
+        bgSize="16px 16px"
+        bgColor="bg.canvas"
+      >
+        {preview}
+      </Box>
+    </GridItem>
+  </Grid>
+);

--- a/src/pages/template-detail/ui/TemplateRequiredServices.tsx
+++ b/src/pages/template-detail/ui/TemplateRequiredServices.tsx
@@ -1,0 +1,46 @@
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+
+import { ServiceBadge, getServiceBadgeKeyFromService } from "@/shared";
+
+type Props = {
+  services: string[];
+};
+
+export const TemplateRequiredServices = ({ services }: Props) => {
+  if (services.length === 0) {
+    return (
+      <Text fontSize="sm" color="text.secondary">
+        연결이 필요한 서비스가 아직 정의되지 않았습니다.
+      </Text>
+    );
+  }
+
+  return (
+    <HStack align="stretch" gap={3} wrap="wrap">
+      {services.map((service) => (
+        <Box
+          key={service}
+          px={3}
+          py={2.5}
+          borderRadius="18px"
+          bg="bg.surface"
+          border="1px solid"
+          borderColor="border.default"
+          boxShadow="0 6px 18px rgba(15, 23, 42, 0.04)"
+        >
+          <HStack gap={2.5}>
+            <ServiceBadge type={getServiceBadgeKeyFromService(service)} />
+            <VStack align="stretch" gap={0}>
+              <Text fontSize="xs" fontWeight="medium" color="text.secondary">
+                필요 서비스
+              </Text>
+              <Text fontSize="sm" fontWeight="semibold" color="text.primary">
+                {service}
+              </Text>
+            </VStack>
+          </HStack>
+        </Box>
+      ))}
+    </HStack>
+  );
+};

--- a/src/pages/template-detail/ui/TemplateWorkflowPreview.tsx
+++ b/src/pages/template-detail/ui/TemplateWorkflowPreview.tsx
@@ -1,31 +1,132 @@
-import { Box, Text, VStack } from "@chakra-ui/react";
+import { useMemo } from "react";
 
-export const TemplateWorkflowPreview = () => (
-  <Box
-    h="full"
-    display="flex"
-    alignItems="center"
-    justifyContent="center"
-    px={8}
-  >
-    <VStack
-      gap={3}
-      px={10}
-      py={8}
-      borderRadius="32px"
-      bg="rgba(255,255,255,0.72)"
-      border="1px solid"
-      borderColor="whiteAlpha.700"
-      backdropFilter="blur(10px)"
-      boxShadow="0 18px 40px rgba(15, 23, 42, 0.08)"
-      textAlign="center"
-    >
-      <Text fontSize="lg" fontWeight="semibold" color="text.primary">
-        워크플로우 프리뷰 준비 중
-      </Text>
-      <Text maxW="360px" fontSize="sm" color="text.secondary">
-        다음 단계에서 템플릿의 노드와 연결 정보를 읽기 전용 그래프로 표시합니다.
-      </Text>
-    </VStack>
-  </Box>
-);
+import { Box, Text, VStack } from "@chakra-ui/react";
+import {
+  Background,
+  BackgroundVariant,
+  type EdgeTypes,
+  type NodeTypes,
+  ReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import { FlowArrowEdge } from "@/entities/connection";
+import {
+  CalendarNode,
+  CommunicationNode,
+  ConditionNode,
+  CreationMethodNode,
+  DataProcessNode,
+  EarlyExitNode,
+  FilterNode,
+  LLMNode,
+  LoopNode,
+  MultiOutputNode,
+  NodeEditorProvider,
+  NotificationNode,
+  OutputFormatNode,
+  PlaceholderNode,
+  SpreadsheetNode,
+  StorageNode,
+  TriggerNode,
+  WebScrapingNode,
+} from "@/entities/node";
+
+import { type TemplatePreviewGraph } from "../model";
+
+type Props = {
+  graph: TemplatePreviewGraph | null;
+};
+
+const nodeTypes = {
+  communication: CommunicationNode,
+  storage: StorageNode,
+  spreadsheet: SpreadsheetNode,
+  "web-scraping": WebScrapingNode,
+  calendar: CalendarNode,
+  trigger: TriggerNode,
+  filter: FilterNode,
+  loop: LoopNode,
+  condition: ConditionNode,
+  "multi-output": MultiOutputNode,
+  "data-process": DataProcessNode,
+  "output-format": OutputFormatNode,
+  "early-exit": EarlyExitNode,
+  notification: NotificationNode,
+  llm: LLMNode,
+  placeholder: PlaceholderNode,
+  "creation-method": CreationMethodNode,
+} satisfies NodeTypes;
+
+const edgeTypes = {
+  "flow-arrow": FlowArrowEdge,
+} satisfies EdgeTypes;
+
+export const TemplateWorkflowPreview = ({ graph }: Props) => {
+  const contextValue = useMemo(
+    () => ({
+      canEditNodes: false,
+      startNodeId: graph?.startNodeId ?? null,
+      endNodeId: graph?.endNodeId ?? null,
+      getNodeStatus: () => null,
+      onOpenPanel: () => {},
+      onRemoveNode: () => {},
+    }),
+    [graph?.endNodeId, graph?.startNodeId],
+  );
+
+  if (!graph || graph.nodes.length === 0) {
+    return (
+      <Box
+        h="full"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        px={8}
+      >
+        <VStack
+          gap={3}
+          px={10}
+          py={8}
+          borderRadius="32px"
+          bg="rgba(255,255,255,0.72)"
+          border="1px solid"
+          borderColor="whiteAlpha.700"
+          backdropFilter="blur(10px)"
+          boxShadow="0 18px 40px rgba(15, 23, 42, 0.08)"
+          textAlign="center"
+        >
+          <Text fontSize="lg" fontWeight="semibold" color="text.primary">
+            프리뷰를 표시할 수 없습니다
+          </Text>
+          <Text maxW="360px" fontSize="sm" color="text.secondary">
+            템플릿에 표시 가능한 노드 정보가 아직 없습니다.
+          </Text>
+        </VStack>
+      </Box>
+    );
+  }
+
+  return (
+    <Box h="full" w="full" px={{ base: 4, lg: 8 }} py={{ base: 6, lg: 10 }}>
+      <NodeEditorProvider value={contextValue}>
+        <ReactFlow
+          nodes={graph.nodes}
+          edges={graph.edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.18 }}
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          zoomOnDoubleClick={false}
+          panOnDrag
+        >
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+        </ReactFlow>
+      </NodeEditorProvider>
+    </Box>
+  );
+};

--- a/src/pages/template-detail/ui/TemplateWorkflowPreview.tsx
+++ b/src/pages/template-detail/ui/TemplateWorkflowPreview.tsx
@@ -1,0 +1,31 @@
+import { Box, Text, VStack } from "@chakra-ui/react";
+
+export const TemplateWorkflowPreview = () => (
+  <Box
+    h="full"
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    px={8}
+  >
+    <VStack
+      gap={3}
+      px={10}
+      py={8}
+      borderRadius="32px"
+      bg="rgba(255,255,255,0.72)"
+      border="1px solid"
+      borderColor="whiteAlpha.700"
+      backdropFilter="blur(10px)"
+      boxShadow="0 18px 40px rgba(15, 23, 42, 0.08)"
+      textAlign="center"
+    >
+      <Text fontSize="lg" fontWeight="semibold" color="text.primary">
+        워크플로우 프리뷰 준비 중
+      </Text>
+      <Text maxW="360px" fontSize="sm" color="text.secondary">
+        다음 단계에서 템플릿의 노드와 연결 정보를 읽기 전용 그래프로 표시합니다.
+      </Text>
+    </VStack>
+  </Box>
+);

--- a/src/pages/template-detail/ui/TemplateWorkflowPreview.tsx
+++ b/src/pages/template-detail/ui/TemplateWorkflowPreview.tsx
@@ -121,8 +121,13 @@ export const TemplateWorkflowPreview = ({ graph }: Props) => {
           nodesDraggable={false}
           nodesConnectable={false}
           elementsSelectable={false}
+          nodesFocusable={false}
+          edgesFocusable={false}
+          panOnDrag={false}
+          zoomOnScroll={false}
+          zoomOnPinch={false}
           zoomOnDoubleClick={false}
-          panOnDrag
+          preventScrolling={false}
         >
           <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
         </ReactFlow>

--- a/src/pages/template-detail/ui/index.ts
+++ b/src/pages/template-detail/ui/index.ts
@@ -1,0 +1,3 @@
+export * from "./TemplateInfoPanel";
+export * from "./TemplatePreviewLayout";
+export * from "./TemplateWorkflowPreview";

--- a/src/pages/template-detail/ui/index.ts
+++ b/src/pages/template-detail/ui/index.ts
@@ -1,3 +1,5 @@
 export * from "./TemplateInfoPanel";
+export * from "./TemplateMetaSection";
 export * from "./TemplatePreviewLayout";
+export * from "./TemplateRequiredServices";
 export * from "./TemplateWorkflowPreview";


### PR DESCRIPTION
## 📌 요약 (Summary)

템플릿 상세 페이지를 기존 문서형 상세 화면에서, Figma 기반의 시각 프리뷰 중심 페이지로 개편했습니다.

기존의 텍스트 중심 상세 구조를 정리하고,
- 왼쪽 정보 패널
- 오른쪽 워크플로우 프리뷰 영역

구조로 전환했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 템플릿 상세 페이지 레이아웃을 시각 프리뷰 중심 구조로 재구성
- 왼쪽 정보 패널에 템플릿 메타데이터 및 CTA 반영
- 오른쪽 영역에 읽기 전용 워크플로우 프리뷰 추가
- 기존 문서형 상세 섹션 제거 및 프리뷰 상호작용 정리

## 🔧 상세 구현 내용 (Implementation Details)

### 1. 템플릿 상세 페이지 레이아웃 재구성
- 기존 `TemplateDetailPage`의 문서형 카드 레이아웃을 제거했습니다.
- 상세 페이지를 좌우 2단 구조로 재편했습니다.
  - 왼쪽: 템플릿 정보 패널
  - 오른쪽: 워크플로우 프리뷰 영역

### 2. 템플릿 정보 패널 구성
- 왼쪽 패널에 아래 정보를 통합했습니다.
  - 템플릿 이름
  - 설명
  - 요약 문구
  - 카테고리
  - 노드 수
  - 연결 수
  - 사용 횟수
  - 생성일
  - 필요 서비스
- `가져오기` CTA와 `목록으로` 액션을 유지했습니다.

### 3. 읽기 전용 워크플로우 프리뷰 추가
- 템플릿의 `nodes`, `edges`를 기반으로 읽기 전용 프리뷰 영역을 구성했습니다.
- 기존 에디터 `Canvas`를 직접 재사용하지 않고, 템플릿 상세 전용 프리뷰 구조로 분리했습니다.
- 프리뷰는 편집이 아닌 확인 목적이므로 상호작용을 최소화했습니다.

### 4. 기존 상세 섹션 정리
- 기존의 아래 구조를 제거/흡수했습니다.
  - 별도 `필요 서비스` 카드
  - 별도 `구성 요약` 텍스트 리스트
  - 문서형 3단 상세 구조
- 관련 정보는 모두 왼쪽 패널 안으로 이동했습니다.

## 🧩 트러블 슈팅 (Trouble Shooting)

- 템플릿 상세를 시각 프리뷰로 전환하는 과정에서, 일부 템플릿 데이터가 그래프 프리뷰에서 기대하는 형식을 충족하지 않는 문제가 확인되었습니다.
- 특히 현재 템플릿 데이터는 DB에 저장된 raw 값을 그대로 사용하고 있어, 프리뷰 렌더링에 필요한 node 위치 정보 등 구조가 완전하지 않은 경우가 있습니다.
- 이번 PR에서는 상세 페이지 UI/구조 개편에 집중하고, 템플릿 데이터 정비는 후속 작업으로 분리합니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 현재 템플릿 프리뷰는 템플릿 데이터가 그래프 렌더링에 필요한 형식을 충족한다는 전제를 가집니다.
- DB에 저장된 기존 템플릿 데이터 중 일부는 프리뷰용 구조가 완전하지 않을 수 있습니다.
- 따라서 후속 작업으로 아래가 필요합니다.
  1. 프리뷰 가능한 형식의 템플릿 데이터 추가/정비
  2. 실제 템플릿 클릭 진입 및 프리뷰 렌더링 테스트
  3. 가져오기 동작까지 포함한 end-to-end 확인

- 이번 PR에는 docker compose 로컬 파일 변경은 포함하지 않습니다.

## 📷 스크린샷 (Screenshots)

- 템플릿 목록에서 상세 페이지 진입 화면
- 왼쪽 정보 패널
- 오른쪽 워크플로우 프리뷰 영역
- 가져오기 CTA 동선

## #️⃣ 관련 이슈 (Related Issues)

- #114
