### PR TITLE
[PR} workflow choice wizard와 choice API 계약 불일치 수정

### DIFF
--- a/docs/WORKFLOW_CHOICE_WIZARD_BACKEND_ALIGNED_DESIGN.md
+++ b/docs/WORKFLOW_CHOICE_WIZARD_BACKEND_ALIGNED_DESIGN.md
@@ -1,0 +1,693 @@
+# Workflow Choice Wizard Backend-Aligned Design
+
+> 작성일: 2026-04-29  
+> 목적: 현재 프론트의 middle-node choice wizard를 실제 백엔드 코드와 백엔드 설계 문서 기준으로 다시 정렬한다.  
+> 범위: `GET /api/workflows/{id}/choices/{prevNodeId}` / `POST /api/workflows/{id}/choices/{prevNodeId}/select` 를 사용하는 middle-node 설정 흐름  
+> 비범위: source/sink picker, OAuth, workflow execute, 템플릿 상세, 대시보드
+
+---
+
+## 1. 문제 정의
+
+현재 워크플로우 생성 화면에서 middle placeholder를 클릭하고 처리 방식을 선택하면
+`POST /api/workflows/{id}/choices/{prevNodeId}/select` 호출이 400을 반환한다.
+
+하지만 이 문제는 단순 필드명 mismatch만의 문제가 아니다.
+
+현재 프론트는 다음 흐름을 하나의 로컬 stateful wizard로 운영한다.
+
+- processing method 선택
+- action 선택
+- follow-up / branch-config 입력
+
+반면 백엔드는 항상 **실제로 저장된 이전 노드의 `outputDataType`** 을 기준으로 choice를 해석한다.
+
+즉 현재 충돌은 아래 3층으로 나뉜다.
+
+1. transport contract mismatch  
+2. wizard state ownership mismatch  
+3. 프론트의 로컬 전이 흐름과 백엔드의 authoritative flow mismatch
+
+---
+
+## 2. 현재 백엔드 동작
+
+### 2.1 `GET /choices/{prevNodeId}`
+
+백엔드는 다음 순서로 선택지를 만든다.
+
+1. workflow 조회
+2. `prevNodeId`에 해당하는 노드 조회
+3. `prevNode.getOutputDataType()` 확인
+4. `ChoiceMappingService.getOptionsForNode(outputDataType, context)` 호출
+
+즉 choice 조회의 기준은 **프론트가 상상하는 현재 단계**가 아니라
+**서버에 저장된 이전 노드의 현재 output type** 이다.
+
+### 2.2 `POST /choices/{prevNodeId}/select`
+
+백엔드는 다음 순서로 선택 결과를 계산한다.
+
+1. workflow 조회
+2. `prevNodeId` 노드 조회
+3. `prevNode.getOutputDataType()` 확인
+4. `ChoiceMappingService.onUserSelect(selectedOptionId, dataType)` 호출
+5. `NodeSelectionResult` 반환
+
+중요한 점:
+
+- 현재 백엔드는 request body의 `dataType`을 authoritative source로 보지 않는다.
+- 항상 `prevNode`의 실제 `outputDataType`을 다시 읽는다.
+
+---
+
+## 3. 현재 백엔드 설계 문서가 의도한 흐름
+
+백엔드 sequence diagram 기준으로, 목록형 데이터(`FILE_LIST`)에서
+`requires_processing_method = true` 인 경우 흐름은 아래와 같다.
+
+1. `GET /choices/{prevNodeId}`
+2. 사용자가 1차 처리 방식 선택  
+   예: `one_by_one`
+3. `POST /choices/{prevNodeId}/select`
+4. 백엔드가 `nodeType=LOOP`, `outputDataType=SINGLE_FILE` 반환
+5. 프론트가 **LOOP 노드를 즉시 저장**
+6. 이후 단계는 **새로 저장된 LOOP 노드 id** 를 기준으로
+   다시 `GET /choices/{loopNodeId}` 를 호출
+7. 다음 action 선택 진행
+
+즉 백엔드가 의도한 구조는:
+
+> processing method 이후의 다음 단계가 같은 `prevNodeId` 위에서 이어지는 것이 아니라,  
+> **새로 저장된 중간 노드를 기준으로 새 choice 단계가 다시 시작되는 흐름**
+
+이다.
+
+---
+
+## 4. 현재 프론트 구현과의 차이
+
+현재 프론트 `OutputPanel`은 다음 구조로 동작한다.
+
+1. `GET /choices/{rootParentNodeId}` 로 wizard 시작
+2. processing method 선택 후 `POST /select`
+3. 로컬 state에서 `currentDataTypeKey`를 전이  
+   예: `FILE_LIST -> SINGLE_FILE`
+4. 이후 action 단계도 **같은 `rootParentNodeId`** 를 기준으로 계속 진행
+
+이 구조는 백엔드 설계와 다르다.
+
+왜냐하면 백엔드는:
+
+- `one_by_one` 선택 후
+- LOOP 노드를 저장한 뒤
+- 그 새 노드를 기준으로 다음 choice를 다시 조회
+
+하길 기대하기 때문이다.
+
+즉 현재 프론트는:
+
+- **중간 노드를 저장하기 전에**
+- 로컬 state만으로 다음 단계 의미를 이어가고 있다.
+
+이 때문에 서버는 여전히 원래 parent node의 `outputDataType`
+예: `FILE_LIST`
+를 기준으로 판단하고, 프론트가 기대하는 `SINGLE_FILE` 문맥과 어긋난다.
+
+---
+
+## 5. 직접적인 400 원인
+
+현재 프론트는 `POST /select` 에 아래 형태로 보낸다.
+
+```json
+{
+  "selectedOptionId": "one_by_one",
+  "dataType": "FILE_LIST",
+  "context": {}
+}
+```
+
+하지만 현재 백엔드 DTO는 JSON property `actionId`를 기대한다.
+
+즉 현재 running backend 기준으로는:
+
+- 프론트: `selectedOptionId`
+- 백엔드: `actionId`
+
+가 불일치하여 400이 발생할 수 있다.
+
+이 mismatch는 반드시 해결해야 하지만, 이것만 고쳐서는 구조 문제가 끝나지 않는다.
+
+---
+
+## 6. 목표 상태
+
+목표는 아래 한 문장으로 요약한다.
+
+> **선택의 의미 결정은 백엔드가 하고, 프론트는 그 결과를 저장하고 다음 단계로 자연스럽게 연결하는 orchestration layer가 된다.**
+
+즉 프론트는 더 이상 choice 의미를 로컬에서 계산하는 주체가 아니라:
+
+- 백엔드가 준 choice를 보여주고
+- 백엔드가 준 `NodeSelectionResult`를 저장하고
+- 그 저장 결과를 기준으로 다음 단계 UI를 열어주는 역할
+
+을 맡는다.
+
+---
+
+## 7. 설계 원칙
+
+### 7.1 백엔드 authority 우선
+
+아래 항목은 백엔드 응답을 authority로 본다.
+
+- choice 단계 분기
+- node type 결정
+- output data type 결정
+- follow-up 존재 여부
+- branch-config 존재 여부
+
+프론트는 정상 흐름에서 이를 재해석하거나 merge 우선권을 갖지 않는다.
+
+### 7.2 중간 노드 저장 후 다음 단계 진행
+
+processing method 또는 action 선택으로 node type이 결정되면,
+프론트는 먼저 그 노드를 workflow에 저장/갱신해야 한다.
+
+그 다음:
+
+- follow-up 이 있으면 현재 노드 추가 설정 단계로 진입
+- follow-up 이 없고 다음 노드 설정이 필요하면
+  **방금 저장된 노드 id 기준으로 새 choice 단계 시작**
+
+### 7.3 같은 `prevNodeId`로 다단계 wizard를 이어가지 않는다
+
+`FILE_LIST -> one_by_one -> LOOP` 가 결정되면,
+이후 단계의 authoritative parent는 root parent가 아니라
+**새로 생성된 LOOP 노드** 다.
+
+### 7.4 로컬 `mappingRules`는 authority가 아니다
+
+정상 흐름에서는:
+
+- `GET /choices` 응답
+- `POST /select` 응답
+
+만으로 wizard를 이어간다.
+
+`mappingRules.ts` / `mappingRulesAdapter.ts` 는 아래 경우에만 사용한다.
+
+1. 백엔드 unavailable 시 제한적 fallback
+2. 개발 중 참고 데이터
+3. 과도기적 호환층
+
+또한 이 fallback 책임은 **`features/choice-panel/model`** 에 둔다.  
+`widgets/output-panel` 이 직접 규칙 해석 authority를 가져서는 안 된다.
+
+---
+
+## 8. 레이어 책임 분리
+
+코드 컨벤션 기준으로 이번 이슈의 책임은 아래처럼 나눈다.
+
+### 8.1 `entities/workflow`
+
+책임:
+
+- choice API request/response type 정의
+- transport contract adapter
+- `actionId` / `selectedOptionId` 같은 백엔드 계약 정합 처리
+- query/mutation hook 제공
+
+포함 후보:
+
+- `src/entities/workflow/api/types.ts`
+- `src/entities/workflow/api/*`
+- `src/entities/workflow/model/useWorkflowChoicesQuery.ts`
+- `src/entities/workflow/model/useSelectWorkflowChoiceMutation.ts`
+
+### 8.2 `features/choice-panel/model`
+
+책임:
+
+- choice flow helper
+- fallback `mappingRules` adapter
+- choice context shaping helper
+- 백엔드 미지원 상황에서의 제한적 보조 규칙
+
+즉 로컬 choice 규칙은 이 레이어에 남고,
+widget이 직접 merge/계산을 들고 있지 않게 한다.
+
+### 8.3 `pages/workflow-editor/model`
+
+책임:
+
+- editor-specific wizard state machine
+- “선택 -> 저장 -> 다음 단계 시작” orchestration
+- 현재 단계가 follow-up 인지, 다음 node choice 인지 판정
+- 새 노드 id 기준 후속 query 시작
+
+즉 이번 이슈의 핵심 orchestration은
+**page-level model 책임** 으로 둔다.
+
+### 8.4 `widgets/output-panel/ui`
+
+책임:
+
+- 현재 wizard state 렌더링
+- step별 UI 표시
+- handler 연결
+
+즉 `OutputPanel`은 **orchestration의 최종 주체가 아니라 render shell** 에 가까워져야 한다.
+
+---
+
+## 9. 목표 UX 흐름
+
+### 9.1 `requires_processing_method = true`
+
+예: `FILE_LIST`
+
+1. 사용자가 middle placeholder 클릭
+2. 프론트가 `GET /choices/{prevNodeId}`
+3. 백엔드가 processing method 선택지 반환
+4. 사용자가 `one_by_one` 선택
+5. 프론트가 `POST /choices/{prevNodeId}/select`
+6. 백엔드가 `NodeSelectionResult(nodeType=LOOP, outputDataType=SINGLE_FILE)` 반환
+7. 프론트가 LOOP 노드 저장
+8. follow-up 이 없으면
+   **LOOP 노드를 기준으로 `GET /choices/{loopNodeId}`**
+9. 사용자는 다음 action 선택 단계로 자연스럽게 진입
+
+### 9.2 `requires_processing_method = false`
+
+예: `SINGLE_FILE`
+
+1. 사용자가 middle placeholder 클릭
+2. 프론트가 `GET /choices/{prevNodeId}`
+3. 백엔드가 action 선택지 반환
+4. 사용자가 action 선택
+5. 프론트가 `POST /choices/{prevNodeId}/select`
+6. 백엔드가 `NodeSelectionResult(nodeType, outputDataType, followUp?, branchConfig?)` 반환
+7. 프론트가 현재 노드 저장/갱신
+8. follow-up / branch-config 가 있으면 현재 노드 설정 단계로 진입
+9. 없으면 다음 노드 설정으로 자동 연결 가능
+
+### 9.3 follow-up / branch-config 존재 시
+
+이 단계는 “다음 노드 설정”이 아니라
+**방금 생성된 현재 노드의 추가 설정 단계** 로 취급한다.
+
+즉 흐름은:
+
+1. 선택 확정
+2. 현재 노드 type 결정
+3. 현재 노드 저장
+4. follow-up UI 표시
+5. follow-up 완료 후 현재 노드 config 저장
+6. 그 다음에야 다음 노드 설정으로 이동
+
+---
+
+## 10. 상태 모델 구체화
+
+프론트가 가져야 할 wizard 상태는 의미 계산용이 아니라
+**UI orchestration용 상태** 여야 한다.
+
+추천 상태 예시:
+
+```ts
+type ChoiceWizardMode =
+  | "idle"
+  | "loading-choices"
+  | "select-processing-method"
+  | "select-action"
+  | "configure-follow-up"
+  | "persisting-node"
+  | "opening-next-node";
+
+type ChoiceWizardContext = {
+  workflowId: string;
+  anchorNodeId: string;      // 현재 단계 기준 parent node
+  selectedNodeId: string | null; // 방금 저장/갱신된 node
+  currentChoice: ChoiceResponse | null;
+  pendingFollowUp: ChoiceFollowUp | null;
+  pendingBranchConfig: ChoiceBranchConfig | null;
+};
+```
+
+주의:
+
+- `currentDataTypeKey` 같은 값은 로컬 의미 추론용 state가 아니라
+  서버 응답 결과를 표시하기 위한 보조 값이어야 한다.
+- “현재 단계의 기준 node id”가
+  root parent인지,
+  새로 생성된 loop node인지
+  명확하게 구분되어야 한다.
+
+### 10.1 상태 전이 표
+
+아래 전이는 page-level controller가 authoritative하게 관리한다.
+
+| 현재 step | 입력 | 다음 step | `anchorNodeId` | `selectedNodeId` | 비고 |
+|------|------|------|------|------|------|
+| `idle` | `openForNode(prevNodeId)` | `loading-choices` | `prevNodeId` | `null` | placeholder 클릭 시작 |
+| `loading-choices` | `GET /choices` 성공 + processing method 필요 | `select-processing-method` | 유지 | `null` | 1차 선택 대기 |
+| `loading-choices` | `GET /choices` 성공 + action 바로 선택 가능 | `select-action` | 유지 | `null` | action 선택 대기 |
+| `select-processing-method` | processing method 선택 | `persisting-node` | 기존 parent 유지 | `null` | `POST /select` 후 저장 단계 진입 |
+| `select-action` | action 선택 | `persisting-node` | 현재 기준 parent 유지 | `null` | `POST /select` 후 저장 단계 진입 |
+| `persisting-node` | node 저장 성공 + follow-up 존재 | `configure-follow-up` | 새로 저장된 node id로 갱신 | 새 node id | 현재 node 추가 설정 |
+| `persisting-node` | node 저장 성공 + follow-up 없음 + 다음 choice 필요 | `opening-next-node` | 새로 저장된 node id로 갱신 | 새 node id | 새 node 기준 다음 단계 시작 |
+| `persisting-node` | node 저장 성공 + 후속 단계 없음 | `idle` | 새 node id 또는 유지 | 새 node id | wizard 완료 |
+| `opening-next-node` | `GET /choices/{newNodeId}` 성공 | `select-processing-method` 또는 `select-action` | 유지 | 유지 | 새 node 기준 choice 재시작 |
+| `configure-follow-up` | follow-up 저장 완료 + 다음 choice 필요 | `opening-next-node` | 현재 node id 유지 | 현재 node id 유지 | 현재 node 설정 후 다음 단계 |
+| `configure-follow-up` | follow-up 저장 완료 + 후속 단계 없음 | `idle` | 유지 | 유지 | wizard 완료 |
+
+규칙:
+
+- `anchorNodeId`는 “지금 choice를 물어볼 기준 node”다.
+- `selectedNodeId`는 “방금 저장/갱신한 현재 node”다.
+- processing method 결과로 중간 node가 생기면 다음 단계의 `anchorNodeId`는 반드시 그 새 node로 바뀐다.
+
+---
+
+## 11. API 계약 구체화
+
+### 11.1 단기 정렬
+
+우선 프론트 request body는 running backend와 맞아야 한다.
+
+예시:
+
+```json
+{
+  "actionId": "one_by_one",
+  "context": {}
+}
+```
+
+또는 백엔드가 `selectedOptionId`를 최종 계약으로 채택한다면
+FE/BE를 함께 바꿔 일치시켜야 한다.
+
+핵심은:
+
+- 페이지나 widget에서 필드명을 임시로 꼬지 않는다
+- **`entities/workflow` adapter에서만 계약을 정렬한다**
+
+### 11.2 `dataType` 필드
+
+현재 백엔드는 authoritative source로 사용하지 않으므로,
+최종 계약에서 아래 중 하나로 정리해야 한다.
+
+1. 완전히 제거
+2. 디버그/참고값으로만 유지
+
+프론트는 백엔드 결정 흐름에 맞추는 쪽으로 설계한다.
+
+중요:
+
+- `dataType`는 page/model과 widget이 의미 추론용으로 들고 다니는 공개 계약 필드가 아니다.
+- 최종 계약 확정 전까지도 `dataType`가 필요하다면
+  **`entities/workflow` transport adapter 내부의 과도기 값** 으로만 취급한다.
+- 즉 controller / `OutputPanel`은 `optionId`와 `context` 중심으로 동작하고,
+  `dataType`는 adapter 레벨에서만 주입/보정 가능해야 한다.
+
+### 11.3 `context`
+
+최종적으로 정리해야 할 항목:
+
+- 어떤 key를 허용하는지
+- `fields_from_service`
+- `fields_from_data`
+- `applicable_when`
+- file subtype / service field / branch option
+
+이 문서는 FE가 context shape를 독자 설계하지 않고
+백엔드와 계약을 확정해야 함을 전제로 한다.
+
+---
+
+## 12. 구현 단계 제안
+
+### 단계 1. transport contract 정렬
+
+목표:
+
+- `POST /choices/{prevNodeId}/select` 400 제거
+- FE/BE request field 정합
+
+포함:
+
+- request body 필드명 정렬
+- `entities/workflow` 타입 수정
+- transport adapter 추가 또는 제거
+
+### 단계 2. processing-method 이후 흐름 재구성
+
+목표:
+
+- `processing method 선택 -> 노드 저장 -> 새 노드 기준 choice 조회`
+  흐름으로 교체
+
+포함:
+
+- root parent 기반 로컬 연장 흐름 제거
+- 새 노드 id 기준 재조회 연결
+
+### 단계 3. action / follow-up 흐름 재구성
+
+목표:
+
+- action 선택 후 현재 노드 저장
+- follow-up / branch-config 는 현재 노드 설정 단계로 처리
+- 완료 후 다음 노드 설정으로 연결
+
+### 단계 4. 로컬 authority 제거
+
+목표:
+
+- `mappingRules` merge 중심 흐름 제거
+- 서버 응답 중심 wizard로 단순화
+
+포함:
+
+- `OutputPanel` 내부 로컬 의미 계산 축소
+- fallback은 feature/model로만 제한
+
+### 단계 5. 선택 결과 파이프라인 분리
+
+목표:
+
+- `NodeSelectionResult` 해석과 mutation 실행을 분리
+- 테스트 가능한 순수 로직과 부수효과 orchestration을 나눈다
+
+원칙:
+
+- `deriveChoiceNextIntent(result, currentState)`  
+  - 순수 함수
+  - 입력: `NodeSelectionResult`, 현재 wizard 상태
+  - 출력: 다음 행동 intent
+
+- `runChoiceNextIntent(intent)`  
+  - 부수효과 함수
+  - 입력: intent
+  - 동작: node add/update mutation, 후속 `GET /choices`, follow-up 진입
+
+예시:
+
+```ts
+type ChoiceNextIntent =
+  | { type: "persist-node"; nodeType: string; outputDataType: string | null }
+  | { type: "configure-current-node"; nodeId: string }
+  | { type: "open-next-choice"; anchorNodeId: string }
+  | { type: "complete" };
+```
+
+금지:
+
+- mutation 실행 함수 안에서 choice 의미를 다시 계산하는 것
+- 반대로 순수 해석 함수 안에서 API 호출을 섞는 것
+
+### 단계 6. observability 강화
+
+목표:
+
+- 백엔드 협의 전에도 현재 흐름이 어디서 끊기는지 쉽게 본다
+
+원칙:
+
+- 1순위는 dev-only logger
+- 2순위는 선택적 debug panel
+- 상시 사용자 노출용 문구를 `OutputPanel`에 과도하게 남기지 않는다
+
+포함:
+
+- 현재 `step`
+- `anchorNodeId`
+- `selectedNodeId`
+- 마지막 `NodeSelectionResult`
+- 마지막 `ChoiceNextIntent`
+- 마지막 API 에러
+
+즉 관측성은 위젯 책임을 두껍게 만드는 방식이 아니라,
+개발 모드에서 흐름을 추적할 수 있는 보조 수단으로 추가한다.
+
+---
+
+## 13. 백엔드와 반드시 정렬해야 하는 하드 계약
+
+아래 항목은 프론트에서 추정하거나 임의 해석하면 안 된다.  
+이번 이슈 구현 전에 **백엔드와 동일한 계약으로 확정**되어야 한다.
+
+### 13.1 `POST /choices/{prevNodeId}/select` request body
+
+반드시 맞아야 하는 항목:
+
+- 선택지 id 필드 이름
+  - `actionId`
+  - `selectedOptionId`
+- `dataType` 포함 여부
+- `context` 포함 여부
+- `context`의 nullable 정책
+
+즉 프론트는 `entities/workflow` 계층에서
+running backend의 request contract와 완전히 동일한 body를 만들어야 한다.
+
+### 13.2 `GET /choices`와 `POST /select`의 책임 경계
+
+반드시 맞아야 하는 항목:
+
+- `GET /choices`는 현재 단계의 선택지만 주는지
+- `POST /select`는 최종 `NodeSelectionResult`만 주는지
+- follow-up / branch-config가 어느 시점 응답에 실리는지
+- processing method와 action이 같은 `ChoiceOption` 구조를 쓰는지
+
+즉 프론트는
+어떤 단계에서 어떤 응답 shape를 기대해야 하는지를
+백엔드 계약과 정확히 맞춰야 한다.
+
+### 13.3 authoritative data type source
+
+반드시 맞아야 하는 항목:
+
+- 백엔드가 계속 `prevNode.outputDataType`만 authoritative source로 쓰는지
+- 아니면 request body의 `dataType`을 의미 있는 입력으로 받을 계획인지
+- processing method 이후 다음 단계의 기준 node가
+  - 기존 parent인지
+  - 새로 저장된 중간 node인지
+
+이 항목은 wizard 전체 흐름을 결정하므로,
+프론트에서 임의로 우회하면 안 된다.
+
+### 13.4 중간 노드 저장 타이밍
+
+반드시 맞아야 하는 항목:
+
+- `NodeSelectionResult` 수신 후 프론트가 즉시 node를 저장해야 하는지
+- 저장 전에 follow-up을 먼저 받아도 되는지
+- processing method 결과가 `LOOP`, `CONDITION_BRANCH`일 때
+  그 노드를 먼저 workflow에 반영해야 하는지
+
+현재 설계는 **먼저 저장 -> 그 다음 단계 진행**을 기준으로 하지만,
+이 타이밍은 백엔드 의도와 완전히 일치해야 한다.
+
+### 13.5 `context` 공식 shape
+
+반드시 맞아야 하는 항목:
+
+- 허용 key 집합
+  - `service`
+  - `fields`
+  - `file_subtype`
+  - `branch option source`
+  - 기타
+- key별 value type
+- `fields_from_service`, `fields_from_data`, `applicable_when`에서
+  각 값이 실제로 어떻게 소비되는지
+
+즉 `context`는 프론트가 “대충 object”로 보내는 영역이 아니라,
+명시적인 계약 문서가 필요한 구조다.
+
+---
+
+## 14. 구현 협의가 필요한 항목
+
+아래 항목은 중요하지만, 위 13장처럼 wizard 구조를 바로 깨뜨리는
+하드 계약과는 구분해서 본다.
+
+### 14.1 error semantics
+
+협의가 필요한 항목:
+
+- invalid option 선택 시 status code
+- 잘못된 단계 전이 시 status code
+- choice unavailable 시 status code
+- 응답 body 에러 shape
+
+프론트는 이 값을 기준으로
+- step 유지
+- fallback 메시지
+- wizard 종료
+
+를 나누게 되지만, 정상 플로우 정렬 이후에 다듬어도 된다.
+
+### 14.2 node add/update payload의 최소 요구사항
+
+협의가 필요한 항목:
+
+- `NodeSelectionResult`를 받은 뒤 프론트가 node add/update 시
+  어떤 필드를 반드시 포함해야 하는지
+  - `type`
+  - `dataType`
+  - `outputDataType`
+  - `config`
+  - `role`
+- follow-up 이전의 중간 node가 불완전 config 상태로 저장돼도 되는지
+- 저장 직후 `GET /choices/{newNodeId}`가 가능하려면
+  어떤 최소 상태가 보장되어야 하는지
+
+이 항목은 중요하지만,
+우선은 “선택 -> 저장 -> 새 node 기준 다음 단계”가 맞물리는지부터 맞춘 뒤
+세부 payload 최소조건을 정리해도 된다.
+
+---
+
+## 15. 오픈 이슈
+
+백엔드와 함께 확인은 필요하지만,
+위 13장/14장보다 우선순위가 한 단계 낮은 UX/표현 계열 항목:
+
+1. `GET /choices` 응답에 UX 보조용 설명 필드를 얼마나 풍부하게 줄지
+2. follow-up 문구/description을 백엔드에서 모두 책임질지
+3. branch-config UI 힌트(placeholder, helper text)까지 내려줄지
+4. 백엔드 unavailable 시 허용할 fallback UX 범위
+
+---
+
+## 16. 최종 결론
+
+현재 choice wizard 문제는 단순 프론트 버그 하나가 아니다.
+
+실제 백엔드가 의도한 구조는:
+
+1. 사용자가 선택
+2. 서버가 node 의미 결정
+3. 프론트가 노드 저장
+4. 새로 저장된 노드를 기준으로 다음 단계 진행
+
+이다.
+
+따라서 프론트는
+로컬 wizard state로 의미를 계속 끌고 가는 구조에서 벗어나,
+**선택마다 백엔드 결정을 저장하고 그 저장 결과를 기준으로 다음 단계를 다시 시작하는 구조**
+로 바뀌어야 한다.
+
+이 방향이:
+
+- 현재 백엔드 코드
+- 백엔드 sequence diagram
+- `mapping_rules.json` 기반 구조
+
+와 가장 잘 맞는다.

--- a/docs/WORKFLOW_CHOICE_WIZARD_BACKEND_ALIGNED_DESIGN.md
+++ b/docs/WORKFLOW_CHOICE_WIZARD_BACKEND_ALIGNED_DESIGN.md
@@ -371,6 +371,23 @@ type ChoiceWizardContext = {
 - `selectedNodeId`는 “방금 저장/갱신한 현재 node”다.
 - processing method 결과로 중간 node가 생기면 다음 단계의 `anchorNodeId`는 반드시 그 새 node로 바뀐다.
 
+### 10.2 anchor node 불변식
+
+구현 중 흔들리지 않도록 아래 불변식을 유지한다.
+
+1. `anchorNodeId`는 **다음 `GET /choices` 호출 대상**과 항상 같아야 한다.
+2. `rootParentNodeId`는 wizard 최초 진입 시점을 설명하는 보조 정보일 뿐,
+   이후 단계의 authoritative 기준 node로 재사용하지 않는다.
+3. `selectedNodeId`는 마지막으로 저장/갱신한 node를 가리키며,
+   follow-up / branch-config 저장 단계에서는 이 node를 현재 설정 대상으로 본다.
+4. processing method 결과로 중간 node가 생성되면,
+   다음 action choice는 반드시 그 중간 node를 `anchorNodeId`로 사용한다.
+5. follow-up 완료 후 다음 choice가 필요하면,
+   직전까지 설정하던 현재 node를 그대로 `anchorNodeId`로 유지한다.
+
+즉 프론트는 더 이상 “처음 클릭한 parent node”를 중심으로 wizard를 이어가지 않고,
+**현재 단계의 authoritative anchor node** 를 기준으로 다음 GET/POST를 이어간다.
+
 ---
 
 ## 11. API 계약 구체화
@@ -427,6 +444,92 @@ FE/BE를 함께 바꿔 일치시켜야 한다.
 이 문서는 FE가 context shape를 독자 설계하지 않고
 백엔드와 계약을 확정해야 함을 전제로 한다.
 
+다만 현재 백엔드 문서 `(2)` 기준으로, 프론트는 GET context와 POST context를
+아래처럼 **역할별로 분리된 모델**로 다루는 설계를 채택한다.
+
+```ts
+type ChoiceQueryContext = {
+  service?: string;
+  file_subtype?: string;
+};
+
+type ChoiceSelectContext = ChoiceQueryContext & {
+  fields?: string[];
+};
+```
+
+원칙:
+
+1. GET `/choices` 는 scalar context만 사용한다.
+   - `service`
+   - `file_subtype`
+2. POST `/select` 는 richer context를 사용할 수 있다.
+   - `service`
+   - `file_subtype`
+   - `fields`
+3. key 이름은 GET/POST가 동일한 canonical set을 공유한다.
+4. page/model은 임의 object를 만들지 않고,
+   `deriveChoiceQueryContext(...)`, `deriveChoiceSelectContext(...)`
+   같은 helper를 통해서만 context를 계산한다.
+
+### 11.4 GET query와 cache key 규칙
+
+GET `/choices` 에 context가 들어가기 시작하면,
+프론트 query layer도 아래 규칙을 반드시 지켜야 한다.
+
+1. query key는 더 이상 `(workflowId, prevNodeId)` 만으로 구성하지 않는다.
+2. `service`, `file_subtype` 가 달라지면 다른 choice cache로 취급한다.
+3. query context가 비어 있으면 기존 기본 조회와 동일하게 동작할 수 있어야 한다.
+
+개념적으로 choice cache key는 아래 형태를 따른다.
+
+```ts
+choice(workflowId, prevNodeId, {
+  service,
+  file_subtype,
+})
+```
+
+이 규칙이 없으면:
+
+- 같은 node 기준 GET이라도
+- context만 바뀐 요청이
+- 같은 캐시를 재사용하는 문제가 생긴다.
+
+### 11.5 follow-up / branch-config empty options 의미
+
+백엔드 문서 `(2)` 기준으로 프론트는 `options_source` 와 `options` 상태를
+같이 보고 follow-up 의미를 판정해야 한다.
+
+#### 경우 A. `options_source != null` + `options` empty/null
+
+의미:
+
+- 동적 옵션 resolve 실패
+- context 부족
+- 현재 단계에서 추가 정보 없이는 진행 불가
+
+프론트 처리:
+
+- “선택지가 없음”이 아니라 “추가 정보 부족으로 옵션을 구성하지 못함”으로 해석
+- 완료 버튼 비활성화
+- 가능한 경우 이전 단계로 유도하거나 context 부족 안내 표시
+
+#### 경우 B. `options_source == null` + `options` empty/null
+
+의미:
+
+- 정적 선택지가 원래 없음
+- 추가 선택 없이 진행 가능
+
+프론트 처리:
+
+- 현재처럼 안내 문구 표시 가능
+- 완료 버튼 허용 가능
+
+즉 `options.length === 0`만으로 follow-up 상태를 판정해서는 안 되고,
+**반드시 `options_source` 존재 여부를 함께 해석**해야 한다.
+
 ---
 
 ## 12. 구현 단계 제안
@@ -455,6 +558,8 @@ FE/BE를 함께 바꿔 일치시켜야 한다.
 
 - root parent 기반 로컬 연장 흐름 제거
 - 새 노드 id 기준 재조회 연결
+- `anchorNodeId` 갱신 규칙 반영
+- `rootParentNodeId`는 최초 진입 보조 정보로만 축소
 
 ### 단계 3. action / follow-up 흐름 재구성
 
@@ -463,6 +568,12 @@ FE/BE를 함께 바꿔 일치시켜야 한다.
 - action 선택 후 현재 노드 저장
 - follow-up / branch-config 는 현재 노드 설정 단계로 처리
 - 완료 후 다음 노드 설정으로 연결
+
+포함:
+
+- `options_source` 기반 empty options 해석 반영
+- resolve 실패 시 완료 차단 / 안내 상태 추가
+- resolve 성공 시 기존 follow-up UI 흐름 유지
 
 ### 단계 4. 로컬 authority 제거
 
@@ -475,6 +586,69 @@ FE/BE를 함께 바꿔 일치시켜야 한다.
 
 - `OutputPanel` 내부 로컬 의미 계산 축소
 - fallback은 feature/model로만 제한
+
+### 단계 4-1. GET context query 연동
+
+목표:
+
+- backend 문서 `(2)` 의 scalar GET context를 query layer에 반영
+
+포함:
+
+- `getWorkflowChoicesAPI(workflowId, prevNodeId, context?)`
+- `useWorkflowChoicesQuery` query key에 context 반영
+- controller에서 `deriveChoiceQueryContext(...)` 사용
+- GET context는 `service`, `file_subtype` 범위로 제한
+
+### 단계 4-2. choice loading / fallback 정책 분리
+
+목표:
+
+- 서버 choice가 아직 로딩 중일 때 로컬 fallback 선택지를 먼저 노출하지 않는다.
+- 서버 choice 조회 실패가 확정된 뒤에만 로컬 fallback을 허용한다.
+- wizard step과 choice 데이터 준비 상태를 분리한다.
+
+상태 원칙:
+
+- `wizardStep`은 사용자가 어느 단계에 있는지 나타낸다.
+- choice response는 해당 step에서 보여줄 선택지가 준비됐는지 나타낸다.
+- `wizardStep === "action"` 이지만 `activeActionChoiceResponse === null`인 상태는
+  **새 anchor 기준 action choice를 기다리는 정상 상태**다.
+- `isWizardMode === true`이면 `wizardStep === null`이어도
+  일반 설정 패널로 빠지지 않고 wizard shell에서 loading 상태를 보여준다.
+
+fallback 허용 조건:
+
+```ts
+const allowChoiceFallback = isChoicesError && !serverChoiceResponse;
+```
+
+resolver 규칙:
+
+- `serverChoiceResponse`가 있으면 서버 choice를 사용한다.
+- `serverChoiceResponse`가 없고 `allowChoiceFallback === true`이면 fallback을 사용한다.
+- 그 외에는 `null`을 반환하고 UI는 choice loading 상태를 보여준다.
+
+controller 노출 상태:
+
+```ts
+isChoiceStepLoading: boolean;
+isChoiceStepUnavailable: boolean;
+isUsingChoiceFallback: boolean;
+```
+
+렌더링 규칙:
+
+1. `isWizardMode`이면 wizard shell을 렌더링한다.
+2. 현재 choice step에 선택지가 없고 loading 상태이면 선택 버튼 대신 loading 안내를 보여준다.
+3. 서버 실패 후 fallback이 만들어진 경우에만 fallback 안내와 fallback 선택지를 함께 보여준다.
+4. 서버 실패 후 fallback도 만들 수 없으면 선택지 unavailable 안내를 보여준다.
+
+서비스 context 규칙:
+
+- `service` context의 최종 해석 주체는 백엔드다.
+- 프론트는 알려진 service key만 표시명으로 변환한다.
+- 프론트 `mappingRules.service_fields`에 없는 service라도 null로 버리지 않고 원본 값을 그대로 보낸다.
 
 ### 단계 5. 선택 결과 파이프라인 분리
 

--- a/src/entities/workflow/api/choice-payload-adapter.ts
+++ b/src/entities/workflow/api/choice-payload-adapter.ts
@@ -1,17 +1,19 @@
 import {
   type SelectWorkflowChoiceCommand,
   type SelectWorkflowChoiceRequestPayload,
+  type SelectWorkflowChoiceTransportMeta,
 } from "./types";
 
 export const toSelectWorkflowChoicePayload = (
   command: SelectWorkflowChoiceCommand,
+  transportMeta?: SelectWorkflowChoiceTransportMeta,
 ): SelectWorkflowChoiceRequestPayload => {
   const payload: SelectWorkflowChoiceRequestPayload = {
     actionId: command.optionId,
   };
 
-  if (command.dataType) {
-    payload.dataType = command.dataType;
+  if (transportMeta?.dataType) {
+    payload.dataType = transportMeta.dataType;
   }
 
   if (command.context) {

--- a/src/entities/workflow/api/choice-payload-adapter.ts
+++ b/src/entities/workflow/api/choice-payload-adapter.ts
@@ -1,0 +1,22 @@
+import {
+  type SelectWorkflowChoiceCommand,
+  type SelectWorkflowChoiceRequestPayload,
+} from "./types";
+
+export const toSelectWorkflowChoicePayload = (
+  command: SelectWorkflowChoiceCommand,
+): SelectWorkflowChoiceRequestPayload => {
+  const payload: SelectWorkflowChoiceRequestPayload = {
+    actionId: command.optionId,
+  };
+
+  if (command.dataType) {
+    payload.dataType = command.dataType;
+  }
+
+  if (command.context) {
+    payload.context = command.context;
+  }
+
+  return payload;
+};

--- a/src/entities/workflow/api/get-workflow-choices.api.ts
+++ b/src/entities/workflow/api/get-workflow-choices.api.ts
@@ -1,12 +1,34 @@
 import { request } from "@/shared/api/core";
 
-import { type ChoiceResponse } from "./types";
+import { type ChoiceQueryContext, type ChoiceResponse } from "./types";
+
+const toWorkflowChoicesQueryParams = (context?: ChoiceQueryContext) => {
+  if (!context) {
+    return undefined;
+  }
+
+  const params: Record<string, string> = {};
+  const service = context.service?.trim();
+  const fileSubtype = context.file_subtype?.trim();
+
+  if (service) {
+    params.service = service;
+  }
+
+  if (fileSubtype) {
+    params.file_subtype = fileSubtype;
+  }
+
+  return Object.keys(params).length > 0 ? params : undefined;
+};
 
 export const getWorkflowChoicesAPI = (
   workflowId: string,
   prevNodeId: string,
+  context?: ChoiceQueryContext,
 ): Promise<ChoiceResponse> =>
   request<ChoiceResponse>({
     url: `/workflows/${workflowId}/choices/${prevNodeId}`,
     method: "GET",
+    params: toWorkflowChoicesQueryParams(context),
   });

--- a/src/entities/workflow/api/select-workflow-choice.api.ts
+++ b/src/entities/workflow/api/select-workflow-choice.api.ts
@@ -4,15 +4,17 @@ import { toSelectWorkflowChoicePayload } from "./choice-payload-adapter";
 import {
   type NodeSelectionResult,
   type SelectWorkflowChoiceCommand,
+  type SelectWorkflowChoiceTransportMeta,
 } from "./types";
 
 export const selectWorkflowChoiceAPI = (
   workflowId: string,
   prevNodeId: string,
   command: SelectWorkflowChoiceCommand,
+  transportMeta?: SelectWorkflowChoiceTransportMeta,
 ): Promise<NodeSelectionResult> =>
   request<NodeSelectionResult>({
     url: `/workflows/${workflowId}/choices/${prevNodeId}/select`,
     method: "POST",
-    data: toSelectWorkflowChoicePayload(command),
+    data: toSelectWorkflowChoicePayload(command, transportMeta),
   });

--- a/src/entities/workflow/api/select-workflow-choice.api.ts
+++ b/src/entities/workflow/api/select-workflow-choice.api.ts
@@ -1,14 +1,18 @@
 import { request } from "@/shared/api/core";
 
-import { type NodeChoiceSelectRequest, type NodeSelectionResult } from "./types";
+import { toSelectWorkflowChoicePayload } from "./choice-payload-adapter";
+import {
+  type NodeSelectionResult,
+  type SelectWorkflowChoiceCommand,
+} from "./types";
 
 export const selectWorkflowChoiceAPI = (
   workflowId: string,
   prevNodeId: string,
-  body: NodeChoiceSelectRequest,
+  command: SelectWorkflowChoiceCommand,
 ): Promise<NodeSelectionResult> =>
   request<NodeSelectionResult>({
     url: `/workflows/${workflowId}/choices/${prevNodeId}/select`,
     method: "POST",
-    data: body,
+    data: toSelectWorkflowChoicePayload(command),
   });

--- a/src/entities/workflow/api/types.ts
+++ b/src/entities/workflow/api/types.ts
@@ -216,7 +216,7 @@ export interface SchemaPreviewRequest {
 
 export interface SelectWorkflowChoiceCommand {
   optionId: string;
-  context?: Record<string, unknown>;
+  context?: ChoiceSelectContext;
 }
 
 export interface SelectWorkflowChoiceTransportMeta {
@@ -226,7 +226,16 @@ export interface SelectWorkflowChoiceTransportMeta {
 export interface SelectWorkflowChoiceRequestPayload {
   actionId: string;
   dataType?: string;
-  context?: Record<string, unknown>;
+  context?: ChoiceSelectContext;
+}
+
+export interface ChoiceQueryContext {
+  service?: string;
+  file_subtype?: string;
+}
+
+export interface ChoiceSelectContext extends ChoiceQueryContext {
+  fields?: string[];
 }
 
 export interface ShareRequest {
@@ -248,7 +257,7 @@ export interface ChoiceOption {
 
 export interface ChoiceFollowUp {
   question: string;
-  options: ChoiceOption[];
+  options?: ChoiceOption[] | null;
   options_source?: string | null;
   multi_select?: boolean | null;
   description?: string | null;

--- a/src/entities/workflow/api/types.ts
+++ b/src/entities/workflow/api/types.ts
@@ -214,9 +214,15 @@ export interface SchemaPreviewRequest {
   edges: EdgeDefinitionResponse[];
 }
 
-export interface NodeChoiceSelectRequest {
-  selectedOptionId: string;
-  dataType: string;
+export interface SelectWorkflowChoiceCommand {
+  optionId: string;
+  dataType?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface SelectWorkflowChoiceRequestPayload {
+  actionId: string;
+  dataType?: string;
   context?: Record<string, unknown>;
 }
 

--- a/src/entities/workflow/api/types.ts
+++ b/src/entities/workflow/api/types.ts
@@ -216,8 +216,11 @@ export interface SchemaPreviewRequest {
 
 export interface SelectWorkflowChoiceCommand {
   optionId: string;
-  dataType?: string;
   context?: Record<string, unknown>;
+}
+
+export interface SelectWorkflowChoiceTransportMeta {
+  dataType?: string;
 }
 
 export interface SelectWorkflowChoiceRequestPayload {

--- a/src/entities/workflow/model/query-keys.ts
+++ b/src/entities/workflow/model/query-keys.ts
@@ -1,3 +1,14 @@
+import { type ChoiceQueryContext } from "../api";
+
+const normalizeChoiceQueryContext = (context?: ChoiceQueryContext) => {
+  const normalized = {
+    file_subtype: context?.file_subtype?.trim() || undefined,
+    service: context?.service?.trim() || undefined,
+  };
+
+  return normalized.file_subtype || normalized.service ? normalized : null;
+};
+
 export const workflowKeys = {
   all: () => ["workflow"] as const,
   editorCatalog: () => [...workflowKeys.all(), "editor-catalog"] as const,
@@ -18,6 +29,19 @@ export const workflowKeys = {
     [...workflowKeys.detail(workflowId), "schema-preview"] as const,
   choicesRoot: (workflowId: string) =>
     [...workflowKeys.detail(workflowId), "choices"] as const,
-  choice: (workflowId: string, prevNodeId: string) =>
-    [...workflowKeys.choicesRoot(workflowId), prevNodeId] as const,
+  choice: (
+    workflowId: string,
+    prevNodeId: string,
+    context?: ChoiceQueryContext,
+  ) => {
+    const normalizedContext = normalizeChoiceQueryContext(context);
+
+    return normalizedContext
+      ? ([
+          ...workflowKeys.choicesRoot(workflowId),
+          prevNodeId,
+          normalizedContext,
+        ] as const)
+      : ([...workflowKeys.choicesRoot(workflowId), prevNodeId] as const);
+  },
 } as const;

--- a/src/entities/workflow/model/useSelectWorkflowChoiceMutation.ts
+++ b/src/entities/workflow/model/useSelectWorkflowChoiceMutation.ts
@@ -3,16 +3,13 @@ import { useMutation } from "@tanstack/react-query";
 import { type MutationPolicyOptions, toMutationMeta } from "@/shared/api";
 import { queryClient } from "@/shared/libs";
 
-import { workflowApi } from "../api";
+import { type SelectWorkflowChoiceCommand, workflowApi } from "../api";
 
 import { workflowKeys } from "./query-keys";
 
-type SelectWorkflowChoiceVariables = {
+type SelectWorkflowChoiceVariables = SelectWorkflowChoiceCommand & {
   workflowId: string;
   prevNodeId: string;
-  selectedOptionId: string;
-  dataType: string;
-  context?: Record<string, unknown>;
 };
 
 export const useSelectWorkflowChoiceMutation = (
@@ -25,12 +22,12 @@ export const useSelectWorkflowChoiceMutation = (
     mutationFn: ({
       workflowId,
       prevNodeId,
-      selectedOptionId,
+      optionId,
       dataType,
       context,
     }: SelectWorkflowChoiceVariables) =>
       workflowApi.selectChoice(workflowId, prevNodeId, {
-        selectedOptionId,
+        optionId,
         dataType,
         context,
       }),
@@ -38,7 +35,10 @@ export const useSelectWorkflowChoiceMutation = (
     meta: toMutationMeta(options),
     onSuccess: async (data, variables, onMutateResult, context) => {
       await queryClient.invalidateQueries({
-        queryKey: workflowKeys.choice(variables.workflowId, variables.prevNodeId),
+        queryKey: workflowKeys.choice(
+          variables.workflowId,
+          variables.prevNodeId,
+        ),
       });
       await options?.onSuccess?.(data, variables, onMutateResult, context);
     },
@@ -46,4 +46,3 @@ export const useSelectWorkflowChoiceMutation = (
       await options?.onError?.(error, variables, onMutateResult, context);
     },
   });
-

--- a/src/entities/workflow/model/useSelectWorkflowChoiceMutation.ts
+++ b/src/entities/workflow/model/useSelectWorkflowChoiceMutation.ts
@@ -3,13 +3,18 @@ import { useMutation } from "@tanstack/react-query";
 import { type MutationPolicyOptions, toMutationMeta } from "@/shared/api";
 import { queryClient } from "@/shared/libs";
 
-import { type SelectWorkflowChoiceCommand, workflowApi } from "../api";
+import {
+  type SelectWorkflowChoiceCommand,
+  type SelectWorkflowChoiceTransportMeta,
+  workflowApi,
+} from "../api";
 
 import { workflowKeys } from "./query-keys";
 
 type SelectWorkflowChoiceVariables = SelectWorkflowChoiceCommand & {
   workflowId: string;
   prevNodeId: string;
+  transport?: SelectWorkflowChoiceTransportMeta;
 };
 
 export const useSelectWorkflowChoiceMutation = (
@@ -23,14 +28,18 @@ export const useSelectWorkflowChoiceMutation = (
       workflowId,
       prevNodeId,
       optionId,
-      dataType,
       context,
+      transport,
     }: SelectWorkflowChoiceVariables) =>
-      workflowApi.selectChoice(workflowId, prevNodeId, {
-        optionId,
-        dataType,
-        context,
-      }),
+      workflowApi.selectChoice(
+        workflowId,
+        prevNodeId,
+        {
+          optionId,
+          context,
+        },
+        transport,
+      ),
     retry: options?.retry,
     meta: toMutationMeta(options),
     onSuccess: async (data, variables, onMutateResult, context) => {

--- a/src/entities/workflow/model/useWorkflowChoicesQuery.ts
+++ b/src/entities/workflow/model/useWorkflowChoicesQuery.ts
@@ -7,12 +7,14 @@ import {
 } from "@/shared/api";
 
 import { workflowApi } from "../api";
+import { type ChoiceQueryContext } from "../api";
 
 import { workflowKeys } from "./query-keys";
 
 export const useWorkflowChoicesQuery = (
   workflowId: string | undefined,
   prevNodeId: string | null,
+  context?: ChoiceQueryContext,
   enabledOrOptions?:
     | boolean
     | QueryPolicyOptions<Awaited<ReturnType<typeof workflowApi.getChoices>>>,
@@ -22,14 +24,14 @@ export const useWorkflowChoicesQuery = (
   return useQuery({
     queryKey:
       workflowId && prevNodeId
-        ? workflowKeys.choice(workflowId, prevNodeId)
+        ? workflowKeys.choice(workflowId, prevNodeId, context)
         : ["workflow", "choices", "idle"],
     queryFn: () => {
       if (!workflowId || !prevNodeId) {
         throw new Error("workflow id and prev node id are required");
       }
 
-      return workflowApi.getChoices(workflowId, prevNodeId);
+      return workflowApi.getChoices(workflowId, prevNodeId, context);
     },
     enabled: Boolean(workflowId && prevNodeId) && (options?.enabled ?? true),
     select: options?.select,
@@ -41,4 +43,3 @@ export const useWorkflowChoicesQuery = (
     throwOnError: false,
   });
 };
-

--- a/src/features/choice-panel/model/choiceFallback.ts
+++ b/src/features/choice-panel/model/choiceFallback.ts
@@ -1,0 +1,129 @@
+﻿import {
+  type ChoiceBranchConfig,
+  type ChoiceFollowUp,
+  type ChoiceOption,
+  type ChoiceResponse,
+} from "@/entities/workflow";
+
+import {
+  type BranchConfig,
+  type FollowUp,
+  type MappingAction,
+  type MappingDataTypeKey,
+  type MappingRules,
+} from "./types";
+
+export type ResolvedChoiceOption = ChoiceOption & {
+  description?: string;
+  followUp?: ChoiceFollowUp | null;
+  branchConfig?: ChoiceBranchConfig | null;
+};
+
+export type ResolvedChoiceResponse = {
+  question: string;
+  options: ResolvedChoiceOption[];
+  requiresProcessingMethod: boolean;
+  multiSelect?: boolean | null;
+};
+
+type FallbackChoiceMode = "initial" | "action";
+
+const toChoiceFollowUp = (followUp: FollowUp | null | undefined) =>
+  followUp
+    ? {
+        question: followUp.question,
+        options: (followUp.options ?? []).map((option) => ({
+          id: option.id,
+          label: option.label,
+          type: option.type ?? null,
+        })),
+        options_source: followUp.options_source ?? null,
+        multi_select: followUp.multi_select ?? null,
+        description: followUp.description ?? null,
+      }
+    : null;
+
+const toChoiceBranchConfig = (branchConfig: BranchConfig | null | undefined) =>
+  branchConfig
+    ? {
+        question: branchConfig.question,
+        options: (branchConfig.options ?? []).map((option) => ({
+          id: option.id,
+          label: option.label,
+          type: option.type ?? null,
+        })),
+        options_source: branchConfig.options_source ?? null,
+        multi_select: branchConfig.multi_select ?? null,
+        description: branchConfig.description ?? null,
+      }
+    : null;
+
+const toResolvedChoiceOption = (
+  option: ChoiceOption | MappingAction,
+): ResolvedChoiceOption => ({
+  id: option.id,
+  label: option.label,
+  type: "type" in option ? (option.type ?? null) : null,
+  node_type: "node_type" in option ? (option.node_type ?? null) : null,
+  output_data_type:
+    "output_data_type" in option ? (option.output_data_type ?? null) : null,
+  priority: "priority" in option ? (option.priority ?? null) : null,
+  description: "description" in option ? option.description : undefined,
+  followUp:
+    "follow_up" in option ? toChoiceFollowUp(option.follow_up ?? null) : null,
+  branchConfig:
+    "branch_config" in option
+      ? toChoiceBranchConfig(option.branch_config ?? null)
+      : null,
+});
+
+export const toResolvedChoiceResponse = (
+  choiceResponse: ChoiceResponse,
+): ResolvedChoiceResponse => ({
+  question: choiceResponse.question,
+  options: choiceResponse.options.map(toResolvedChoiceOption),
+  requiresProcessingMethod: choiceResponse.requiresProcessingMethod,
+  multiSelect: choiceResponse.multiSelect ?? null,
+});
+
+export const buildFallbackChoiceResponse = (
+  mappingRules: MappingRules,
+  dataTypeKey: MappingDataTypeKey,
+  mode: FallbackChoiceMode = "initial",
+): ResolvedChoiceResponse => {
+  const config = mappingRules.data_types[dataTypeKey];
+
+  if (
+    mode === "initial" &&
+    config.requires_processing_method &&
+    config.processing_method
+  ) {
+    return {
+      question: config.processing_method.question,
+      options: config.processing_method.options.map(toResolvedChoiceOption),
+      requiresProcessingMethod: true,
+      multiSelect: null,
+    };
+  }
+
+  return {
+    question: `${config.label}을 어떻게 처리할까요?`,
+    options: config.actions.map(toResolvedChoiceOption),
+    requiresProcessingMethod: false,
+    multiSelect: null,
+  };
+};
+
+export const resolveChoiceResponse = ({
+  fallbackChoice,
+  serverChoice,
+}: {
+  serverChoice?: ChoiceResponse | null;
+  fallbackChoice?: ResolvedChoiceResponse | null;
+}): ResolvedChoiceResponse | null => {
+  if (serverChoice) {
+    return toResolvedChoiceResponse(serverChoice);
+  }
+
+  return fallbackChoice ?? null;
+};

--- a/src/features/choice-panel/model/choiceFallback.ts
+++ b/src/features/choice-panel/model/choiceFallback.ts
@@ -26,6 +26,8 @@ export type ResolvedChoiceResponse = {
   multiSelect?: boolean | null;
 };
 
+export type ChoiceResolutionSource = "server" | "fallback" | null;
+
 type FallbackChoiceMode = "initial" | "action";
 
 const toChoiceFollowUp = (followUp: FollowUp | null | undefined) =>
@@ -126,4 +128,65 @@ export const resolveChoiceResponse = ({
   }
 
   return fallbackChoice ?? null;
+};
+
+export const resolveInitialChoiceResponse = ({
+  dataTypeKey,
+  mappingRules,
+  serverChoice,
+}: {
+  mappingRules: MappingRules;
+  dataTypeKey: MappingDataTypeKey | null;
+  serverChoice?: ChoiceResponse | null;
+}): {
+  choice: ResolvedChoiceResponse | null;
+  source: ChoiceResolutionSource;
+} => {
+  const fallbackChoice = dataTypeKey
+    ? buildFallbackChoiceResponse(mappingRules, dataTypeKey, "initial")
+    : null;
+  const choice = resolveChoiceResponse({
+    serverChoice,
+    fallbackChoice,
+  });
+
+  return {
+    choice,
+    source: serverChoice ? "server" : fallbackChoice ? "fallback" : null,
+  };
+};
+
+export const resolveActionChoiceResponse = ({
+  currentDataTypeKey,
+  initialChoiceResponse,
+  initialDataTypeKey,
+  mappingRules,
+}: {
+  mappingRules: MappingRules;
+  currentDataTypeKey: MappingDataTypeKey | null;
+  initialChoiceResponse: ResolvedChoiceResponse | null;
+  initialDataTypeKey: MappingDataTypeKey | null;
+}): ResolvedChoiceResponse | null => {
+  if (!currentDataTypeKey) {
+    return null;
+  }
+
+  const fallbackChoice = buildFallbackChoiceResponse(
+    mappingRules,
+    currentDataTypeKey,
+    "action",
+  );
+
+  if (
+    initialChoiceResponse &&
+    initialChoiceResponse.requiresProcessingMethod === false &&
+    currentDataTypeKey === initialDataTypeKey
+  ) {
+    return resolveChoiceResponse({
+      serverChoice: initialChoiceResponse,
+      fallbackChoice,
+    });
+  }
+
+  return fallbackChoice;
 };

--- a/src/features/choice-panel/model/choiceFallback.ts
+++ b/src/features/choice-panel/model/choiceFallback.ts
@@ -28,6 +28,11 @@ export type ResolvedChoiceResponse = {
 
 export type ChoiceResolutionSource = "server" | "fallback" | null;
 
+type ChoiceResolutionResult = {
+  choice: ResolvedChoiceResponse | null;
+  source: ChoiceResolutionSource;
+};
+
 type FallbackChoiceMode = "initial" | "action";
 
 const toChoiceFollowUp = (followUp: FollowUp | null | undefined) =>
@@ -117,20 +122,36 @@ export const buildFallbackChoiceResponse = (
 };
 
 export const resolveChoiceResponse = ({
+  allowFallback,
   fallbackChoice,
   serverChoice,
 }: {
   serverChoice?: ChoiceResponse | null;
   fallbackChoice?: ResolvedChoiceResponse | null;
-}): ResolvedChoiceResponse | null => {
+  allowFallback: boolean;
+}): ChoiceResolutionResult => {
   if (serverChoice) {
-    return toResolvedChoiceResponse(serverChoice);
+    return {
+      choice: toResolvedChoiceResponse(serverChoice),
+      source: "server",
+    };
   }
 
-  return fallbackChoice ?? null;
+  if (allowFallback && fallbackChoice) {
+    return {
+      choice: fallbackChoice,
+      source: "fallback",
+    };
+  }
+
+  return {
+    choice: null,
+    source: null,
+  };
 };
 
 export const resolveInitialChoiceResponse = ({
+  allowFallback,
   dataTypeKey,
   mappingRules,
   serverChoice,
@@ -138,37 +159,35 @@ export const resolveInitialChoiceResponse = ({
   mappingRules: MappingRules;
   dataTypeKey: MappingDataTypeKey | null;
   serverChoice?: ChoiceResponse | null;
-}): {
-  choice: ResolvedChoiceResponse | null;
-  source: ChoiceResolutionSource;
-} => {
+  allowFallback: boolean;
+}): ChoiceResolutionResult => {
   const fallbackChoice = dataTypeKey
     ? buildFallbackChoiceResponse(mappingRules, dataTypeKey, "initial")
     : null;
-  const choice = resolveChoiceResponse({
+
+  return resolveChoiceResponse({
+    allowFallback,
     serverChoice,
     fallbackChoice,
   });
-
-  return {
-    choice,
-    source: serverChoice ? "server" : fallbackChoice ? "fallback" : null,
-  };
 };
 
 export const resolveActionChoiceResponse = ({
+  allowFallback,
   currentDataTypeKey,
-  initialChoiceResponse,
-  initialDataTypeKey,
   mappingRules,
+  serverChoice,
 }: {
   mappingRules: MappingRules;
   currentDataTypeKey: MappingDataTypeKey | null;
-  initialChoiceResponse: ResolvedChoiceResponse | null;
-  initialDataTypeKey: MappingDataTypeKey | null;
-}): ResolvedChoiceResponse | null => {
+  serverChoice?: ChoiceResponse | null;
+  allowFallback: boolean;
+}): ChoiceResolutionResult => {
   if (!currentDataTypeKey) {
-    return null;
+    return {
+      choice: null,
+      source: null,
+    };
   }
 
   const fallbackChoice = buildFallbackChoiceResponse(
@@ -177,16 +196,9 @@ export const resolveActionChoiceResponse = ({
     "action",
   );
 
-  if (
-    initialChoiceResponse &&
-    initialChoiceResponse.requiresProcessingMethod === false &&
-    currentDataTypeKey === initialDataTypeKey
-  ) {
-    return resolveChoiceResponse({
-      serverChoice: initialChoiceResponse,
-      fallbackChoice,
-    });
-  }
-
-  return fallbackChoice;
+  return resolveChoiceResponse({
+    allowFallback,
+    serverChoice,
+    fallbackChoice,
+  });
 };

--- a/src/features/choice-panel/model/index.ts
+++ b/src/features/choice-panel/model/index.ts
@@ -1,3 +1,4 @@
+export * from "./choiceFallback";
 export * from "./dataTypeKeyMap";
 export * from "./mappingRulesAdapter";
 export * from "./mappingRules";

--- a/src/pages/workflow-editor/WorkflowEditorPage.tsx
+++ b/src/pages/workflow-editor/WorkflowEditorPage.tsx
@@ -11,6 +11,8 @@ import { hydrateStore, useWorkflowStore } from "@/features/workflow-editor";
 import { EDITOR_CANVAS_AREA_ID, ROUTE_PATHS, getAuthUser } from "@/shared";
 import { Canvas, EditorRemoteBar, InputPanel, OutputPanel } from "@/widgets";
 
+import { useChoiceWizardController } from "./model";
+
 const EditorLoadingView = () => (
   <Box
     display="flex"
@@ -67,6 +69,7 @@ const WorkflowEditorInner = () => {
   );
   const resetEditor = useWorkflowStore((state) => state.resetEditor);
   const { data: workflow, isLoading, isError } = useWorkflowQuery(id);
+  const choiceWizardController = useChoiceWizardController();
   const hydratedWorkflowIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -155,7 +158,7 @@ const WorkflowEditorInner = () => {
       <EditorRemoteBar />
       <ServiceSelectionPanel />
       <InputPanel />
-      <OutputPanel />
+      <OutputPanel wizardController={choiceWizardController} />
     </Box>
   );
 };

--- a/src/pages/workflow-editor/model/choiceSelectionPipeline.ts
+++ b/src/pages/workflow-editor/model/choiceSelectionPipeline.ts
@@ -1,0 +1,121 @@
+import { type NodeType } from "@/entities/node";
+import {
+  type ChoiceBranchConfig,
+  type ChoiceFollowUp,
+  type NodeSelectionResult,
+} from "@/entities/workflow";
+import {
+  MAPPING_NODE_TYPE_MAP,
+  type MappingDataTypeKey,
+  type MappingRules,
+  type ResolvedChoiceOption,
+  type ResolvedChoiceResponse,
+  buildFallbackChoiceResponse,
+} from "@/features/choice-panel";
+
+const isMappingDataTypeKey = (
+  mappingRules: MappingRules,
+  value: string | null | undefined,
+): value is MappingDataTypeKey =>
+  Boolean(value && value in mappingRules.data_types);
+
+const toChoiceNodeType = (value: string | null | undefined): NodeType =>
+  value && value in MAPPING_NODE_TYPE_MAP
+    ? MAPPING_NODE_TYPE_MAP[value as keyof typeof MAPPING_NODE_TYPE_MAP]
+    : "data-process";
+
+export type ProcessingMethodSelectionIntent = {
+  isConfigured: boolean;
+  nextActionChoice: ResolvedChoiceResponse;
+  nextDataTypeKey: MappingDataTypeKey;
+  nextNodeType: NodeType;
+  nextStep: "action" | "complete";
+};
+
+export type ActionSelectionIntent = {
+  branchConfig: ChoiceBranchConfig | null;
+  followUp: ChoiceFollowUp | null;
+  hasFollowUp: boolean;
+  nextDataTypeKey: MappingDataTypeKey;
+  nextNodeType: NodeType;
+  nextStep: "follow-up" | "complete";
+  shouldUseActionLeaf: boolean;
+};
+
+export const deriveProcessingMethodSelectionIntent = ({
+  currentDataTypeKey,
+  mappingRules,
+  option,
+  selectionResult,
+}: {
+  currentDataTypeKey: MappingDataTypeKey;
+  mappingRules: MappingRules;
+  option: ResolvedChoiceOption;
+  selectionResult: NodeSelectionResult;
+}): ProcessingMethodSelectionIntent => {
+  const nextDataTypeKey = isMappingDataTypeKey(
+    mappingRules,
+    selectionResult.outputDataType,
+  )
+    ? selectionResult.outputDataType
+    : isMappingDataTypeKey(mappingRules, option.output_data_type)
+      ? option.output_data_type
+      : currentDataTypeKey;
+
+  const nextActionChoice = buildFallbackChoiceResponse(
+    mappingRules,
+    nextDataTypeKey,
+    "action",
+  );
+  const nextStep = nextActionChoice.options.length > 0 ? "action" : "complete";
+
+  return {
+    isConfigured: nextStep === "complete",
+    nextActionChoice,
+    nextDataTypeKey,
+    nextNodeType: selectionResult.nodeType
+      ? toChoiceNodeType(selectionResult.nodeType)
+      : toChoiceNodeType(option.node_type),
+    nextStep,
+  };
+};
+
+export const deriveActionSelectionIntent = ({
+  currentDataTypeKey,
+  mappingRules,
+  option,
+  selectionResult,
+  stagingNodeType,
+}: {
+  currentDataTypeKey: MappingDataTypeKey;
+  mappingRules: MappingRules;
+  option: ResolvedChoiceOption;
+  selectionResult: NodeSelectionResult;
+  stagingNodeType: NodeType;
+}): ActionSelectionIntent => {
+  const nextDataTypeKey = isMappingDataTypeKey(
+    mappingRules,
+    selectionResult.outputDataType,
+  )
+    ? selectionResult.outputDataType
+    : isMappingDataTypeKey(mappingRules, option.output_data_type)
+      ? option.output_data_type
+      : currentDataTypeKey;
+
+  const followUp = selectionResult.followUp ?? option.followUp ?? null;
+  const branchConfig =
+    selectionResult.branchConfig ?? option.branchConfig ?? null;
+  const hasFollowUp = Boolean(followUp || branchConfig);
+
+  return {
+    branchConfig,
+    followUp,
+    hasFollowUp,
+    nextDataTypeKey,
+    nextNodeType: selectionResult.nodeType
+      ? toChoiceNodeType(selectionResult.nodeType)
+      : toChoiceNodeType(option.node_type),
+    nextStep: hasFollowUp ? "follow-up" : "complete",
+    shouldUseActionLeaf: stagingNodeType === "loop",
+  };
+};

--- a/src/pages/workflow-editor/model/choiceWizardContext.ts
+++ b/src/pages/workflow-editor/model/choiceWizardContext.ts
@@ -1,0 +1,144 @@
+import { type Edge, type Node } from "@xyflow/react";
+
+import { type FlowNodeData } from "@/entities/node";
+import {
+  type ChoiceQueryContext,
+  type ChoiceSelectContext,
+} from "@/entities/workflow";
+
+const SERVICE_KEY_TO_CONTEXT_SERVICE: Record<string, string> = {
+  coupang: "쿠팡",
+  github: "GitHub",
+  google_calendar: "Google Calendar",
+  naver_news: "네이버 뉴스",
+  youtube: "유튜브",
+};
+
+type ChoiceContextParams = {
+  nodes: Node<FlowNodeData>[];
+  edges: Edge[];
+  anchorNodeId: string | null;
+};
+
+const toRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+const toStringValue = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+
+const toStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const normalizeService = (service: string | null): string | null => {
+  if (!service) {
+    return null;
+  }
+
+  return SERVICE_KEY_TO_CONTEXT_SERVICE[service] ?? service;
+};
+
+const getConfig = (node: Node<FlowNodeData>) => toRecord(node.data.config);
+
+const readService = (node: Node<FlowNodeData>) =>
+  normalizeService(toStringValue(getConfig(node)?.["service"]));
+
+const readFileSubtype = (node: Node<FlowNodeData>) => {
+  const config = getConfig(node);
+  return (
+    toStringValue(config?.["file_subtype"]) ??
+    toStringValue(config?.["fileSubtype"])
+  );
+};
+
+const readFields = (node: Node<FlowNodeData>) => {
+  const config = getConfig(node);
+  const fields = toStringList(config?.["fields"]);
+  return fields.length > 0 ? fields : toStringList(config?.["outputFields"]);
+};
+
+const getNodeLookup = (nodes: Node<FlowNodeData>[]) =>
+  new Map(nodes.map((node) => [node.id, node]));
+
+const getUpstreamNodes = ({
+  anchorNodeId,
+  edges,
+  nodes,
+}: Pick<ChoiceContextParams, "anchorNodeId" | "edges" | "nodes">) => {
+  if (!anchorNodeId) {
+    return [];
+  }
+
+  const nodeLookup = getNodeLookup(nodes);
+  const result: Node<FlowNodeData>[] = [];
+  const visited = new Set<string>();
+  const queue = [anchorNodeId];
+
+  while (queue.length > 0) {
+    const nodeId = queue.shift();
+    if (!nodeId || visited.has(nodeId)) {
+      continue;
+    }
+
+    visited.add(nodeId);
+
+    const node = nodeLookup.get(nodeId);
+    if (node) {
+      result.push(node);
+    }
+
+    edges
+      .filter((edge) => edge.target === nodeId)
+      .forEach((edge) => queue.push(edge.source));
+  }
+
+  return result;
+};
+
+const firstNonNull = <T>(values: T[]): NonNullable<T> | null =>
+  (values.find((value) => value != null) as NonNullable<T> | undefined) ?? null;
+
+export const deriveChoiceQueryContext = ({
+  anchorNodeId,
+  edges,
+  nodes,
+}: ChoiceContextParams): ChoiceQueryContext | undefined => {
+  const upstreamNodes = getUpstreamNodes({ anchorNodeId, edges, nodes });
+  const service = firstNonNull(upstreamNodes.map(readService));
+  const fileSubtype = firstNonNull(upstreamNodes.map(readFileSubtype));
+
+  return service || fileSubtype
+    ? {
+        ...(service ? { service } : {}),
+        ...(fileSubtype ? { file_subtype: fileSubtype } : {}),
+      }
+    : undefined;
+};
+
+export const deriveChoiceSelectContext = (
+  params: ChoiceContextParams,
+): ChoiceSelectContext | undefined => {
+  const queryContext = deriveChoiceQueryContext(params);
+  const upstreamNodes = getUpstreamNodes(params);
+  const fields = firstNonNull(
+    upstreamNodes
+      .map(readFields)
+      .map((values) => (values.length > 0 ? values : null)),
+  );
+
+  return queryContext || fields
+    ? {
+        ...(queryContext ?? {}),
+        ...(fields ? { fields } : {}),
+      }
+    : undefined;
+};

--- a/src/pages/workflow-editor/model/choiceWizardLogger.ts
+++ b/src/pages/workflow-editor/model/choiceWizardLogger.ts
@@ -1,0 +1,18 @@
+type ChoiceWizardLogPayload = {
+  anchorNodeId?: string | null;
+  details?: Record<string, unknown>;
+  event: string;
+  nextStep?: string | null;
+  optionId?: string | null;
+  source?: "fallback" | "server" | null;
+  step?: string | null;
+  targetNodeId?: string | null;
+};
+
+export const logChoiceWizardEvent = (payload: ChoiceWizardLogPayload) => {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+
+  console.info("[choice-wizard]", payload);
+};

--- a/src/pages/workflow-editor/model/choiceWizardNodePersistence.ts
+++ b/src/pages/workflow-editor/model/choiceWizardNodePersistence.ts
@@ -1,0 +1,251 @@
+import { type Edge } from "@xyflow/react";
+
+import {
+  type DataType,
+  type FlowNodeData,
+  type NodeType,
+} from "@/entities/node";
+import {
+  type WorkflowResponse,
+  findAddedNodeId,
+  toBackendDataType,
+  toBackendNodeType,
+  toNodeAddRequest,
+} from "@/entities/workflow";
+import {
+  type MappingDataTypeKey,
+  toDataType,
+  toMappingKey,
+} from "@/features/choice-panel";
+
+export type WizardNodeSnapshot = {
+  authWarning?: boolean;
+  config: FlowNodeData["config"];
+  inputTypes: DataType[];
+  outputTypes: DataType[];
+  position: { x: number; y: number };
+  role: "start" | "middle" | "end";
+  type: NodeType;
+};
+
+type ResolveNodeRole = (nodeId: string) => "start" | "middle" | "end";
+
+type UpdateWorkflowNode = (args: {
+  workflowId: string;
+  nodeId: string;
+  body: {
+    category?: string;
+    type?: string;
+    config?: Record<string, unknown>;
+    position?: { x: number; y: number };
+    dataType?: string | null;
+    outputDataType?: string | null;
+    role?: "start" | "middle" | "end";
+    authWarning?: boolean;
+  };
+}) => Promise<WorkflowResponse>;
+
+type AddWorkflowNode = (args: {
+  workflowId: string;
+  body: ReturnType<typeof toNodeAddRequest>;
+}) => Promise<WorkflowResponse>;
+
+type DeleteWorkflowNode = (args: {
+  workflowId: string;
+  nodeId: string;
+}) => Promise<WorkflowResponse>;
+
+type FlowNode = {
+  id: string;
+  position: { x: number; y: number };
+  data: {
+    type: NodeType;
+    config: FlowNodeData["config"];
+    inputTypes: DataType[];
+    outputTypes: DataType[];
+    authWarning?: boolean;
+  };
+};
+
+export const canSafelyDeleteChoiceWizardLeaf = ({
+  edges,
+  nodeId,
+  resolveNodeRole,
+  sessionOwnedLeafNodeIds,
+  stagingNodeId,
+}: {
+  edges: Edge[];
+  nodeId: string;
+  resolveNodeRole: ResolveNodeRole;
+  sessionOwnedLeafNodeIds: string[];
+  stagingNodeId: string | null;
+}) => {
+  if (!sessionOwnedLeafNodeIds.includes(nodeId)) {
+    return false;
+  }
+
+  if (nodeId === stagingNodeId) {
+    return false;
+  }
+
+  if (resolveNodeRole(nodeId) !== "middle") {
+    return false;
+  }
+
+  return !edges.some((edge) => edge.source === nodeId);
+};
+
+export const createChoiceWizardNodePersistence = ({
+  addWorkflowNode,
+  deleteWorkflowNode,
+  resolveNodeRole,
+  syncWorkflowFromResponse,
+  updateWorkflowNode,
+  workflowId,
+}: {
+  addWorkflowNode: AddWorkflowNode;
+  deleteWorkflowNode: DeleteWorkflowNode;
+  resolveNodeRole: ResolveNodeRole;
+  syncWorkflowFromResponse: (workflow: WorkflowResponse) => void;
+  updateWorkflowNode: UpdateWorkflowNode;
+  workflowId: string | null;
+}) => {
+  const syncUpdatedNode = (workflow: WorkflowResponse, nodeId: string) => {
+    const nextNode = workflow.nodes.find((node) => node.id === nodeId);
+    if (!nextNode) {
+      throw new Error("node was not updated");
+    }
+
+    syncWorkflowFromResponse(workflow);
+    return nextNode.id;
+  };
+
+  const updatePersistedNode = async ({
+    config,
+    inputDataTypeKey,
+    node,
+    outputDataTypeKey,
+    position,
+    role,
+    type,
+  }: {
+    node: FlowNode;
+    type: NodeType;
+    config: FlowNodeData["config"];
+    inputDataTypeKey?: MappingDataTypeKey | null;
+    outputDataTypeKey?: MappingDataTypeKey | null;
+    position?: { x: number; y: number };
+    role?: "start" | "middle" | "end";
+  }) => {
+    if (!workflowId) {
+      throw new Error("workflowId is required");
+    }
+
+    const nextWorkflow = await updateWorkflowNode({
+      workflowId,
+      nodeId: node.id,
+      body: {
+        category: toBackendNodeType(type).category,
+        type: toBackendNodeType(type).type,
+        config: config as unknown as Record<string, unknown>,
+        position: position ?? node.position,
+        dataType:
+          inputDataTypeKey !== undefined
+            ? inputDataTypeKey
+              ? toBackendDataType(toDataType(inputDataTypeKey))
+              : null
+            : node.data.inputTypes[0]
+              ? toBackendDataType(node.data.inputTypes[0])
+              : null,
+        outputDataType:
+          outputDataTypeKey !== undefined
+            ? outputDataTypeKey
+              ? toBackendDataType(toDataType(outputDataTypeKey))
+              : null
+            : node.data.outputTypes[0]
+              ? toBackendDataType(node.data.outputTypes[0])
+              : null,
+        role: role ?? resolveNodeRole(node.id),
+        authWarning: node.data.authWarning ?? false,
+      },
+    });
+
+    return syncUpdatedNode(nextWorkflow, node.id);
+  };
+
+  const placeWorkflowNode = async ({
+    config,
+    inputDataTypeKey,
+    outputDataTypeKey,
+    position,
+    previousNodes,
+    sourceNodeId,
+    type,
+  }: {
+    type: NodeType;
+    sourceNodeId: string;
+    position: { x: number; y: number };
+    previousNodes: FlowNode[];
+    inputDataTypeKey?: MappingDataTypeKey | null;
+    outputDataTypeKey: MappingDataTypeKey | null;
+    config?: Partial<FlowNodeData["config"]>;
+  }) => {
+    if (!workflowId) {
+      throw new Error("workflowId is required");
+    }
+
+    const nextWorkflow = await addWorkflowNode({
+      workflowId,
+      body: toNodeAddRequest({
+        type,
+        position,
+        prevNodeId: sourceNodeId,
+        config,
+        inputTypes: inputDataTypeKey
+          ? [toDataType(inputDataTypeKey)]
+          : undefined,
+        outputTypes: outputDataTypeKey
+          ? [toDataType(outputDataTypeKey)]
+          : undefined,
+      }),
+    });
+
+    const addedNodeId =
+      findAddedNodeId(previousNodes, nextWorkflow.nodes) ??
+      nextWorkflow.nodes.at(-1)?.id ??
+      null;
+    const addedNode = nextWorkflow.nodes.find(
+      (node) => node.id === addedNodeId,
+    );
+
+    if (!addedNodeId || !addedNode) {
+      return null;
+    }
+
+    syncWorkflowFromResponse(nextWorkflow);
+    return addedNodeId;
+  };
+
+  const removeWorkflowNode = async (nodeId: string) => {
+    if (!workflowId) {
+      throw new Error("workflowId is required");
+    }
+
+    const nextWorkflow = await deleteWorkflowNode({
+      workflowId,
+      nodeId,
+    });
+    syncWorkflowFromResponse(nextWorkflow);
+  };
+
+  return {
+    placeWorkflowNode,
+    removeWorkflowNode,
+    syncUpdatedNode,
+    syncWorkflowFromResponse,
+    updatePersistedNode,
+  };
+};
+
+export const toSnapshotDataTypeKey = (dataType?: DataType | null) =>
+  dataType ? toMappingKey(dataType) : null;

--- a/src/pages/workflow-editor/model/choiceWizardStateTransitions.ts
+++ b/src/pages/workflow-editor/model/choiceWizardStateTransitions.ts
@@ -1,0 +1,83 @@
+import {
+  type ChoiceBranchConfig,
+  type ChoiceFollowUp,
+} from "@/entities/workflow";
+import {
+  type MappingDataTypeKey,
+  type ResolvedChoiceOption,
+} from "@/features/choice-panel";
+
+export type ChoiceWizardStep = "processing-method" | "action" | "follow-up";
+
+export type ChoiceWizardStatePatch = {
+  actionNodeId?: string | null;
+  currentDataTypeKey?: MappingDataTypeKey | null;
+  selectedAction?: ResolvedChoiceOption | null;
+  selectedBranchConfig?: ChoiceBranchConfig | null;
+  selectedFollowUp?: ChoiceFollowUp | null;
+  selectedProcessingOption?: ResolvedChoiceOption | null;
+  wizardStep?: ChoiceWizardStep | null;
+};
+
+export const createProcessingMethodTransitionPatch = ({
+  nextDataTypeKey,
+  nextStep,
+  option,
+}: {
+  option: ResolvedChoiceOption;
+  nextDataTypeKey: MappingDataTypeKey;
+  nextStep: "action" | "complete";
+}): ChoiceWizardStatePatch => ({
+  currentDataTypeKey: nextDataTypeKey,
+  selectedProcessingOption: option,
+  wizardStep: nextStep === "action" ? "action" : null,
+});
+
+export const createActionTransitionPatch = ({
+  action,
+  branchConfig,
+  followUp,
+  nextDataTypeKey,
+  nextStep,
+}: {
+  action: ResolvedChoiceOption;
+  branchConfig: ChoiceBranchConfig | null;
+  followUp: ChoiceFollowUp | null;
+  nextDataTypeKey: MappingDataTypeKey;
+  nextStep: "follow-up" | "complete";
+}): ChoiceWizardStatePatch => ({
+  currentDataTypeKey: nextDataTypeKey,
+  selectedAction: action,
+  selectedBranchConfig: branchConfig,
+  selectedFollowUp: followUp,
+  wizardStep: nextStep === "follow-up" ? "follow-up" : null,
+});
+
+export const createBackToProcessingMethodPatch = ({
+  initialDataTypeKey,
+}: {
+  initialDataTypeKey: MappingDataTypeKey;
+}): ChoiceWizardStatePatch => ({
+  actionNodeId: null,
+  currentDataTypeKey: initialDataTypeKey,
+  selectedAction: null,
+  selectedBranchConfig: null,
+  selectedFollowUp: null,
+  selectedProcessingOption: null,
+  wizardStep: "processing-method",
+});
+
+export const createBackToActionPatch = (): ChoiceWizardStatePatch => ({
+  selectedAction: null,
+  selectedBranchConfig: null,
+  selectedFollowUp: null,
+  wizardStep: "action",
+});
+
+export const resolveBackToActionTargetNodeId = ({
+  actionNodeId,
+  stagingNodeId,
+}: {
+  actionNodeId: string | null;
+  stagingNodeId: string | null;
+}) => actionNodeId ?? stagingNodeId;

--- a/src/pages/workflow-editor/model/choiceWizardWorkflowGraph.ts
+++ b/src/pages/workflow-editor/model/choiceWizardWorkflowGraph.ts
@@ -1,0 +1,46 @@
+import { NODE_REGISTRY } from "@/entities/node";
+import { type FlowNodeData, type NodeType } from "@/entities/node";
+import { type WorkflowResponse } from "@/entities/workflow";
+import {
+  type WorkflowHydratedState,
+  hydrateStore,
+} from "@/features/workflow-editor";
+
+type SyncWorkflowGraph = (
+  payload: WorkflowHydratedState,
+  options?: {
+    preserveActivePanelNodeId?: boolean;
+    preserveActivePlaceholder?: boolean;
+    preserveDirty?: boolean;
+  },
+) => void;
+
+export const buildChoiceWizardNodeConfig = ({
+  type,
+  baseConfig,
+  isConfigured,
+  overrides,
+  preserveExistingConfig = false,
+}: {
+  type: NodeType;
+  baseConfig?: FlowNodeData["config"];
+  isConfigured: boolean;
+  overrides?: Partial<FlowNodeData["config"]>;
+  preserveExistingConfig?: boolean;
+}) =>
+  ({
+    ...(preserveExistingConfig
+      ? (baseConfig ?? NODE_REGISTRY[type].defaultConfig)
+      : NODE_REGISTRY[type].defaultConfig),
+    ...overrides,
+    isConfigured,
+  }) as FlowNodeData["config"];
+
+export const createChoiceWizardWorkflowSync =
+  (syncWorkflowGraph: SyncWorkflowGraph) => (workflow: WorkflowResponse) => {
+    syncWorkflowGraph(hydrateStore(workflow), {
+      preserveActivePanelNodeId: true,
+      preserveActivePlaceholder: true,
+      preserveDirty: true,
+    });
+  };

--- a/src/pages/workflow-editor/model/index.ts
+++ b/src/pages/workflow-editor/model/index.ts
@@ -1,2 +1,3 @@
 export * from "./choiceSelectionPipeline";
+export * from "./choiceWizardLogger";
 export * from "./useChoiceWizardController";

--- a/src/pages/workflow-editor/model/index.ts
+++ b/src/pages/workflow-editor/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./useChoiceWizardController";

--- a/src/pages/workflow-editor/model/index.ts
+++ b/src/pages/workflow-editor/model/index.ts
@@ -1,4 +1,5 @@
 export * from "./choiceSelectionPipeline";
 export * from "./choiceWizardLogger";
 export * from "./choiceWizardNodePersistence";
+export * from "./choiceWizardStateTransitions";
 export * from "./useChoiceWizardController";

--- a/src/pages/workflow-editor/model/index.ts
+++ b/src/pages/workflow-editor/model/index.ts
@@ -1,5 +1,1 @@
-export * from "./choiceSelectionPipeline";
-export * from "./choiceWizardLogger";
-export * from "./choiceWizardNodePersistence";
-export * from "./choiceWizardStateTransitions";
 export * from "./useChoiceWizardController";

--- a/src/pages/workflow-editor/model/index.ts
+++ b/src/pages/workflow-editor/model/index.ts
@@ -1,1 +1,2 @@
+export * from "./choiceSelectionPipeline";
 export * from "./useChoiceWizardController";

--- a/src/pages/workflow-editor/model/index.ts
+++ b/src/pages/workflow-editor/model/index.ts
@@ -1,3 +1,4 @@
 export * from "./choiceSelectionPipeline";
 export * from "./choiceWizardLogger";
+export * from "./choiceWizardNodePersistence";
 export * from "./useChoiceWizardController";

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -23,7 +23,6 @@ import {
   useWorkflowChoicesQuery,
 } from "@/entities/workflow";
 import {
-  MAPPING_NODE_TYPE_MAP,
   type ResolvedChoiceOption,
   type ResolvedChoiceResponse,
   buildFallbackChoiceResponse,
@@ -42,6 +41,11 @@ import {
   useWorkflowStore,
 } from "@/features/workflow-editor";
 
+import {
+  deriveActionSelectionIntent,
+  deriveProcessingMethodSelectionIntent,
+} from "./choiceSelectionPipeline";
+
 type WizardStep = "processing-method" | "action" | "follow-up";
 type WizardChoiceOption = ResolvedChoiceOption;
 type WizardChoiceResponse = ResolvedChoiceResponse;
@@ -58,12 +62,6 @@ type WizardNodeSnapshot = {
 
 const DEFAULT_FLOW_NODE_WIDTH = 172;
 const NODE_GAP_X = 96;
-
-const isMappingDataTypeKey = (
-  mappingRules: MappingRules,
-  value: string | null | undefined,
-): value is MappingDataTypeKey =>
-  Boolean(value && value in mappingRules.data_types);
 
 const mergeChoiceResponses = (
   primary: ChoiceResponse | null | undefined,
@@ -85,11 +83,6 @@ const buildLocalActionResponse = (
   dataTypeKey: MappingDataTypeKey,
 ): WizardChoiceResponse =>
   buildFallbackChoiceResponse(mappingRules, dataTypeKey, "action");
-
-const toChoiceNodeType = (value: string | null | undefined): NodeType =>
-  value && value in MAPPING_NODE_TYPE_MAP
-    ? MAPPING_NODE_TYPE_MAP[value as keyof typeof MAPPING_NODE_TYPE_MAP]
-    : "data-process";
 export const useChoiceWizardController = () => {
   const nodes = useWorkflowStore((state) => state.nodes);
   const edges = useWorkflowStore((state) => state.edges);
@@ -536,48 +529,36 @@ export const useChoiceWizardController = () => {
           dataType: currentDataTypeKey,
         });
 
-        const nextDataTypeKey = isMappingDataTypeKey(
+        const selectionIntent = deriveProcessingMethodSelectionIntent({
+          currentDataTypeKey,
           mappingRules,
-          selectionResult.outputDataType,
-        )
-          ? selectionResult.outputDataType
-          : isMappingDataTypeKey(mappingRules, option.output_data_type)
-            ? option.output_data_type
-            : currentDataTypeKey;
-
-        const nextActions = buildLocalActionResponse(
-          mappingRules,
-          nextDataTypeKey,
-        );
-
-        const nextNodeType = selectionResult.nodeType
-          ? toChoiceNodeType(selectionResult.nodeType)
-          : toChoiceNodeType(option.node_type);
-        const isConfigured = nextActions.options.length === 0;
+          option,
+          selectionResult,
+        });
 
         await updatePersistedNode({
           node: stagingNode,
-          type: nextNodeType,
+          type: selectionIntent.nextNodeType,
           config: buildNodeConfig({
-            type: nextNodeType,
-            isConfigured,
+            type: selectionIntent.nextNodeType,
+            isConfigured: selectionIntent.isConfigured,
           }),
           inputDataTypeKey: initialDataTypeKey,
-          outputDataTypeKey: nextDataTypeKey,
+          outputDataTypeKey: selectionIntent.nextDataTypeKey,
           role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
         });
 
         openPanel(stagingNode.id);
 
-        if (nextActions.options.length > 0) {
-          setCurrentDataTypeKey(nextDataTypeKey);
+        if (selectionIntent.nextStep === "action") {
+          setCurrentDataTypeKey(selectionIntent.nextDataTypeKey);
           setWizardStep("action");
           return;
         }
 
         finishWizard();
       } catch {
-        setWizardError("泥섎━ 諛⑹떇??諛섏쁺?섏? 紐삵뻽?듬땲??");
+        setWizardError("처리 방식을 반영하지 못했습니다.");
       }
     },
     [
@@ -613,49 +594,38 @@ export const useChoiceWizardController = () => {
           dataType: currentDataTypeKey,
         });
 
-        const nextDataTypeKey = isMappingDataTypeKey(
+        const selectionIntent = deriveActionSelectionIntent({
+          currentDataTypeKey,
           mappingRules,
-          selectionResult.outputDataType,
-        )
-          ? selectionResult.outputDataType
-          : isMappingDataTypeKey(mappingRules, action.output_data_type)
-            ? action.output_data_type
-            : currentDataTypeKey;
-
-        const followUp = selectionResult.followUp ?? action.followUp ?? null;
-        const branchConfig =
-          selectionResult.branchConfig ?? action.branchConfig ?? null;
-
-        const actionNodeType = selectionResult.nodeType
-          ? toChoiceNodeType(selectionResult.nodeType)
-          : toChoiceNodeType(action.node_type);
-        const hasFollowUp = Boolean(followUp || branchConfig);
+          option: action,
+          selectionResult,
+          stagingNodeType: stagingNode.data.type,
+        });
         const finalActionConfig = buildNodeConfig({
-          type: actionNodeType,
-          isConfigured: !hasFollowUp,
-          overrides: hasFollowUp
+          type: selectionIntent.nextNodeType,
+          isConfigured: !selectionIntent.hasFollowUp,
+          overrides: selectionIntent.hasFollowUp
             ? undefined
             : {
                 choiceActionId: action.id,
                 choiceSelections: null,
               },
         });
-        const shouldUseActionLeaf = stagingNode.data.type === "loop";
         let targetNodeId = stagingNode.id;
 
-        if (shouldUseActionLeaf) {
+        if (selectionIntent.shouldUseActionLeaf) {
           if (actionNode) {
             await updatePersistedNode({
               node: actionNode,
-              type: actionNodeType,
+              type: selectionIntent.nextNodeType,
               config: finalActionConfig,
               inputDataTypeKey: currentDataTypeKey,
-              outputDataTypeKey: nextDataTypeKey,
+              outputDataTypeKey: selectionIntent.nextDataTypeKey,
             });
             targetNodeId = actionNode.id;
           } else {
             const createdActionNodeId = await placeWorkflowNode({
-              type: actionNodeType,
+              type: selectionIntent.nextNodeType,
               sourceNodeId: stagingNode.id,
               position: {
                 x:
@@ -663,7 +633,7 @@ export const useChoiceWizardController = () => {
                 y: stagingNode.position.y,
               },
               inputDataTypeKey: currentDataTypeKey,
-              outputDataTypeKey: nextDataTypeKey,
+              outputDataTypeKey: selectionIntent.nextDataTypeKey,
               config: finalActionConfig,
             });
 
@@ -682,22 +652,22 @@ export const useChoiceWizardController = () => {
         } else {
           await updatePersistedNode({
             node: stagingNode,
-            type: actionNodeType,
+            type: selectionIntent.nextNodeType,
             config: finalActionConfig,
             inputDataTypeKey: currentDataTypeKey,
-            outputDataTypeKey: nextDataTypeKey,
+            outputDataTypeKey: selectionIntent.nextDataTypeKey,
             role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
           });
           setActionNodeId(null);
         }
 
         setSelectedAction(action);
-        setSelectedFollowUp(followUp);
-        setSelectedBranchConfig(branchConfig);
-        setCurrentDataTypeKey(nextDataTypeKey);
+        setSelectedFollowUp(selectionIntent.followUp);
+        setSelectedBranchConfig(selectionIntent.branchConfig);
+        setCurrentDataTypeKey(selectionIntent.nextDataTypeKey);
         openPanel(targetNodeId);
 
-        if (followUp || branchConfig) {
+        if (selectionIntent.nextStep === "follow-up") {
           setWizardStep("follow-up");
           return;
         }

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -38,8 +38,16 @@ import {
   createChoiceWizardNodePersistence,
   toSnapshotDataTypeKey,
 } from "./choiceWizardNodePersistence";
+import {
+  type ChoiceWizardStatePatch,
+  type ChoiceWizardStep,
+  createActionTransitionPatch,
+  createBackToActionPatch,
+  createBackToProcessingMethodPatch,
+  createProcessingMethodTransitionPatch,
+  resolveBackToActionTargetNodeId,
+} from "./choiceWizardStateTransitions";
 
-type WizardStep = "processing-method" | "action" | "follow-up";
 type WizardChoiceOption = ResolvedChoiceOption;
 
 const DEFAULT_FLOW_NODE_WIDTH = 172;
@@ -75,7 +83,7 @@ export const useChoiceWizardController = () => {
     [mappingRulesResponse],
   );
 
-  const [wizardStep, setWizardStep] = useState<WizardStep | null>(null);
+  const [wizardStep, setWizardStep] = useState<ChoiceWizardStep | null>(null);
   const [initialDataTypeKey, setInitialDataTypeKey] =
     useState<MappingDataTypeKey | null>(null);
   const [currentDataTypeKey, setCurrentDataTypeKey] =
@@ -97,6 +105,30 @@ export const useChoiceWizardController = () => {
     string[]
   >([]);
   const [wizardError, setWizardError] = useState<string | null>(null);
+
+  const applyWizardStatePatch = useCallback((patch: ChoiceWizardStatePatch) => {
+    if ("actionNodeId" in patch) {
+      setActionNodeId(patch.actionNodeId ?? null);
+    }
+    if ("currentDataTypeKey" in patch) {
+      setCurrentDataTypeKey(patch.currentDataTypeKey ?? null);
+    }
+    if ("selectedAction" in patch) {
+      setSelectedAction(patch.selectedAction ?? null);
+    }
+    if ("selectedBranchConfig" in patch) {
+      setSelectedBranchConfig(patch.selectedBranchConfig ?? null);
+    }
+    if ("selectedFollowUp" in patch) {
+      setSelectedFollowUp(patch.selectedFollowUp ?? null);
+    }
+    if ("selectedProcessingOption" in patch) {
+      setSelectedProcessingOption(patch.selectedProcessingOption ?? null);
+    }
+    if ("wizardStep" in patch) {
+      setWizardStep(patch.wizardStep ?? null);
+    }
+  }, []);
 
   const reset = useCallback(() => {
     setWizardStep(null);
@@ -383,9 +415,15 @@ export const useChoiceWizardController = () => {
 
         openPanel(stagingNode.id);
 
+        applyWizardStatePatch(
+          createProcessingMethodTransitionPatch({
+            option,
+            nextDataTypeKey: selectionIntent.nextDataTypeKey,
+            nextStep: selectionIntent.nextStep,
+          }),
+        );
+
         if (selectionIntent.nextStep === "action") {
-          setCurrentDataTypeKey(selectionIntent.nextDataTypeKey);
-          setWizardStep("action");
           return;
         }
 
@@ -411,6 +449,7 @@ export const useChoiceWizardController = () => {
       finishWizard,
       initialDataTypeKey,
       mappingRules,
+      applyWizardStatePatch,
       openPanel,
       resolveNodeRole,
       rootParentNodeId,
@@ -520,14 +559,18 @@ export const useChoiceWizardController = () => {
           setActionNodeId(null);
         }
 
-        setSelectedAction(action);
-        setSelectedFollowUp(selectionIntent.followUp);
-        setSelectedBranchConfig(selectionIntent.branchConfig);
-        setCurrentDataTypeKey(selectionIntent.nextDataTypeKey);
+        applyWizardStatePatch(
+          createActionTransitionPatch({
+            action,
+            branchConfig: selectionIntent.branchConfig,
+            followUp: selectionIntent.followUp,
+            nextDataTypeKey: selectionIntent.nextDataTypeKey,
+            nextStep: selectionIntent.nextStep,
+          }),
+        );
         openPanel(targetNodeId);
 
         if (selectionIntent.nextStep === "follow-up") {
-          setWizardStep("follow-up");
           return;
         }
 
@@ -552,6 +595,7 @@ export const useChoiceWizardController = () => {
       currentDataTypeKey,
       finishWizard,
       mappingRules,
+      applyWizardStatePatch,
       openPanel,
       placeWorkflowNode,
       resolveNodeRole,
@@ -609,13 +653,11 @@ export const useChoiceWizardController = () => {
       });
 
       openPanel(stagingNode.id);
-      setActionNodeId(null);
-      setSelectedAction(null);
-      setSelectedFollowUp(null);
-      setSelectedBranchConfig(null);
-      setSelectedProcessingOption(null);
-      setCurrentDataTypeKey(initialDataTypeKey);
-      setWizardStep("processing-method");
+      applyWizardStatePatch(
+        createBackToProcessingMethodPatch({
+          initialDataTypeKey,
+        }),
+      );
     } catch {
       setWizardError("이전 단계로 돌아가지 못했습니다.");
     }
@@ -626,6 +668,7 @@ export const useChoiceWizardController = () => {
     edges,
     initialDataTypeKey,
     openPanel,
+    applyWizardStatePatch,
     resolveNodeRole,
     removeWorkflowNode,
     sessionOwnedLeafNodeIds,
@@ -635,18 +678,18 @@ export const useChoiceWizardController = () => {
   ]);
 
   const backToAction = useCallback(() => {
-    const targetNodeId = actionNodeId ?? stagingNodeId;
+    const targetNodeId = resolveBackToActionTargetNodeId({
+      actionNodeId,
+      stagingNodeId,
+    });
     if (!targetNodeId) {
       return;
     }
 
     setWizardError(null);
     openPanel(targetNodeId);
-    setSelectedAction(null);
-    setSelectedFollowUp(null);
-    setSelectedBranchConfig(null);
-    setWizardStep("action");
-  }, [actionNodeId, openPanel, stagingNodeId]);
+    applyWizardStatePatch(createBackToActionPatch());
+  }, [actionNodeId, applyWizardStatePatch, openPanel, stagingNodeId]);
 
   const completeFollowUp = useCallback(
     async (selections: Record<string, string | string[]>) => {

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -1,11 +1,9 @@
 ﻿import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { NODE_REGISTRY } from "@/entities/node";
-import { type FlowNodeData, type NodeType } from "@/entities/node";
+import { type FlowNodeData } from "@/entities/node";
 import {
   type ChoiceBranchConfig,
   type ChoiceFollowUp,
-  type WorkflowResponse,
   useAddWorkflowNodeMutation,
   useDeleteWorkflowNodeMutation,
   useMappingRulesQuery,
@@ -22,7 +20,6 @@ import {
 } from "@/features/choice-panel";
 import { type MappingDataTypeKey } from "@/features/choice-panel";
 import {
-  hydrateStore,
   isMiddleWizardPending,
   useWorkflowStore,
 } from "@/features/workflow-editor";
@@ -47,6 +44,10 @@ import {
   createProcessingMethodTransitionPatch,
   resolveBackToActionTargetNodeId,
 } from "./choiceWizardStateTransitions";
+import {
+  buildChoiceWizardNodeConfig,
+  createChoiceWizardWorkflowSync,
+} from "./choiceWizardWorkflowGraph";
 
 type WizardChoiceOption = ResolvedChoiceOption;
 
@@ -250,38 +251,8 @@ export const useChoiceWizardController = () => {
     isUpdateNodePending ||
     isSelectChoicePending;
 
-  const buildNodeConfig = useCallback(
-    ({
-      type,
-      baseConfig,
-      isConfigured,
-      overrides,
-      preserveExistingConfig = false,
-    }: {
-      type: NodeType;
-      baseConfig?: FlowNodeData["config"];
-      isConfigured: boolean;
-      overrides?: Partial<FlowNodeData["config"]>;
-      preserveExistingConfig?: boolean;
-    }) =>
-      ({
-        ...(preserveExistingConfig
-          ? (baseConfig ?? NODE_REGISTRY[type].defaultConfig)
-          : NODE_REGISTRY[type].defaultConfig),
-        ...overrides,
-        isConfigured,
-      }) as FlowNodeData["config"],
-    [],
-  );
-
-  const syncWorkflowFromResponse = useCallback(
-    (workflow: WorkflowResponse) => {
-      syncWorkflowGraph(hydrateStore(workflow), {
-        preserveActivePanelNodeId: true,
-        preserveActivePlaceholder: true,
-        preserveDirty: true,
-      });
-    },
+  const syncWorkflowFromResponse = useMemo(
+    () => createChoiceWizardWorkflowSync(syncWorkflowGraph),
     [syncWorkflowGraph],
   );
   const { placeWorkflowNode, removeWorkflowNode, updatePersistedNode } =
@@ -404,7 +375,7 @@ export const useChoiceWizardController = () => {
         await updatePersistedNode({
           node: stagingNode,
           type: selectionIntent.nextNodeType,
-          config: buildNodeConfig({
+          config: buildChoiceWizardNodeConfig({
             type: selectionIntent.nextNodeType,
             isConfigured: selectionIntent.isConfigured,
           }),
@@ -444,7 +415,6 @@ export const useChoiceWizardController = () => {
     },
     [
       baseStagingSnapshot?.role,
-      buildNodeConfig,
       currentDataTypeKey,
       finishWizard,
       initialDataTypeKey,
@@ -499,7 +469,7 @@ export const useChoiceWizardController = () => {
           optionId: action.id,
           step: wizardStep,
         });
-        const finalActionConfig = buildNodeConfig({
+        const finalActionConfig = buildChoiceWizardNodeConfig({
           type: selectionIntent.nextNodeType,
           isConfigured: !selectionIntent.hasFollowUp,
           overrides: selectionIntent.hasFollowUp
@@ -591,7 +561,6 @@ export const useChoiceWizardController = () => {
     [
       actionNode,
       baseStagingSnapshot?.role,
-      buildNodeConfig,
       currentDataTypeKey,
       finishWizard,
       mappingRules,
@@ -704,7 +673,7 @@ export const useChoiceWizardController = () => {
         await updatePersistedNode({
           node: targetNode,
           type: targetNode.data.type,
-          config: buildNodeConfig({
+          config: buildChoiceWizardNodeConfig({
             type: targetNode.data.type,
             baseConfig: targetNode.data.config,
             isConfigured: true,
@@ -750,7 +719,6 @@ export const useChoiceWizardController = () => {
     [
       actionNode,
       baseStagingSnapshot?.role,
-      buildNodeConfig,
       finishWizard,
       openPanel,
       resolveNodeRole,

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -28,6 +28,10 @@ import {
   deriveActionSelectionIntent,
   deriveProcessingMethodSelectionIntent,
 } from "./choiceSelectionPipeline";
+import {
+  deriveChoiceQueryContext,
+  deriveChoiceSelectContext,
+} from "./choiceWizardContext";
 import { logChoiceWizardEvent } from "./choiceWizardLogger";
 import {
   type WizardNodeSnapshot,
@@ -98,6 +102,7 @@ export const useChoiceWizardController = () => {
   const [selectedBranchConfig, setSelectedBranchConfig] =
     useState<ChoiceBranchConfig | null>(null);
   const [stagingNodeId, setStagingNodeId] = useState<string | null>(null);
+  const [anchorNodeId, setAnchorNodeId] = useState<string | null>(null);
   const [rootParentNodeId, setRootParentNodeId] = useState<string | null>(null);
   const [baseStagingSnapshot, setBaseStagingSnapshot] =
     useState<WizardNodeSnapshot | null>(null);
@@ -140,6 +145,7 @@ export const useChoiceWizardController = () => {
     setSelectedFollowUp(null);
     setSelectedBranchConfig(null);
     setStagingNodeId(null);
+    setAnchorNodeId(null);
     setRootParentNodeId(null);
     setBaseStagingSnapshot(null);
     setActionNodeId(null);
@@ -207,6 +213,27 @@ export const useChoiceWizardController = () => {
     startNodeId,
     endNodeId,
   );
+  const activeChoiceAnchorNodeId = isWizardMode
+    ? (anchorNodeId ?? parentNode?.id ?? null)
+    : null;
+  const choiceQueryContext = useMemo(
+    () =>
+      deriveChoiceQueryContext({
+        anchorNodeId: activeChoiceAnchorNodeId,
+        edges,
+        nodes,
+      }),
+    [activeChoiceAnchorNodeId, edges, nodes],
+  );
+  const getChoiceSelectContext = useCallback(
+    (anchorNodeId: string | null) =>
+      deriveChoiceSelectContext({
+        anchorNodeId,
+        edges,
+        nodes,
+      }),
+    [edges, nodes],
+  );
 
   const {
     data: serverChoiceResponse,
@@ -214,35 +241,68 @@ export const useChoiceWizardController = () => {
     isError: isChoicesError,
   } = useWorkflowChoicesQuery(
     workflowId || undefined,
-    isWizardMode ? (parentNode?.id ?? null) : null,
+    activeChoiceAnchorNodeId,
+    choiceQueryContext,
     isWizardMode,
   );
+  const allowChoiceFallback = isChoicesError && !serverChoiceResponse;
+  const isInitialChoiceStep =
+    wizardStep === null || wizardStep === "processing-method";
 
   const { choice: initialChoiceResponse, source: initialChoiceSource } =
     useMemo(
       () =>
         resolveInitialChoiceResponse({
+          allowFallback: isInitialChoiceStep ? allowChoiceFallback : false,
           mappingRules,
           dataTypeKey: initialDataTypeKey,
-          serverChoice: serverChoiceResponse,
+          serverChoice: isInitialChoiceStep ? serverChoiceResponse : null,
         }),
-      [initialDataTypeKey, mappingRules, serverChoiceResponse],
+      [
+        allowChoiceFallback,
+        initialDataTypeKey,
+        isInitialChoiceStep,
+        mappingRules,
+        serverChoiceResponse,
+      ],
     );
-  const activeActionChoiceResponse = useMemo(
+  const {
+    choice: activeActionChoiceResponse,
+    source: activeActionChoiceSource,
+  } = useMemo(
     () =>
       resolveActionChoiceResponse({
+        allowFallback: wizardStep === "action" ? allowChoiceFallback : false,
         mappingRules,
         currentDataTypeKey,
-        initialChoiceResponse,
-        initialDataTypeKey,
+        serverChoice: wizardStep === "action" ? serverChoiceResponse : null,
       }),
     [
+      allowChoiceFallback,
       currentDataTypeKey,
-      initialChoiceResponse,
-      initialDataTypeKey,
       mappingRules,
+      serverChoiceResponse,
+      wizardStep,
     ],
   );
+  const isChoiceStep =
+    isWizardMode &&
+    (wizardStep === null ||
+      wizardStep === "processing-method" ||
+      wizardStep === "action");
+  const currentChoiceResponse =
+    wizardStep === "action"
+      ? activeActionChoiceResponse
+      : initialChoiceResponse;
+  const hasChoiceStepContent = Boolean(currentChoiceResponse);
+  const isChoiceStepLoading =
+    isChoiceStep && !hasChoiceStepContent && !isChoicesError;
+  const isChoiceStepUnavailable =
+    isChoiceStep && !hasChoiceStepContent && isChoicesError;
+  const isUsingChoiceFallback =
+    (wizardStep === "action"
+      ? activeActionChoiceSource
+      : initialChoiceSource) === "fallback";
 
   const isWorkflowBusy =
     isChoicesLoading ||
@@ -288,6 +348,7 @@ export const useChoiceWizardController = () => {
 
     const mappingKey = toMappingKey(parentOutputType);
     setStagingNodeId(activeNode.id);
+    setAnchorNodeId(parentNode.id);
     setRootParentNodeId(parentNode.id);
     setBaseStagingSnapshot(createSnapshot(activeNode));
     setInitialDataTypeKey(mappingKey);
@@ -310,7 +371,7 @@ export const useChoiceWizardController = () => {
       : "action";
 
     logChoiceWizardEvent({
-      anchorNodeId: parentNode?.id ?? null,
+      anchorNodeId: activeChoiceAnchorNodeId,
       event: "wizard-open",
       nextStep,
       source: initialChoiceSource,
@@ -320,8 +381,8 @@ export const useChoiceWizardController = () => {
   }, [
     initialChoiceResponse,
     initialChoiceSource,
+    activeChoiceAnchorNodeId,
     isWizardMode,
-    parentNode?.id,
     wizardStep,
   ]);
 
@@ -331,9 +392,10 @@ export const useChoiceWizardController = () => {
 
   const selectProcessingMethod = useCallback(
     async (option: WizardChoiceOption) => {
+      const currentAnchorNodeId = anchorNodeId ?? rootParentNodeId;
       if (
         !stagingNode ||
-        !rootParentNodeId ||
+        !currentAnchorNodeId ||
         !currentDataTypeKey ||
         !initialDataTypeKey
       ) {
@@ -346,8 +408,9 @@ export const useChoiceWizardController = () => {
       try {
         const selectionResult = await selectWorkflowChoice({
           workflowId,
-          prevNodeId: rootParentNodeId,
+          prevNodeId: currentAnchorNodeId,
           optionId: option.id,
+          context: getChoiceSelectContext(currentAnchorNodeId),
           transport: {
             dataType: currentDataTypeKey,
           },
@@ -361,7 +424,7 @@ export const useChoiceWizardController = () => {
         });
 
         logChoiceWizardEvent({
-          anchorNodeId: rootParentNodeId,
+          anchorNodeId: currentAnchorNodeId,
           details: {
             outputDataType: selectionIntent.nextDataTypeKey,
           },
@@ -372,7 +435,7 @@ export const useChoiceWizardController = () => {
           targetNodeId: stagingNode.id,
         });
 
-        await updatePersistedNode({
+        const updatedNodeId = await updatePersistedNode({
           node: stagingNode,
           type: selectionIntent.nextNodeType,
           config: buildChoiceWizardNodeConfig({
@@ -384,6 +447,7 @@ export const useChoiceWizardController = () => {
           role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
         });
 
+        setAnchorNodeId(updatedNodeId);
         openPanel(stagingNode.id);
 
         applyWizardStatePatch(
@@ -401,7 +465,7 @@ export const useChoiceWizardController = () => {
         finishWizard();
       } catch {
         logChoiceWizardEvent({
-          anchorNodeId: rootParentNodeId,
+          anchorNodeId: currentAnchorNodeId,
           details: {
             message: "processing-method-persist-failed",
           },
@@ -414,9 +478,11 @@ export const useChoiceWizardController = () => {
       }
     },
     [
+      anchorNodeId,
       baseStagingSnapshot?.role,
       currentDataTypeKey,
       finishWizard,
+      getChoiceSelectContext,
       initialDataTypeKey,
       mappingRules,
       applyWizardStatePatch,
@@ -433,7 +499,8 @@ export const useChoiceWizardController = () => {
 
   const selectAction = useCallback(
     async (action: WizardChoiceOption) => {
-      if (!stagingNode || !rootParentNodeId || !currentDataTypeKey) {
+      const currentAnchorNodeId = anchorNodeId ?? rootParentNodeId;
+      if (!stagingNode || !currentAnchorNodeId || !currentDataTypeKey) {
         return;
       }
 
@@ -442,8 +509,9 @@ export const useChoiceWizardController = () => {
       try {
         const selectionResult = await selectWorkflowChoice({
           workflowId,
-          prevNodeId: rootParentNodeId,
+          prevNodeId: currentAnchorNodeId,
           optionId: action.id,
+          context: getChoiceSelectContext(currentAnchorNodeId),
           transport: {
             dataType: currentDataTypeKey,
           },
@@ -458,7 +526,7 @@ export const useChoiceWizardController = () => {
         });
 
         logChoiceWizardEvent({
-          anchorNodeId: rootParentNodeId,
+          anchorNodeId: currentAnchorNodeId,
           details: {
             hasFollowUp: selectionIntent.hasFollowUp,
             outputDataType: selectionIntent.nextDataTypeKey,
@@ -491,6 +559,7 @@ export const useChoiceWizardController = () => {
               outputDataTypeKey: selectionIntent.nextDataTypeKey,
             });
             targetNodeId = actionNode.id;
+            setAnchorNodeId(actionNode.id);
           } else {
             const createdActionNodeId = await placeWorkflowNode({
               type: selectionIntent.nextNodeType,
@@ -503,6 +572,7 @@ export const useChoiceWizardController = () => {
               inputDataTypeKey: currentDataTypeKey,
               outputDataTypeKey: selectionIntent.nextDataTypeKey,
               config: finalActionConfig,
+              previousNodes: nodes,
             });
 
             if (!createdActionNodeId) {
@@ -516,9 +586,10 @@ export const useChoiceWizardController = () => {
                 : [...current, createdActionNodeId],
             );
             targetNodeId = createdActionNodeId;
+            setAnchorNodeId(createdActionNodeId);
           }
         } else {
-          await updatePersistedNode({
+          const updatedNodeId = await updatePersistedNode({
             node: stagingNode,
             type: selectionIntent.nextNodeType,
             config: finalActionConfig,
@@ -527,6 +598,7 @@ export const useChoiceWizardController = () => {
             role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
           });
           setActionNodeId(null);
+          setAnchorNodeId(updatedNodeId);
         }
 
         applyWizardStatePatch(
@@ -547,7 +619,7 @@ export const useChoiceWizardController = () => {
         finishWizard();
       } catch {
         logChoiceWizardEvent({
-          anchorNodeId: rootParentNodeId,
+          anchorNodeId: currentAnchorNodeId,
           details: {
             message: "action-persist-failed",
           },
@@ -560,11 +632,14 @@ export const useChoiceWizardController = () => {
     },
     [
       actionNode,
+      anchorNodeId,
       baseStagingSnapshot?.role,
       currentDataTypeKey,
       finishWizard,
+      getChoiceSelectContext,
       mappingRules,
       applyWizardStatePatch,
+      nodes,
       openPanel,
       placeWorkflowNode,
       resolveNodeRole,
@@ -621,6 +696,7 @@ export const useChoiceWizardController = () => {
         role: baseStagingSnapshot.role,
       });
 
+      setAnchorNodeId(rootParentNodeId);
       openPanel(stagingNode.id);
       applyWizardStatePatch(
         createBackToProcessingMethodPatch({
@@ -640,6 +716,7 @@ export const useChoiceWizardController = () => {
     applyWizardStatePatch,
     resolveNodeRole,
     removeWorkflowNode,
+    rootParentNodeId,
     sessionOwnedLeafNodeIds,
     stagingNode,
     stagingNodeId,
@@ -656,6 +733,7 @@ export const useChoiceWizardController = () => {
     }
 
     setWizardError(null);
+    setAnchorNodeId(targetNodeId);
     openPanel(targetNodeId);
     applyWizardStatePatch(createBackToActionPatch());
   }, [actionNodeId, applyWizardStatePatch, openPanel, stagingNodeId]);
@@ -690,7 +768,7 @@ export const useChoiceWizardController = () => {
         });
 
         logChoiceWizardEvent({
-          anchorNodeId: rootParentNodeId,
+          anchorNodeId: anchorNodeId ?? rootParentNodeId,
           details: {
             selectionKeys: Object.keys(selections),
           },
@@ -700,11 +778,12 @@ export const useChoiceWizardController = () => {
           step: wizardStep,
           targetNodeId: targetNode.id,
         });
+        setAnchorNodeId(targetNode.id);
         openPanel(targetNode.id);
         finishWizard();
       } catch {
         logChoiceWizardEvent({
-          anchorNodeId: rootParentNodeId,
+          anchorNodeId: anchorNodeId ?? rootParentNodeId,
           details: {
             message: "follow-up-persist-failed",
           },
@@ -718,6 +797,7 @@ export const useChoiceWizardController = () => {
     },
     [
       actionNode,
+      anchorNodeId,
       baseStagingSnapshot?.role,
       finishWizard,
       openPanel,
@@ -740,6 +820,9 @@ export const useChoiceWizardController = () => {
     selectedBranchConfig,
     wizardError,
     isWorkflowBusy,
+    isChoiceStepLoading,
+    isChoiceStepUnavailable,
+    isUsingChoiceFallback,
     isChoicesError,
     serverChoiceResponse,
     selectProcessingMethod,

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -545,7 +545,9 @@ export const useChoiceWizardController = () => {
           workflowId,
           prevNodeId: rootParentNodeId,
           optionId: option.id,
-          dataType: currentDataTypeKey,
+          transport: {
+            dataType: currentDataTypeKey,
+          },
         });
 
         const selectionIntent = deriveProcessingMethodSelectionIntent({
@@ -633,7 +635,9 @@ export const useChoiceWizardController = () => {
           workflowId,
           prevNodeId: rootParentNodeId,
           optionId: action.id,
-          dataType: currentDataTypeKey,
+          transport: {
+            dataType: currentDataTypeKey,
+          },
         });
 
         const selectionIntent = deriveActionSelectionIntent({

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { NODE_REGISTRY } from "@/entities/node";
 import {
@@ -9,7 +9,6 @@ import {
 import {
   type ChoiceBranchConfig,
   type ChoiceFollowUp,
-  type ChoiceOption,
   type ChoiceResponse,
   type WorkflowResponse,
   findAddedNodeId,
@@ -25,14 +24,15 @@ import {
 } from "@/entities/workflow";
 import {
   MAPPING_NODE_TYPE_MAP,
+  type ResolvedChoiceOption,
+  type ResolvedChoiceResponse,
+  buildFallbackChoiceResponse,
+  resolveChoiceResponse,
   toChoiceMappingRules,
   toDataType,
   toMappingKey,
 } from "@/features/choice-panel";
 import {
-  type BranchConfig,
-  type FollowUp,
-  type MappingAction,
   type MappingDataTypeKey,
   type MappingRules,
 } from "@/features/choice-panel";
@@ -43,19 +43,8 @@ import {
 } from "@/features/workflow-editor";
 
 type WizardStep = "processing-method" | "action" | "follow-up";
-
-type WizardChoiceOption = ChoiceOption & {
-  description?: string;
-  followUp?: ChoiceFollowUp | null;
-  branchConfig?: ChoiceBranchConfig | null;
-};
-
-type WizardChoiceResponse = {
-  question: string;
-  options: WizardChoiceOption[];
-  requiresProcessingMethod: boolean;
-  multiSelect?: boolean | null;
-};
+type WizardChoiceOption = ResolvedChoiceOption;
+type WizardChoiceResponse = ResolvedChoiceResponse;
 
 type WizardNodeSnapshot = {
   authWarning?: boolean;
@@ -76,138 +65,31 @@ const isMappingDataTypeKey = (
 ): value is MappingDataTypeKey =>
   Boolean(value && value in mappingRules.data_types);
 
-const toChoiceFollowUp = (followUp: FollowUp | null | undefined) =>
-  followUp
-    ? {
-        question: followUp.question,
-        options: (followUp.options ?? []).map((option) => ({
-          id: option.id,
-          label: option.label,
-          type: option.type ?? null,
-        })),
-        options_source: followUp.options_source ?? null,
-        multi_select: followUp.multi_select ?? null,
-        description: followUp.description ?? null,
-      }
-    : null;
-
-const toChoiceBranchConfig = (branchConfig: BranchConfig | null | undefined) =>
-  branchConfig
-    ? {
-        question: branchConfig.question,
-        options: (branchConfig.options ?? []).map((option) => ({
-          id: option.id,
-          label: option.label,
-          type: option.type ?? null,
-        })),
-        options_source: branchConfig.options_source ?? null,
-        multi_select: branchConfig.multi_select ?? null,
-        description: branchConfig.description ?? null,
-      }
-    : null;
-
-const toWizardChoiceOption = (
-  option: ChoiceOption | MappingAction,
-): WizardChoiceOption => ({
-  id: option.id,
-  label: option.label,
-  type: "type" in option ? (option.type ?? null) : null,
-  node_type: "node_type" in option ? (option.node_type ?? null) : null,
-  output_data_type:
-    "output_data_type" in option ? (option.output_data_type ?? null) : null,
-  priority: "priority" in option ? (option.priority ?? null) : null,
-  description: "description" in option ? option.description : undefined,
-  followUp:
-    "follow_up" in option ? toChoiceFollowUp(option.follow_up ?? null) : null,
-  branchConfig:
-    "branch_config" in option
-      ? toChoiceBranchConfig(option.branch_config ?? null)
-      : null,
-});
-
 const mergeChoiceResponses = (
   primary: ChoiceResponse | null | undefined,
   fallback: WizardChoiceResponse | null,
-): WizardChoiceResponse | null => {
-  if (!primary && !fallback) {
-    return null;
-  }
-
-  if (!primary) {
-    return fallback;
-  }
-
-  const normalizedPrimary: WizardChoiceResponse = {
-    question: primary.question,
-    options: primary.options.map(toWizardChoiceOption),
-    requiresProcessingMethod: primary.requiresProcessingMethod,
-    multiSelect: primary.multiSelect ?? null,
-  };
-
-  if (!fallback) {
-    return normalizedPrimary;
-  }
-
-  const fallbackOptionMap = new Map(
-    fallback.options.map((option) => [option.id, option]),
-  );
-
-  return {
-    question: normalizedPrimary.question || fallback.question,
-    requiresProcessingMethod: normalizedPrimary.requiresProcessingMethod,
-    multiSelect: normalizedPrimary.multiSelect ?? fallback.multiSelect ?? null,
-    options:
-      normalizedPrimary.options.length > 0
-        ? normalizedPrimary.options.map((option) => ({
-            ...fallbackOptionMap.get(option.id),
-            ...option,
-          }))
-        : fallback.options,
-  };
-};
+): WizardChoiceResponse | null =>
+  resolveChoiceResponse({
+    serverChoice: primary,
+    fallbackChoice: fallback,
+  });
 
 const buildLocalChoiceResponse = (
   mappingRules: MappingRules,
   dataTypeKey: MappingDataTypeKey,
-): WizardChoiceResponse => {
-  const config = mappingRules.data_types[dataTypeKey];
-
-  if (config.requires_processing_method && config.processing_method) {
-    return {
-      question: config.processing_method.question,
-      options: config.processing_method.options.map(toWizardChoiceOption),
-      requiresProcessingMethod: true,
-      multiSelect: null,
-    };
-  }
-
-  return {
-    question: `${config.label}를 어떻게 처리할까요?`,
-    options: config.actions.map(toWizardChoiceOption),
-    requiresProcessingMethod: false,
-    multiSelect: null,
-  };
-};
+): WizardChoiceResponse =>
+  buildFallbackChoiceResponse(mappingRules, dataTypeKey, "initial");
 
 const buildLocalActionResponse = (
   mappingRules: MappingRules,
   dataTypeKey: MappingDataTypeKey,
-): WizardChoiceResponse => {
-  const config = mappingRules.data_types[dataTypeKey];
-
-  return {
-    question: `${config.label}를 어떻게 처리할까요?`,
-    options: config.actions.map(toWizardChoiceOption),
-    requiresProcessingMethod: false,
-    multiSelect: null,
-  };
-};
+): WizardChoiceResponse =>
+  buildFallbackChoiceResponse(mappingRules, dataTypeKey, "action");
 
 const toChoiceNodeType = (value: string | null | undefined): NodeType =>
   value && value in MAPPING_NODE_TYPE_MAP
     ? MAPPING_NODE_TYPE_MAP[value as keyof typeof MAPPING_NODE_TYPE_MAP]
     : "data-process";
-
 export const useChoiceWizardController = () => {
   const nodes = useWorkflowStore((state) => state.nodes);
   const edges = useWorkflowStore((state) => state.edges);
@@ -695,7 +577,7 @@ export const useChoiceWizardController = () => {
 
         finishWizard();
       } catch {
-        setWizardError("처리 방식을 반영하지 못했습니다.");
+        setWizardError("泥섎━ 諛⑹떇??諛섏쁺?섏? 紐삵뻽?듬땲??");
       }
     },
     [

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -1,0 +1,986 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { NODE_REGISTRY } from "@/entities/node";
+import {
+  type DataType,
+  type FlowNodeData,
+  type NodeType,
+} from "@/entities/node";
+import {
+  type ChoiceBranchConfig,
+  type ChoiceFollowUp,
+  type ChoiceOption,
+  type ChoiceResponse,
+  type WorkflowResponse,
+  findAddedNodeId,
+  toBackendDataType,
+  toBackendNodeType,
+  toNodeAddRequest,
+  useAddWorkflowNodeMutation,
+  useDeleteWorkflowNodeMutation,
+  useMappingRulesQuery,
+  useSelectWorkflowChoiceMutation,
+  useUpdateWorkflowNodeMutation,
+  useWorkflowChoicesQuery,
+} from "@/entities/workflow";
+import {
+  MAPPING_NODE_TYPE_MAP,
+  toChoiceMappingRules,
+  toDataType,
+  toMappingKey,
+} from "@/features/choice-panel";
+import {
+  type BranchConfig,
+  type FollowUp,
+  type MappingAction,
+  type MappingDataTypeKey,
+  type MappingRules,
+} from "@/features/choice-panel";
+import {
+  hydrateStore,
+  isMiddleWizardPending,
+  useWorkflowStore,
+} from "@/features/workflow-editor";
+
+type WizardStep = "processing-method" | "action" | "follow-up";
+
+type WizardChoiceOption = ChoiceOption & {
+  description?: string;
+  followUp?: ChoiceFollowUp | null;
+  branchConfig?: ChoiceBranchConfig | null;
+};
+
+type WizardChoiceResponse = {
+  question: string;
+  options: WizardChoiceOption[];
+  requiresProcessingMethod: boolean;
+  multiSelect?: boolean | null;
+};
+
+type WizardNodeSnapshot = {
+  authWarning?: boolean;
+  config: FlowNodeData["config"];
+  inputTypes: DataType[];
+  outputTypes: DataType[];
+  position: { x: number; y: number };
+  role: "start" | "middle" | "end";
+  type: NodeType;
+};
+
+const DEFAULT_FLOW_NODE_WIDTH = 172;
+const NODE_GAP_X = 96;
+
+const isMappingDataTypeKey = (
+  mappingRules: MappingRules,
+  value: string | null | undefined,
+): value is MappingDataTypeKey =>
+  Boolean(value && value in mappingRules.data_types);
+
+const toChoiceFollowUp = (followUp: FollowUp | null | undefined) =>
+  followUp
+    ? {
+        question: followUp.question,
+        options: (followUp.options ?? []).map((option) => ({
+          id: option.id,
+          label: option.label,
+          type: option.type ?? null,
+        })),
+        options_source: followUp.options_source ?? null,
+        multi_select: followUp.multi_select ?? null,
+        description: followUp.description ?? null,
+      }
+    : null;
+
+const toChoiceBranchConfig = (branchConfig: BranchConfig | null | undefined) =>
+  branchConfig
+    ? {
+        question: branchConfig.question,
+        options: (branchConfig.options ?? []).map((option) => ({
+          id: option.id,
+          label: option.label,
+          type: option.type ?? null,
+        })),
+        options_source: branchConfig.options_source ?? null,
+        multi_select: branchConfig.multi_select ?? null,
+        description: branchConfig.description ?? null,
+      }
+    : null;
+
+const toWizardChoiceOption = (
+  option: ChoiceOption | MappingAction,
+): WizardChoiceOption => ({
+  id: option.id,
+  label: option.label,
+  type: "type" in option ? (option.type ?? null) : null,
+  node_type: "node_type" in option ? (option.node_type ?? null) : null,
+  output_data_type:
+    "output_data_type" in option ? (option.output_data_type ?? null) : null,
+  priority: "priority" in option ? (option.priority ?? null) : null,
+  description: "description" in option ? option.description : undefined,
+  followUp:
+    "follow_up" in option ? toChoiceFollowUp(option.follow_up ?? null) : null,
+  branchConfig:
+    "branch_config" in option
+      ? toChoiceBranchConfig(option.branch_config ?? null)
+      : null,
+});
+
+const mergeChoiceResponses = (
+  primary: ChoiceResponse | null | undefined,
+  fallback: WizardChoiceResponse | null,
+): WizardChoiceResponse | null => {
+  if (!primary && !fallback) {
+    return null;
+  }
+
+  if (!primary) {
+    return fallback;
+  }
+
+  const normalizedPrimary: WizardChoiceResponse = {
+    question: primary.question,
+    options: primary.options.map(toWizardChoiceOption),
+    requiresProcessingMethod: primary.requiresProcessingMethod,
+    multiSelect: primary.multiSelect ?? null,
+  };
+
+  if (!fallback) {
+    return normalizedPrimary;
+  }
+
+  const fallbackOptionMap = new Map(
+    fallback.options.map((option) => [option.id, option]),
+  );
+
+  return {
+    question: normalizedPrimary.question || fallback.question,
+    requiresProcessingMethod: normalizedPrimary.requiresProcessingMethod,
+    multiSelect: normalizedPrimary.multiSelect ?? fallback.multiSelect ?? null,
+    options:
+      normalizedPrimary.options.length > 0
+        ? normalizedPrimary.options.map((option) => ({
+            ...fallbackOptionMap.get(option.id),
+            ...option,
+          }))
+        : fallback.options,
+  };
+};
+
+const buildLocalChoiceResponse = (
+  mappingRules: MappingRules,
+  dataTypeKey: MappingDataTypeKey,
+): WizardChoiceResponse => {
+  const config = mappingRules.data_types[dataTypeKey];
+
+  if (config.requires_processing_method && config.processing_method) {
+    return {
+      question: config.processing_method.question,
+      options: config.processing_method.options.map(toWizardChoiceOption),
+      requiresProcessingMethod: true,
+      multiSelect: null,
+    };
+  }
+
+  return {
+    question: `${config.label}를 어떻게 처리할까요?`,
+    options: config.actions.map(toWizardChoiceOption),
+    requiresProcessingMethod: false,
+    multiSelect: null,
+  };
+};
+
+const buildLocalActionResponse = (
+  mappingRules: MappingRules,
+  dataTypeKey: MappingDataTypeKey,
+): WizardChoiceResponse => {
+  const config = mappingRules.data_types[dataTypeKey];
+
+  return {
+    question: `${config.label}를 어떻게 처리할까요?`,
+    options: config.actions.map(toWizardChoiceOption),
+    requiresProcessingMethod: false,
+    multiSelect: null,
+  };
+};
+
+const toChoiceNodeType = (value: string | null | undefined): NodeType =>
+  value && value in MAPPING_NODE_TYPE_MAP
+    ? MAPPING_NODE_TYPE_MAP[value as keyof typeof MAPPING_NODE_TYPE_MAP]
+    : "data-process";
+
+export const useChoiceWizardController = () => {
+  const nodes = useWorkflowStore((state) => state.nodes);
+  const edges = useWorkflowStore((state) => state.edges);
+  const activePanelNodeId = useWorkflowStore(
+    (state) => state.activePanelNodeId,
+  );
+  const workflowId = useWorkflowStore((state) => state.workflowId);
+  const startNodeId = useWorkflowStore((state) => state.startNodeId);
+  const endNodeId = useWorkflowStore((state) => state.endNodeId);
+  const syncWorkflowGraph = useWorkflowStore(
+    (state) => state.syncWorkflowGraph,
+  );
+  const openPanel = useWorkflowStore((state) => state.openPanel);
+
+  const { mutateAsync: addWorkflowNode, isPending: isAddNodePending } =
+    useAddWorkflowNodeMutation();
+  const { mutateAsync: deleteWorkflowNode, isPending: isDeleteNodePending } =
+    useDeleteWorkflowNodeMutation();
+  const { mutateAsync: updateWorkflowNode, isPending: isUpdateNodePending } =
+    useUpdateWorkflowNodeMutation();
+  const {
+    mutateAsync: selectWorkflowChoice,
+    isPending: isSelectChoicePending,
+  } = useSelectWorkflowChoiceMutation();
+  const { data: mappingRulesResponse } = useMappingRulesQuery();
+
+  const mappingRules = useMemo(
+    () => toChoiceMappingRules(mappingRulesResponse),
+    [mappingRulesResponse],
+  );
+
+  const [wizardStep, setWizardStep] = useState<WizardStep | null>(null);
+  const [initialDataTypeKey, setInitialDataTypeKey] =
+    useState<MappingDataTypeKey | null>(null);
+  const [currentDataTypeKey, setCurrentDataTypeKey] =
+    useState<MappingDataTypeKey | null>(null);
+  const [selectedProcessingOption, setSelectedProcessingOption] =
+    useState<WizardChoiceOption | null>(null);
+  const [selectedAction, setSelectedAction] =
+    useState<WizardChoiceOption | null>(null);
+  const [selectedFollowUp, setSelectedFollowUp] =
+    useState<ChoiceFollowUp | null>(null);
+  const [selectedBranchConfig, setSelectedBranchConfig] =
+    useState<ChoiceBranchConfig | null>(null);
+  const [stagingNodeId, setStagingNodeId] = useState<string | null>(null);
+  const [rootParentNodeId, setRootParentNodeId] = useState<string | null>(null);
+  const [baseStagingSnapshot, setBaseStagingSnapshot] =
+    useState<WizardNodeSnapshot | null>(null);
+  const [actionNodeId, setActionNodeId] = useState<string | null>(null);
+  const [sessionOwnedLeafNodeIds, setSessionOwnedLeafNodeIds] = useState<
+    string[]
+  >([]);
+  const [wizardError, setWizardError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setWizardStep(null);
+    setInitialDataTypeKey(null);
+    setCurrentDataTypeKey(null);
+    setSelectedProcessingOption(null);
+    setSelectedAction(null);
+    setSelectedFollowUp(null);
+    setSelectedBranchConfig(null);
+    setStagingNodeId(null);
+    setRootParentNodeId(null);
+    setBaseStagingSnapshot(null);
+    setActionNodeId(null);
+    setSessionOwnedLeafNodeIds([]);
+    setWizardError(null);
+  }, []);
+
+  const activeNode = useMemo(
+    () => nodes.find((node) => node.id === activePanelNodeId) ?? null,
+    [activePanelNodeId, nodes],
+  );
+  const incomingEdge = useMemo(
+    () =>
+      activePanelNodeId
+        ? (edges.find((edge) => edge.target === activePanelNodeId) ?? null)
+        : null,
+    [activePanelNodeId, edges],
+  );
+  const parentNode = useMemo(
+    () =>
+      incomingEdge
+        ? (nodes.find((node) => node.id === incomingEdge.source) ?? null)
+        : null,
+    [incomingEdge, nodes],
+  );
+  const stagingNode = useMemo(
+    () => nodes.find((node) => node.id === stagingNodeId) ?? null,
+    [nodes, stagingNodeId],
+  );
+  const actionNode = useMemo(
+    () => nodes.find((node) => node.id === actionNodeId) ?? null,
+    [actionNodeId, nodes],
+  );
+
+  const resolveNodeRole = useCallback(
+    (nodeId: string): "start" | "middle" | "end" => {
+      if (nodeId === startNodeId) {
+        return "start";
+      }
+      if (nodeId === endNodeId) {
+        return "end";
+      }
+      return "middle";
+    },
+    [endNodeId, startNodeId],
+  );
+
+  const createSnapshot = useCallback(
+    (node: (typeof nodes)[number]): WizardNodeSnapshot => ({
+      authWarning: node.data.authWarning,
+      config: {
+        ...node.data.config,
+      } as FlowNodeData["config"],
+      inputTypes: [...node.data.inputTypes],
+      outputTypes: [...node.data.outputTypes],
+      position: { ...node.position },
+      role: resolveNodeRole(node.id),
+      type: node.data.type,
+    }),
+    [resolveNodeRole],
+  );
+
+  const isWizardMode = isMiddleWizardPending(
+    activeNode,
+    startNodeId,
+    endNodeId,
+  );
+
+  const {
+    data: serverChoiceResponse,
+    isLoading: isChoicesLoading,
+    isError: isChoicesError,
+  } = useWorkflowChoicesQuery(
+    workflowId || undefined,
+    isWizardMode ? (parentNode?.id ?? null) : null,
+    isWizardMode,
+  );
+
+  const initialLocalChoiceResponse = useMemo(
+    () =>
+      initialDataTypeKey
+        ? buildLocalChoiceResponse(mappingRules, initialDataTypeKey)
+        : null,
+    [initialDataTypeKey, mappingRules],
+  );
+  const initialChoiceResponse = useMemo(
+    () =>
+      mergeChoiceResponses(serverChoiceResponse, initialLocalChoiceResponse),
+    [initialLocalChoiceResponse, serverChoiceResponse],
+  );
+  const currentActionChoiceResponse = useMemo(
+    () =>
+      currentDataTypeKey
+        ? buildLocalActionResponse(mappingRules, currentDataTypeKey)
+        : null,
+    [currentDataTypeKey, mappingRules],
+  );
+  const activeActionChoiceResponse = useMemo(() => {
+    if (!currentActionChoiceResponse) {
+      return null;
+    }
+
+    if (
+      initialChoiceResponse &&
+      initialChoiceResponse.requiresProcessingMethod === false &&
+      currentDataTypeKey === initialDataTypeKey
+    ) {
+      return mergeChoiceResponses(
+        initialChoiceResponse,
+        currentActionChoiceResponse,
+      );
+    }
+
+    return currentActionChoiceResponse;
+  }, [
+    currentActionChoiceResponse,
+    currentDataTypeKey,
+    initialChoiceResponse,
+    initialDataTypeKey,
+  ]);
+
+  const isWorkflowBusy =
+    isChoicesLoading ||
+    isAddNodePending ||
+    isDeleteNodePending ||
+    isUpdateNodePending ||
+    isSelectChoicePending;
+
+  const buildNodeConfig = useCallback(
+    ({
+      type,
+      baseConfig,
+      isConfigured,
+      overrides,
+      preserveExistingConfig = false,
+    }: {
+      type: NodeType;
+      baseConfig?: FlowNodeData["config"];
+      isConfigured: boolean;
+      overrides?: Partial<FlowNodeData["config"]>;
+      preserveExistingConfig?: boolean;
+    }) =>
+      ({
+        ...(preserveExistingConfig
+          ? (baseConfig ?? NODE_REGISTRY[type].defaultConfig)
+          : NODE_REGISTRY[type].defaultConfig),
+        ...overrides,
+        isConfigured,
+      }) as FlowNodeData["config"],
+    [],
+  );
+
+  const syncWorkflowFromResponse = useCallback(
+    (workflow: WorkflowResponse) => {
+      syncWorkflowGraph(hydrateStore(workflow), {
+        preserveActivePanelNodeId: true,
+        preserveActivePlaceholder: true,
+        preserveDirty: true,
+      });
+    },
+    [syncWorkflowGraph],
+  );
+
+  const syncUpdatedNode = useCallback(
+    (workflow: WorkflowResponse, nodeId: string) => {
+      const nextNode = workflow.nodes.find((node) => node.id === nodeId);
+      if (!nextNode) {
+        throw new Error("node was not updated");
+      }
+
+      syncWorkflowFromResponse(workflow);
+      return nextNode.id;
+    },
+    [syncWorkflowFromResponse],
+  );
+
+  const canSafelyDeleteWizardLeaf = useCallback(
+    (nodeId: string) => {
+      if (!sessionOwnedLeafNodeIds.includes(nodeId)) {
+        return false;
+      }
+
+      if (nodeId === stagingNodeId) {
+        return false;
+      }
+
+      if (resolveNodeRole(nodeId) !== "middle") {
+        return false;
+      }
+
+      return !edges.some((edge) => edge.source === nodeId);
+    },
+    [edges, resolveNodeRole, sessionOwnedLeafNodeIds, stagingNodeId],
+  );
+
+  const updatePersistedNode = useCallback(
+    async ({
+      node,
+      type,
+      config,
+      inputDataTypeKey,
+      outputDataTypeKey,
+      position,
+      role,
+    }: {
+      node: (typeof nodes)[number];
+      type: NodeType;
+      config: FlowNodeData["config"];
+      inputDataTypeKey?: MappingDataTypeKey | null;
+      outputDataTypeKey?: MappingDataTypeKey | null;
+      position?: { x: number; y: number };
+      role?: "start" | "middle" | "end";
+    }) => {
+      if (!workflowId) {
+        throw new Error("workflowId is required");
+      }
+
+      const nextWorkflow = await updateWorkflowNode({
+        workflowId,
+        nodeId: node.id,
+        body: {
+          category: toBackendNodeType(type).category,
+          type: toBackendNodeType(type).type,
+          config: config as unknown as Record<string, unknown>,
+          position: position ?? node.position,
+          dataType:
+            inputDataTypeKey !== undefined
+              ? inputDataTypeKey
+                ? toBackendDataType(toDataType(inputDataTypeKey))
+                : null
+              : node.data.inputTypes[0]
+                ? toBackendDataType(node.data.inputTypes[0])
+                : null,
+          outputDataType:
+            outputDataTypeKey !== undefined
+              ? outputDataTypeKey
+                ? toBackendDataType(toDataType(outputDataTypeKey))
+                : null
+              : node.data.outputTypes[0]
+                ? toBackendDataType(node.data.outputTypes[0])
+                : null,
+          role: role ?? resolveNodeRole(node.id),
+          authWarning: node.data.authWarning ?? false,
+        },
+      });
+
+      return syncUpdatedNode(nextWorkflow, node.id);
+    },
+    [resolveNodeRole, syncUpdatedNode, updateWorkflowNode, workflowId],
+  );
+
+  const placeWorkflowNode = useCallback(
+    async ({
+      type,
+      sourceNodeId,
+      position,
+      inputDataTypeKey,
+      outputDataTypeKey,
+      config,
+    }: {
+      type: NodeType;
+      sourceNodeId: string;
+      position: { x: number; y: number };
+      inputDataTypeKey?: MappingDataTypeKey | null;
+      outputDataTypeKey: MappingDataTypeKey | null;
+      config?: Partial<FlowNodeData["config"]>;
+    }) => {
+      if (!workflowId) {
+        throw new Error("workflowId is required");
+      }
+
+      const previousNodes = useWorkflowStore.getState().nodes;
+      const nextWorkflow = await addWorkflowNode({
+        workflowId,
+        body: toNodeAddRequest({
+          type,
+          position,
+          prevNodeId: sourceNodeId,
+          config,
+          inputTypes: inputDataTypeKey
+            ? [toDataType(inputDataTypeKey)]
+            : undefined,
+          outputTypes: outputDataTypeKey
+            ? [toDataType(outputDataTypeKey)]
+            : undefined,
+        }),
+      });
+
+      const addedNodeId =
+        findAddedNodeId(previousNodes, nextWorkflow.nodes) ??
+        nextWorkflow.nodes.at(-1)?.id ??
+        null;
+      const addedNode = nextWorkflow.nodes.find(
+        (node) => node.id === addedNodeId,
+      );
+
+      if (!addedNodeId || !addedNode) {
+        return null;
+      }
+
+      syncWorkflowFromResponse(nextWorkflow);
+      return addedNodeId;
+    },
+    [addWorkflowNode, syncWorkflowFromResponse, workflowId],
+  );
+
+  const removeWorkflowNode = useCallback(
+    async (nodeId: string) => {
+      if (!workflowId) {
+        throw new Error("workflowId is required");
+      }
+
+      const nextWorkflow = await deleteWorkflowNode({
+        workflowId,
+        nodeId,
+      });
+      syncWorkflowFromResponse(nextWorkflow);
+    },
+    [deleteWorkflowNode, syncWorkflowFromResponse, workflowId],
+  );
+
+  useEffect(() => {
+    if (!isWizardMode || !activeNode || !parentNode || initialDataTypeKey) {
+      return;
+    }
+
+    const parentOutputType = parentNode.data.outputTypes[0] ?? null;
+    if (!parentOutputType) {
+      return;
+    }
+
+    const mappingKey = toMappingKey(parentOutputType);
+    setStagingNodeId(activeNode.id);
+    setRootParentNodeId(parentNode.id);
+    setBaseStagingSnapshot(createSnapshot(activeNode));
+    setInitialDataTypeKey(mappingKey);
+    setCurrentDataTypeKey(mappingKey);
+  }, [
+    activeNode,
+    createSnapshot,
+    initialDataTypeKey,
+    isWizardMode,
+    parentNode,
+  ]);
+
+  useEffect(() => {
+    if (!isWizardMode || wizardStep || !initialChoiceResponse) {
+      return;
+    }
+
+    setWizardStep(
+      initialChoiceResponse.requiresProcessingMethod
+        ? "processing-method"
+        : "action",
+    );
+  }, [initialChoiceResponse, isWizardMode, wizardStep]);
+
+  const finishWizard = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  const selectProcessingMethod = useCallback(
+    async (option: WizardChoiceOption) => {
+      if (
+        !stagingNode ||
+        !rootParentNodeId ||
+        !currentDataTypeKey ||
+        !initialDataTypeKey
+      ) {
+        return;
+      }
+
+      setWizardError(null);
+      setSelectedProcessingOption(option);
+
+      try {
+        const selectionResult = await selectWorkflowChoice({
+          workflowId,
+          prevNodeId: rootParentNodeId,
+          optionId: option.id,
+          dataType: currentDataTypeKey,
+        });
+
+        const nextDataTypeKey = isMappingDataTypeKey(
+          mappingRules,
+          selectionResult.outputDataType,
+        )
+          ? selectionResult.outputDataType
+          : isMappingDataTypeKey(mappingRules, option.output_data_type)
+            ? option.output_data_type
+            : currentDataTypeKey;
+
+        const nextActions = buildLocalActionResponse(
+          mappingRules,
+          nextDataTypeKey,
+        );
+
+        const nextNodeType = selectionResult.nodeType
+          ? toChoiceNodeType(selectionResult.nodeType)
+          : toChoiceNodeType(option.node_type);
+        const isConfigured = nextActions.options.length === 0;
+
+        await updatePersistedNode({
+          node: stagingNode,
+          type: nextNodeType,
+          config: buildNodeConfig({
+            type: nextNodeType,
+            isConfigured,
+          }),
+          inputDataTypeKey: initialDataTypeKey,
+          outputDataTypeKey: nextDataTypeKey,
+          role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
+        });
+
+        openPanel(stagingNode.id);
+
+        if (nextActions.options.length > 0) {
+          setCurrentDataTypeKey(nextDataTypeKey);
+          setWizardStep("action");
+          return;
+        }
+
+        finishWizard();
+      } catch {
+        setWizardError("처리 방식을 반영하지 못했습니다.");
+      }
+    },
+    [
+      baseStagingSnapshot?.role,
+      buildNodeConfig,
+      currentDataTypeKey,
+      finishWizard,
+      initialDataTypeKey,
+      mappingRules,
+      openPanel,
+      resolveNodeRole,
+      rootParentNodeId,
+      selectWorkflowChoice,
+      stagingNode,
+      updatePersistedNode,
+      workflowId,
+    ],
+  );
+
+  const selectAction = useCallback(
+    async (action: WizardChoiceOption) => {
+      if (!stagingNode || !rootParentNodeId || !currentDataTypeKey) {
+        return;
+      }
+
+      setWizardError(null);
+
+      try {
+        const selectionResult = await selectWorkflowChoice({
+          workflowId,
+          prevNodeId: rootParentNodeId,
+          optionId: action.id,
+          dataType: currentDataTypeKey,
+        });
+
+        const nextDataTypeKey = isMappingDataTypeKey(
+          mappingRules,
+          selectionResult.outputDataType,
+        )
+          ? selectionResult.outputDataType
+          : isMappingDataTypeKey(mappingRules, action.output_data_type)
+            ? action.output_data_type
+            : currentDataTypeKey;
+
+        const followUp = selectionResult.followUp ?? action.followUp ?? null;
+        const branchConfig =
+          selectionResult.branchConfig ?? action.branchConfig ?? null;
+
+        const actionNodeType = selectionResult.nodeType
+          ? toChoiceNodeType(selectionResult.nodeType)
+          : toChoiceNodeType(action.node_type);
+        const hasFollowUp = Boolean(followUp || branchConfig);
+        const finalActionConfig = buildNodeConfig({
+          type: actionNodeType,
+          isConfigured: !hasFollowUp,
+          overrides: hasFollowUp
+            ? undefined
+            : {
+                choiceActionId: action.id,
+                choiceSelections: null,
+              },
+        });
+        const shouldUseActionLeaf = stagingNode.data.type === "loop";
+        let targetNodeId = stagingNode.id;
+
+        if (shouldUseActionLeaf) {
+          if (actionNode) {
+            await updatePersistedNode({
+              node: actionNode,
+              type: actionNodeType,
+              config: finalActionConfig,
+              inputDataTypeKey: currentDataTypeKey,
+              outputDataTypeKey: nextDataTypeKey,
+            });
+            targetNodeId = actionNode.id;
+          } else {
+            const createdActionNodeId = await placeWorkflowNode({
+              type: actionNodeType,
+              sourceNodeId: stagingNode.id,
+              position: {
+                x:
+                  stagingNode.position.x + DEFAULT_FLOW_NODE_WIDTH + NODE_GAP_X,
+                y: stagingNode.position.y,
+              },
+              inputDataTypeKey: currentDataTypeKey,
+              outputDataTypeKey: nextDataTypeKey,
+              config: finalActionConfig,
+            });
+
+            if (!createdActionNodeId) {
+              throw new Error("action node was not created");
+            }
+
+            setActionNodeId(createdActionNodeId);
+            setSessionOwnedLeafNodeIds((current) =>
+              current.includes(createdActionNodeId)
+                ? current
+                : [...current, createdActionNodeId],
+            );
+            targetNodeId = createdActionNodeId;
+          }
+        } else {
+          await updatePersistedNode({
+            node: stagingNode,
+            type: actionNodeType,
+            config: finalActionConfig,
+            inputDataTypeKey: currentDataTypeKey,
+            outputDataTypeKey: nextDataTypeKey,
+            role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
+          });
+          setActionNodeId(null);
+        }
+
+        setSelectedAction(action);
+        setSelectedFollowUp(followUp);
+        setSelectedBranchConfig(branchConfig);
+        setCurrentDataTypeKey(nextDataTypeKey);
+        openPanel(targetNodeId);
+
+        if (followUp || branchConfig) {
+          setWizardStep("follow-up");
+          return;
+        }
+
+        finishWizard();
+      } catch {
+        setWizardError("작업 노드를 반영하지 못했습니다.");
+      }
+    },
+    [
+      actionNode,
+      baseStagingSnapshot?.role,
+      buildNodeConfig,
+      currentDataTypeKey,
+      finishWizard,
+      mappingRules,
+      openPanel,
+      placeWorkflowNode,
+      resolveNodeRole,
+      rootParentNodeId,
+      selectWorkflowChoice,
+      stagingNode,
+      updatePersistedNode,
+      workflowId,
+    ],
+  );
+
+  const backToProcessingMethod = useCallback(async () => {
+    if (!initialDataTypeKey || !stagingNode || !baseStagingSnapshot) {
+      return;
+    }
+
+    setWizardError(null);
+
+    try {
+      if (actionNodeId && actionNode) {
+        if (!canSafelyDeleteWizardLeaf(actionNode.id)) {
+          setWizardError(
+            "이미 후속 연결이 생겨 이전 단계로 되돌리지 못합니다.",
+          );
+          return;
+        }
+
+        await removeWorkflowNode(actionNode.id);
+        setSessionOwnedLeafNodeIds((current) =>
+          current.filter((nodeId) => nodeId !== actionNode.id),
+        );
+      }
+
+      await updatePersistedNode({
+        node: stagingNode,
+        type: baseStagingSnapshot.type,
+        config: baseStagingSnapshot.config,
+        inputDataTypeKey: baseStagingSnapshot.inputTypes[0]
+          ? toMappingKey(baseStagingSnapshot.inputTypes[0])
+          : null,
+        outputDataTypeKey: baseStagingSnapshot.outputTypes[0]
+          ? toMappingKey(baseStagingSnapshot.outputTypes[0])
+          : null,
+        position: baseStagingSnapshot.position,
+        role: baseStagingSnapshot.role,
+      });
+
+      openPanel(stagingNode.id);
+      setActionNodeId(null);
+      setSelectedAction(null);
+      setSelectedFollowUp(null);
+      setSelectedBranchConfig(null);
+      setSelectedProcessingOption(null);
+      setCurrentDataTypeKey(initialDataTypeKey);
+      setWizardStep("processing-method");
+    } catch {
+      setWizardError("이전 단계로 돌아가지 못했습니다.");
+    }
+  }, [
+    actionNode,
+    actionNodeId,
+    baseStagingSnapshot,
+    canSafelyDeleteWizardLeaf,
+    initialDataTypeKey,
+    openPanel,
+    removeWorkflowNode,
+    stagingNode,
+    updatePersistedNode,
+  ]);
+
+  const backToAction = useCallback(() => {
+    const targetNodeId = actionNodeId ?? stagingNodeId;
+    if (!targetNodeId) {
+      return;
+    }
+
+    setWizardError(null);
+    openPanel(targetNodeId);
+    setSelectedAction(null);
+    setSelectedFollowUp(null);
+    setSelectedBranchConfig(null);
+    setWizardStep("action");
+  }, [actionNodeId, openPanel, stagingNodeId]);
+
+  const completeFollowUp = useCallback(
+    async (selections: Record<string, string | string[]>) => {
+      const targetNode = actionNode ?? stagingNode;
+      if (!targetNode || !selectedAction) {
+        return;
+      }
+
+      setWizardError(null);
+
+      try {
+        await updatePersistedNode({
+          node: targetNode,
+          type: targetNode.data.type,
+          config: buildNodeConfig({
+            type: targetNode.data.type,
+            baseConfig: targetNode.data.config,
+            isConfigured: true,
+            overrides: {
+              choiceActionId: selectedAction.id,
+              choiceSelections: selections,
+            },
+            preserveExistingConfig: true,
+          }),
+          role:
+            targetNode.id === stagingNode?.id
+              ? (baseStagingSnapshot?.role ?? resolveNodeRole(targetNode.id))
+              : resolveNodeRole(targetNode.id),
+        });
+
+        openPanel(targetNode.id);
+        finishWizard();
+      } catch {
+        setWizardError("후속 설정을 반영하지 못했습니다.");
+      }
+    },
+    [
+      actionNode,
+      baseStagingSnapshot?.role,
+      buildNodeConfig,
+      finishWizard,
+      openPanel,
+      resolveNodeRole,
+      selectedAction,
+      stagingNode,
+      updatePersistedNode,
+    ],
+  );
+
+  return {
+    isWizardMode,
+    wizardStep,
+    initialChoiceResponse,
+    activeActionChoiceResponse,
+    selectedProcessingOption,
+    selectedFollowUp,
+    selectedBranchConfig,
+    wizardError,
+    isWorkflowBusy,
+    isChoicesError,
+    serverChoiceResponse,
+    selectProcessingMethod,
+    selectAction,
+    backToProcessingMethod,
+    backToAction,
+    completeFollowUp,
+    reset,
+  };
+};

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -9,7 +9,6 @@ import {
 import {
   type ChoiceBranchConfig,
   type ChoiceFollowUp,
-  type ChoiceResponse,
   type WorkflowResponse,
   findAddedNodeId,
   toBackendDataType,
@@ -24,17 +23,13 @@ import {
 } from "@/entities/workflow";
 import {
   type ResolvedChoiceOption,
-  type ResolvedChoiceResponse,
-  buildFallbackChoiceResponse,
-  resolveChoiceResponse,
+  resolveActionChoiceResponse,
+  resolveInitialChoiceResponse,
   toChoiceMappingRules,
   toDataType,
   toMappingKey,
 } from "@/features/choice-panel";
-import {
-  type MappingDataTypeKey,
-  type MappingRules,
-} from "@/features/choice-panel";
+import { type MappingDataTypeKey } from "@/features/choice-panel";
 import {
   hydrateStore,
   isMiddleWizardPending,
@@ -49,7 +44,6 @@ import { logChoiceWizardEvent } from "./choiceWizardLogger";
 
 type WizardStep = "processing-method" | "action" | "follow-up";
 type WizardChoiceOption = ResolvedChoiceOption;
-type WizardChoiceResponse = ResolvedChoiceResponse;
 
 type WizardNodeSnapshot = {
   authWarning?: boolean;
@@ -63,27 +57,6 @@ type WizardNodeSnapshot = {
 
 const DEFAULT_FLOW_NODE_WIDTH = 172;
 const NODE_GAP_X = 96;
-
-const mergeChoiceResponses = (
-  primary: ChoiceResponse | null | undefined,
-  fallback: WizardChoiceResponse | null,
-): WizardChoiceResponse | null =>
-  resolveChoiceResponse({
-    serverChoice: primary,
-    fallbackChoice: fallback,
-  });
-
-const buildLocalChoiceResponse = (
-  mappingRules: MappingRules,
-  dataTypeKey: MappingDataTypeKey,
-): WizardChoiceResponse =>
-  buildFallbackChoiceResponse(mappingRules, dataTypeKey, "initial");
-
-const buildLocalActionResponse = (
-  mappingRules: MappingRules,
-  dataTypeKey: MappingDataTypeKey,
-): WizardChoiceResponse =>
-  buildFallbackChoiceResponse(mappingRules, dataTypeKey, "action");
 export const useChoiceWizardController = () => {
   const nodes = useWorkflowStore((state) => state.nodes);
   const edges = useWorkflowStore((state) => state.edges);
@@ -225,53 +198,31 @@ export const useChoiceWizardController = () => {
     isWizardMode,
   );
 
-  const initialLocalChoiceResponse = useMemo(
+  const { choice: initialChoiceResponse, source: initialChoiceSource } =
+    useMemo(
+      () =>
+        resolveInitialChoiceResponse({
+          mappingRules,
+          dataTypeKey: initialDataTypeKey,
+          serverChoice: serverChoiceResponse,
+        }),
+      [initialDataTypeKey, mappingRules, serverChoiceResponse],
+    );
+  const activeActionChoiceResponse = useMemo(
     () =>
-      initialDataTypeKey
-        ? buildLocalChoiceResponse(mappingRules, initialDataTypeKey)
-        : null,
-    [initialDataTypeKey, mappingRules],
-  );
-  const initialChoiceResponse = useMemo(
-    () =>
-      mergeChoiceResponses(serverChoiceResponse, initialLocalChoiceResponse),
-    [initialLocalChoiceResponse, serverChoiceResponse],
-  );
-  const initialChoiceSource = serverChoiceResponse
-    ? "server"
-    : initialLocalChoiceResponse
-      ? "fallback"
-      : null;
-  const currentActionChoiceResponse = useMemo(
-    () =>
-      currentDataTypeKey
-        ? buildLocalActionResponse(mappingRules, currentDataTypeKey)
-        : null,
-    [currentDataTypeKey, mappingRules],
-  );
-  const activeActionChoiceResponse = useMemo(() => {
-    if (!currentActionChoiceResponse) {
-      return null;
-    }
-
-    if (
-      initialChoiceResponse &&
-      initialChoiceResponse.requiresProcessingMethod === false &&
-      currentDataTypeKey === initialDataTypeKey
-    ) {
-      return mergeChoiceResponses(
+      resolveActionChoiceResponse({
+        mappingRules,
+        currentDataTypeKey,
         initialChoiceResponse,
-        currentActionChoiceResponse,
-      );
-    }
-
-    return currentActionChoiceResponse;
-  }, [
-    currentActionChoiceResponse,
-    currentDataTypeKey,
-    initialChoiceResponse,
-    initialDataTypeKey,
-  ]);
+        initialDataTypeKey,
+      }),
+    [
+      currentDataTypeKey,
+      initialChoiceResponse,
+      initialDataTypeKey,
+      mappingRules,
+    ],
+  );
 
   const isWorkflowBusy =
     isChoicesLoading ||

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -1,19 +1,11 @@
 ﻿import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { NODE_REGISTRY } from "@/entities/node";
-import {
-  type DataType,
-  type FlowNodeData,
-  type NodeType,
-} from "@/entities/node";
+import { type FlowNodeData, type NodeType } from "@/entities/node";
 import {
   type ChoiceBranchConfig,
   type ChoiceFollowUp,
   type WorkflowResponse,
-  findAddedNodeId,
-  toBackendDataType,
-  toBackendNodeType,
-  toNodeAddRequest,
   useAddWorkflowNodeMutation,
   useDeleteWorkflowNodeMutation,
   useMappingRulesQuery,
@@ -26,7 +18,6 @@ import {
   resolveActionChoiceResponse,
   resolveInitialChoiceResponse,
   toChoiceMappingRules,
-  toDataType,
   toMappingKey,
 } from "@/features/choice-panel";
 import { type MappingDataTypeKey } from "@/features/choice-panel";
@@ -41,19 +32,15 @@ import {
   deriveProcessingMethodSelectionIntent,
 } from "./choiceSelectionPipeline";
 import { logChoiceWizardEvent } from "./choiceWizardLogger";
+import {
+  type WizardNodeSnapshot,
+  canSafelyDeleteChoiceWizardLeaf,
+  createChoiceWizardNodePersistence,
+  toSnapshotDataTypeKey,
+} from "./choiceWizardNodePersistence";
 
 type WizardStep = "processing-method" | "action" | "follow-up";
 type WizardChoiceOption = ResolvedChoiceOption;
-
-type WizardNodeSnapshot = {
-  authWarning?: boolean;
-  config: FlowNodeData["config"];
-  inputTypes: DataType[];
-  outputTypes: DataType[];
-  position: { x: number; y: number };
-  role: "start" | "middle" | "end";
-  type: NodeType;
-};
 
 const DEFAULT_FLOW_NODE_WIDTH = 172;
 const NODE_GAP_X = 96;
@@ -265,164 +252,26 @@ export const useChoiceWizardController = () => {
     },
     [syncWorkflowGraph],
   );
-
-  const syncUpdatedNode = useCallback(
-    (workflow: WorkflowResponse, nodeId: string) => {
-      const nextNode = workflow.nodes.find((node) => node.id === nodeId);
-      if (!nextNode) {
-        throw new Error("node was not updated");
-      }
-
-      syncWorkflowFromResponse(workflow);
-      return nextNode.id;
-    },
-    [syncWorkflowFromResponse],
-  );
-
-  const canSafelyDeleteWizardLeaf = useCallback(
-    (nodeId: string) => {
-      if (!sessionOwnedLeafNodeIds.includes(nodeId)) {
-        return false;
-      }
-
-      if (nodeId === stagingNodeId) {
-        return false;
-      }
-
-      if (resolveNodeRole(nodeId) !== "middle") {
-        return false;
-      }
-
-      return !edges.some((edge) => edge.source === nodeId);
-    },
-    [edges, resolveNodeRole, sessionOwnedLeafNodeIds, stagingNodeId],
-  );
-
-  const updatePersistedNode = useCallback(
-    async ({
-      node,
-      type,
-      config,
-      inputDataTypeKey,
-      outputDataTypeKey,
-      position,
-      role,
-    }: {
-      node: (typeof nodes)[number];
-      type: NodeType;
-      config: FlowNodeData["config"];
-      inputDataTypeKey?: MappingDataTypeKey | null;
-      outputDataTypeKey?: MappingDataTypeKey | null;
-      position?: { x: number; y: number };
-      role?: "start" | "middle" | "end";
-    }) => {
-      if (!workflowId) {
-        throw new Error("workflowId is required");
-      }
-
-      const nextWorkflow = await updateWorkflowNode({
-        workflowId,
-        nodeId: node.id,
-        body: {
-          category: toBackendNodeType(type).category,
-          type: toBackendNodeType(type).type,
-          config: config as unknown as Record<string, unknown>,
-          position: position ?? node.position,
-          dataType:
-            inputDataTypeKey !== undefined
-              ? inputDataTypeKey
-                ? toBackendDataType(toDataType(inputDataTypeKey))
-                : null
-              : node.data.inputTypes[0]
-                ? toBackendDataType(node.data.inputTypes[0])
-                : null,
-          outputDataType:
-            outputDataTypeKey !== undefined
-              ? outputDataTypeKey
-                ? toBackendDataType(toDataType(outputDataTypeKey))
-                : null
-              : node.data.outputTypes[0]
-                ? toBackendDataType(node.data.outputTypes[0])
-                : null,
-          role: role ?? resolveNodeRole(node.id),
-          authWarning: node.data.authWarning ?? false,
-        },
-      });
-
-      return syncUpdatedNode(nextWorkflow, node.id);
-    },
-    [resolveNodeRole, syncUpdatedNode, updateWorkflowNode, workflowId],
-  );
-
-  const placeWorkflowNode = useCallback(
-    async ({
-      type,
-      sourceNodeId,
-      position,
-      inputDataTypeKey,
-      outputDataTypeKey,
-      config,
-    }: {
-      type: NodeType;
-      sourceNodeId: string;
-      position: { x: number; y: number };
-      inputDataTypeKey?: MappingDataTypeKey | null;
-      outputDataTypeKey: MappingDataTypeKey | null;
-      config?: Partial<FlowNodeData["config"]>;
-    }) => {
-      if (!workflowId) {
-        throw new Error("workflowId is required");
-      }
-
-      const previousNodes = useWorkflowStore.getState().nodes;
-      const nextWorkflow = await addWorkflowNode({
-        workflowId,
-        body: toNodeAddRequest({
-          type,
-          position,
-          prevNodeId: sourceNodeId,
-          config,
-          inputTypes: inputDataTypeKey
-            ? [toDataType(inputDataTypeKey)]
-            : undefined,
-          outputTypes: outputDataTypeKey
-            ? [toDataType(outputDataTypeKey)]
-            : undefined,
+  const { placeWorkflowNode, removeWorkflowNode, updatePersistedNode } =
+    useMemo(
+      () =>
+        createChoiceWizardNodePersistence({
+          addWorkflowNode,
+          deleteWorkflowNode,
+          resolveNodeRole,
+          syncWorkflowFromResponse,
+          updateWorkflowNode,
+          workflowId,
         }),
-      });
-
-      const addedNodeId =
-        findAddedNodeId(previousNodes, nextWorkflow.nodes) ??
-        nextWorkflow.nodes.at(-1)?.id ??
-        null;
-      const addedNode = nextWorkflow.nodes.find(
-        (node) => node.id === addedNodeId,
-      );
-
-      if (!addedNodeId || !addedNode) {
-        return null;
-      }
-
-      syncWorkflowFromResponse(nextWorkflow);
-      return addedNodeId;
-    },
-    [addWorkflowNode, syncWorkflowFromResponse, workflowId],
-  );
-
-  const removeWorkflowNode = useCallback(
-    async (nodeId: string) => {
-      if (!workflowId) {
-        throw new Error("workflowId is required");
-      }
-
-      const nextWorkflow = await deleteWorkflowNode({
+      [
+        addWorkflowNode,
+        deleteWorkflowNode,
+        resolveNodeRole,
+        syncWorkflowFromResponse,
+        updateWorkflowNode,
         workflowId,
-        nodeId,
-      });
-      syncWorkflowFromResponse(nextWorkflow);
-    },
-    [deleteWorkflowNode, syncWorkflowFromResponse, workflowId],
-  );
+      ],
+    );
 
   useEffect(() => {
     if (!isWizardMode || !activeNode || !parentNode || initialDataTypeKey) {
@@ -724,7 +573,15 @@ export const useChoiceWizardController = () => {
 
     try {
       if (actionNodeId && actionNode) {
-        if (!canSafelyDeleteWizardLeaf(actionNode.id)) {
+        if (
+          !canSafelyDeleteChoiceWizardLeaf({
+            edges,
+            nodeId: actionNode.id,
+            resolveNodeRole,
+            sessionOwnedLeafNodeIds,
+            stagingNodeId,
+          })
+        ) {
           setWizardError(
             "이미 후속 연결이 생겨 이전 단계로 되돌리지 못합니다.",
           );
@@ -741,12 +598,12 @@ export const useChoiceWizardController = () => {
         node: stagingNode,
         type: baseStagingSnapshot.type,
         config: baseStagingSnapshot.config,
-        inputDataTypeKey: baseStagingSnapshot.inputTypes[0]
-          ? toMappingKey(baseStagingSnapshot.inputTypes[0])
-          : null,
-        outputDataTypeKey: baseStagingSnapshot.outputTypes[0]
-          ? toMappingKey(baseStagingSnapshot.outputTypes[0])
-          : null,
+        inputDataTypeKey: toSnapshotDataTypeKey(
+          baseStagingSnapshot.inputTypes[0],
+        ),
+        outputDataTypeKey: toSnapshotDataTypeKey(
+          baseStagingSnapshot.outputTypes[0],
+        ),
         position: baseStagingSnapshot.position,
         role: baseStagingSnapshot.role,
       });
@@ -766,11 +623,14 @@ export const useChoiceWizardController = () => {
     actionNode,
     actionNodeId,
     baseStagingSnapshot,
-    canSafelyDeleteWizardLeaf,
+    edges,
     initialDataTypeKey,
     openPanel,
+    resolveNodeRole,
     removeWorkflowNode,
+    sessionOwnedLeafNodeIds,
     stagingNode,
+    stagingNodeId,
     updatePersistedNode,
   ]);
 

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -45,6 +45,7 @@ import {
   deriveActionSelectionIntent,
   deriveProcessingMethodSelectionIntent,
 } from "./choiceSelectionPipeline";
+import { logChoiceWizardEvent } from "./choiceWizardLogger";
 
 type WizardStep = "processing-method" | "action" | "follow-up";
 type WizardChoiceOption = ResolvedChoiceOption;
@@ -236,6 +237,11 @@ export const useChoiceWizardController = () => {
       mergeChoiceResponses(serverChoiceResponse, initialLocalChoiceResponse),
     [initialLocalChoiceResponse, serverChoiceResponse],
   );
+  const initialChoiceSource = serverChoiceResponse
+    ? "server"
+    : initialLocalChoiceResponse
+      ? "fallback"
+      : null;
   const currentActionChoiceResponse = useMemo(
     () =>
       currentDataTypeKey
@@ -496,12 +502,25 @@ export const useChoiceWizardController = () => {
       return;
     }
 
-    setWizardStep(
-      initialChoiceResponse.requiresProcessingMethod
-        ? "processing-method"
-        : "action",
-    );
-  }, [initialChoiceResponse, isWizardMode, wizardStep]);
+    const nextStep = initialChoiceResponse.requiresProcessingMethod
+      ? "processing-method"
+      : "action";
+
+    logChoiceWizardEvent({
+      anchorNodeId: parentNode?.id ?? null,
+      event: "wizard-open",
+      nextStep,
+      source: initialChoiceSource,
+      step: wizardStep,
+    });
+    setWizardStep(nextStep);
+  }, [
+    initialChoiceResponse,
+    initialChoiceSource,
+    isWizardMode,
+    parentNode?.id,
+    wizardStep,
+  ]);
 
   const finishWizard = useCallback(() => {
     reset();
@@ -536,6 +555,18 @@ export const useChoiceWizardController = () => {
           selectionResult,
         });
 
+        logChoiceWizardEvent({
+          anchorNodeId: rootParentNodeId,
+          details: {
+            outputDataType: selectionIntent.nextDataTypeKey,
+          },
+          event: "processing-method-selected",
+          nextStep: selectionIntent.nextStep,
+          optionId: option.id,
+          step: wizardStep,
+          targetNodeId: stagingNode.id,
+        });
+
         await updatePersistedNode({
           node: stagingNode,
           type: selectionIntent.nextNodeType,
@@ -558,6 +589,16 @@ export const useChoiceWizardController = () => {
 
         finishWizard();
       } catch {
+        logChoiceWizardEvent({
+          anchorNodeId: rootParentNodeId,
+          details: {
+            message: "processing-method-persist-failed",
+          },
+          event: "wizard-error",
+          optionId: option.id,
+          step: wizardStep,
+          targetNodeId: stagingNode.id,
+        });
         setWizardError("처리 방식을 반영하지 못했습니다.");
       }
     },
@@ -574,6 +615,7 @@ export const useChoiceWizardController = () => {
       selectWorkflowChoice,
       stagingNode,
       updatePersistedNode,
+      wizardStep,
       workflowId,
     ],
   );
@@ -600,6 +642,19 @@ export const useChoiceWizardController = () => {
           option: action,
           selectionResult,
           stagingNodeType: stagingNode.data.type,
+        });
+
+        logChoiceWizardEvent({
+          anchorNodeId: rootParentNodeId,
+          details: {
+            hasFollowUp: selectionIntent.hasFollowUp,
+            outputDataType: selectionIntent.nextDataTypeKey,
+            shouldUseActionLeaf: selectionIntent.shouldUseActionLeaf,
+          },
+          event: "action-selected",
+          nextStep: selectionIntent.nextStep,
+          optionId: action.id,
+          step: wizardStep,
         });
         const finalActionConfig = buildNodeConfig({
           type: selectionIntent.nextNodeType,
@@ -674,6 +729,15 @@ export const useChoiceWizardController = () => {
 
         finishWizard();
       } catch {
+        logChoiceWizardEvent({
+          anchorNodeId: rootParentNodeId,
+          details: {
+            message: "action-persist-failed",
+          },
+          event: "wizard-error",
+          optionId: action.id,
+          step: wizardStep,
+        });
         setWizardError("작업 노드를 반영하지 못했습니다.");
       }
     },
@@ -691,6 +755,7 @@ export const useChoiceWizardController = () => {
       selectWorkflowChoice,
       stagingNode,
       updatePersistedNode,
+      wizardStep,
       workflowId,
     ],
   );
@@ -797,9 +862,30 @@ export const useChoiceWizardController = () => {
               : resolveNodeRole(targetNode.id),
         });
 
+        logChoiceWizardEvent({
+          anchorNodeId: rootParentNodeId,
+          details: {
+            selectionKeys: Object.keys(selections),
+          },
+          event: "follow-up-complete",
+          nextStep: "complete",
+          optionId: selectedAction.id,
+          step: wizardStep,
+          targetNodeId: targetNode.id,
+        });
         openPanel(targetNode.id);
         finishWizard();
       } catch {
+        logChoiceWizardEvent({
+          anchorNodeId: rootParentNodeId,
+          details: {
+            message: "follow-up-persist-failed",
+          },
+          event: "wizard-error",
+          optionId: selectedAction.id,
+          step: wizardStep,
+          targetNodeId: targetNode.id,
+        });
         setWizardError("후속 설정을 반영하지 못했습니다.");
       }
     },
@@ -810,9 +896,11 @@ export const useChoiceWizardController = () => {
       finishWizard,
       openPanel,
       resolveNodeRole,
+      rootParentNodeId,
       selectedAction,
       stagingNode,
       updatePersistedNode,
+      wizardStep,
     ],
   );
 

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -688,7 +688,7 @@ export const OutputPanel = () => {
       const selectionResult = await selectWorkflowChoice({
         workflowId,
         prevNodeId: rootParentNodeId,
-        selectedOptionId: option.id,
+        optionId: option.id,
         dataType: currentDataTypeKey,
       });
 
@@ -748,7 +748,7 @@ export const OutputPanel = () => {
       const selectionResult = await selectWorkflowChoice({
         workflowId,
         prevNodeId: rootParentNodeId,
-        selectedOptionId: action.id,
+        optionId: action.id,
         dataType: currentDataTypeKey,
       });
 

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -1,50 +1,19 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { MdCancel } from "react-icons/md";
 
 import { Box, Icon, Spinner, Text, VStack } from "@chakra-ui/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
 import {
-  type DataType,
-  type FlowNodeData,
-  type NodeType,
-} from "@/entities/node";
-import {
   type ChoiceBranchConfig,
   type ChoiceFollowUp,
   type ChoiceOption,
   type ChoiceResponse,
-  type WorkflowResponse,
-  findAddedNodeId,
-  toBackendDataType,
-  toBackendNodeType,
-  toNodeAddRequest,
-  useAddWorkflowNodeMutation,
-  useDeleteWorkflowNodeMutation,
-  useMappingRulesQuery,
-  useSelectWorkflowChoiceMutation,
-  useUpdateWorkflowNodeMutation,
-  useWorkflowChoicesQuery,
 } from "@/entities/workflow";
-import {
-  MAPPING_NODE_TYPE_MAP,
-  OUTPUT_DATA_LABELS,
-  toChoiceMappingRules,
-  toDataType,
-  toMappingKey,
-} from "@/features/choice-panel";
-import {
-  type BranchConfig,
-  type FollowUp,
-  type MappingAction,
-  type MappingDataTypeKey,
-  type MappingRules,
-} from "@/features/choice-panel";
+import { OUTPUT_DATA_LABELS } from "@/features/choice-panel";
 import { PanelRenderer } from "@/features/configure-node";
 import {
-  hydrateStore,
   isMiddleWizardCompleted,
-  isMiddleWizardPending,
   useWorkflowStore,
 } from "@/features/workflow-editor";
 import { useDualPanelLayout } from "@/shared";
@@ -70,361 +39,61 @@ type WizardChoiceResponse = {
   multiSelect?: boolean | null;
 };
 
-const DEFAULT_FLOW_NODE_WIDTH = 172;
-const NODE_GAP_X = 96;
+type OutputPanelWizardController = {
+  isWizardMode: boolean;
+  wizardStep: WizardStep | null;
+  initialChoiceResponse: WizardChoiceResponse | null;
+  activeActionChoiceResponse: WizardChoiceResponse | null;
+  selectedProcessingOption: WizardChoiceOption | null;
+  selectedFollowUp: ChoiceFollowUp | null;
+  selectedBranchConfig: ChoiceBranchConfig | null;
+  wizardError: string | null;
+  isWorkflowBusy: boolean;
+  isChoicesError: boolean;
+  serverChoiceResponse: ChoiceResponse | null | undefined;
+  selectProcessingMethod: (option: WizardChoiceOption) => Promise<void>;
+  selectAction: (action: WizardChoiceOption) => Promise<void>;
+  backToProcessingMethod: () => Promise<void>;
+  backToAction: () => void;
+  completeFollowUp: (
+    selections: Record<string, string | string[]>,
+  ) => Promise<void>;
+  reset: () => void;
+};
+
+type Props = {
+  wizardController: OutputPanelWizardController;
+};
+
 const PANEL_TRANSITION_MS = 240;
 
-const isMappingDataTypeKey = (
-  mappingRules: MappingRules,
-  value: string | null | undefined,
-): value is MappingDataTypeKey =>
-  Boolean(value && value in mappingRules.data_types);
-
-type WizardNodeSnapshot = {
-  authWarning?: boolean;
-  config: FlowNodeData["config"];
-  inputTypes: DataType[];
-  outputTypes: DataType[];
-  position: { x: number; y: number };
-  role: "start" | "middle" | "end";
-  type: NodeType;
-};
-
-const toChoiceFollowUp = (followUp: FollowUp | null | undefined) =>
-  followUp
-    ? {
-        question: followUp.question,
-        options: (followUp.options ?? []).map((option) => ({
-          id: option.id,
-          label: option.label,
-          type: option.type ?? null,
-        })),
-        options_source: followUp.options_source ?? null,
-        multi_select: followUp.multi_select ?? null,
-        description: followUp.description ?? null,
-      }
-    : null;
-
-const toChoiceBranchConfig = (branchConfig: BranchConfig | null | undefined) =>
-  branchConfig
-    ? {
-        question: branchConfig.question,
-        options: (branchConfig.options ?? []).map((option) => ({
-          id: option.id,
-          label: option.label,
-          type: option.type ?? null,
-        })),
-        options_source: branchConfig.options_source ?? null,
-        multi_select: branchConfig.multi_select ?? null,
-        description: branchConfig.description ?? null,
-      }
-    : null;
-
-const toWizardChoiceOption = (
-  option: ChoiceOption | MappingAction,
-): WizardChoiceOption => ({
-  id: option.id,
-  label: option.label,
-  type: "type" in option ? (option.type ?? null) : null,
-  node_type: "node_type" in option ? (option.node_type ?? null) : null,
-  output_data_type:
-    "output_data_type" in option ? (option.output_data_type ?? null) : null,
-  priority: "priority" in option ? (option.priority ?? null) : null,
-  description: "description" in option ? option.description : undefined,
-  followUp:
-    "follow_up" in option ? toChoiceFollowUp(option.follow_up ?? null) : null,
-  branchConfig:
-    "branch_config" in option
-      ? toChoiceBranchConfig(option.branch_config ?? null)
-      : null,
-});
-
-const mergeChoiceResponses = (
-  primary: ChoiceResponse | null | undefined,
-  fallback: WizardChoiceResponse | null,
-): WizardChoiceResponse | null => {
-  if (!primary && !fallback) {
-    return null;
-  }
-
-  if (!primary) {
-    return fallback;
-  }
-
-  const normalizedPrimary: WizardChoiceResponse = {
-    question: primary.question,
-    options: primary.options.map(toWizardChoiceOption),
-    requiresProcessingMethod: primary.requiresProcessingMethod,
-    multiSelect: primary.multiSelect ?? null,
-  };
-
-  if (!fallback) {
-    return normalizedPrimary;
-  }
-
-  const fallbackOptionMap = new Map(
-    fallback.options.map((option) => [option.id, option]),
-  );
-
-  return {
-    question: normalizedPrimary.question || fallback.question,
-    requiresProcessingMethod: normalizedPrimary.requiresProcessingMethod,
-    multiSelect: normalizedPrimary.multiSelect ?? fallback.multiSelect ?? null,
-    options:
-      normalizedPrimary.options.length > 0
-        ? normalizedPrimary.options.map((option) => ({
-            ...fallbackOptionMap.get(option.id),
-            ...option,
-          }))
-        : fallback.options,
-  };
-};
-
-const buildLocalChoiceResponse = (
-  mappingRules: MappingRules,
-  dataTypeKey: MappingDataTypeKey,
-): WizardChoiceResponse => {
-  const config = mappingRules.data_types[dataTypeKey];
-
-  if (config.requires_processing_method && config.processing_method) {
-    return {
-      question: config.processing_method.question,
-      options: config.processing_method.options.map(toWizardChoiceOption),
-      requiresProcessingMethod: true,
-      multiSelect: null,
-    };
-  }
-
-  return {
-    question: `${config.label}을 어떻게 처리할까요?`,
-    options: config.actions.map(toWizardChoiceOption),
-    requiresProcessingMethod: false,
-    multiSelect: null,
-  };
-};
-
-const buildLocalActionResponse = (
-  mappingRules: MappingRules,
-  dataTypeKey: MappingDataTypeKey,
-): WizardChoiceResponse => {
-  const config = mappingRules.data_types[dataTypeKey];
-
-  return {
-    question: `${config.label}을 어떻게 처리할까요?`,
-    options: config.actions.map(toWizardChoiceOption),
-    requiresProcessingMethod: false,
-    multiSelect: null,
-  };
-};
-
-const toChoiceNodeType = (value: string | null | undefined): NodeType =>
-  value && value in MAPPING_NODE_TYPE_MAP
-    ? MAPPING_NODE_TYPE_MAP[value as keyof typeof MAPPING_NODE_TYPE_MAP]
-    : "data-process";
-
-export const OutputPanel = () => {
+export const OutputPanel = ({ wizardController }: Props) => {
   const nodes = useWorkflowStore((state) => state.nodes);
-  const edges = useWorkflowStore((state) => state.edges);
   const activePanelNodeId = useWorkflowStore(
     (state) => state.activePanelNodeId,
   );
   const activePlaceholder = useWorkflowStore(
     (state) => state.activePlaceholder,
   );
-  const workflowId = useWorkflowStore((state) => state.workflowId);
-  const startNodeId = useWorkflowStore((state) => state.startNodeId);
-  const endNodeId = useWorkflowStore((state) => state.endNodeId);
   const canEditNodes = useWorkflowStore(
     (state) => state.editorCapabilities.canEditNodes,
   );
-  const syncWorkflowGraph = useWorkflowStore(
-    (state) => state.syncWorkflowGraph,
-  );
-  const openPanel = useWorkflowStore((state) => state.openPanel);
   const closePanel = useWorkflowStore((state) => state.closePanel);
-  const { mutateAsync: addWorkflowNode, isPending: isAddNodePending } =
-    useAddWorkflowNodeMutation();
-  const { mutateAsync: deleteWorkflowNode, isPending: isDeleteNodePending } =
-    useDeleteWorkflowNodeMutation();
-  const { mutateAsync: updateWorkflowNode, isPending: isUpdateNodePending } =
-    useUpdateWorkflowNodeMutation();
-  const {
-    mutateAsync: selectWorkflowChoice,
-    isPending: isSelectChoicePending,
-  } = useSelectWorkflowChoiceMutation();
-  const { data: mappingRulesResponse } = useMappingRulesQuery();
   const layout = useDualPanelLayout();
   const isOpen = Boolean(activePanelNodeId) && activePlaceholder === null;
-  const mappingRules = useMemo(
-    () => toChoiceMappingRules(mappingRulesResponse),
-    [mappingRulesResponse],
-  );
-
-  const [wizardStep, setWizardStep] = useState<WizardStep | null>(null);
-  const [initialDataTypeKey, setInitialDataTypeKey] =
-    useState<MappingDataTypeKey | null>(null);
-  const [currentDataTypeKey, setCurrentDataTypeKey] =
-    useState<MappingDataTypeKey | null>(null);
-  const [selectedProcessingOption, setSelectedProcessingOption] =
-    useState<WizardChoiceOption | null>(null);
-  const [selectedAction, setSelectedAction] =
-    useState<WizardChoiceOption | null>(null);
-  const [selectedFollowUp, setSelectedFollowUp] =
-    useState<ChoiceFollowUp | null>(null);
-  const [selectedBranchConfig, setSelectedBranchConfig] =
-    useState<ChoiceBranchConfig | null>(null);
-  const [stagingNodeId, setStagingNodeId] = useState<string | null>(null);
-  const [rootParentNodeId, setRootParentNodeId] = useState<string | null>(null);
-  const [baseStagingSnapshot, setBaseStagingSnapshot] =
-    useState<WizardNodeSnapshot | null>(null);
-  const [actionNodeId, setActionNodeId] = useState<string | null>(null);
-  const [sessionOwnedLeafNodeIds, setSessionOwnedLeafNodeIds] = useState<
-    string[]
-  >([]);
-  const [wizardError, setWizardError] = useState<string | null>(null);
-
-  const resetWizardState = useCallback(() => {
-    setWizardStep(null);
-    setInitialDataTypeKey(null);
-    setCurrentDataTypeKey(null);
-    setSelectedProcessingOption(null);
-    setSelectedAction(null);
-    setSelectedFollowUp(null);
-    setSelectedBranchConfig(null);
-    setStagingNodeId(null);
-    setRootParentNodeId(null);
-    setBaseStagingSnapshot(null);
-    setActionNodeId(null);
-    setSessionOwnedLeafNodeIds([]);
-    setWizardError(null);
-  }, []);
 
   const activeNode = useMemo(
     () => nodes.find((node) => node.id === activePanelNodeId) ?? null,
     [activePanelNodeId, nodes],
   );
-  const incomingEdge = useMemo(
-    () =>
-      activePanelNodeId
-        ? (edges.find((edge) => edge.target === activePanelNodeId) ?? null)
-        : null,
-    [activePanelNodeId, edges],
-  );
-  const parentNode = useMemo(
-    () =>
-      incomingEdge
-        ? (nodes.find((node) => node.id === incomingEdge.source) ?? null)
-        : null,
-    [incomingEdge, nodes],
-  );
-  const stagingNode = useMemo(
-    () => nodes.find((node) => node.id === stagingNodeId) ?? null,
-    [nodes, stagingNodeId],
-  );
-  const actionNode = useMemo(
-    () => nodes.find((node) => node.id === actionNodeId) ?? null,
-    [actionNodeId, nodes],
-  );
 
-  const resolveNodeRole = useCallback(
-    (nodeId: string): "start" | "middle" | "end" => {
-      if (nodeId === startNodeId) {
-        return "start";
-      }
-      if (nodeId === endNodeId) {
-        return "end";
-      }
-      return "middle";
-    },
-    [endNodeId, startNodeId],
-  );
-
-  const createSnapshot = useCallback(
-    (node: (typeof nodes)[number]): WizardNodeSnapshot => ({
-      authWarning: node.data.authWarning,
-      config: {
-        ...node.data.config,
-      } as FlowNodeData["config"],
-      inputTypes: [...node.data.inputTypes],
-      outputTypes: [...node.data.outputTypes],
-      position: { ...node.position },
-      role: resolveNodeRole(node.id),
-      type: node.data.type,
-    }),
-    [resolveNodeRole],
-  );
-
-  const isWizardMode = isMiddleWizardPending(
-    activeNode,
-    startNodeId,
-    endNodeId,
-  );
   const isDetailMode = isMiddleWizardCompleted(activeNode);
-
-  const {
-    data: serverChoiceResponse,
-    isLoading: isChoicesLoading,
-    isError: isChoicesError,
-  } = useWorkflowChoicesQuery(
-    workflowId || undefined,
-    isWizardMode ? (parentNode?.id ?? null) : null,
-    isWizardMode,
-  );
-
-  const initialLocalChoiceResponse = useMemo(
-    () =>
-      initialDataTypeKey
-        ? buildLocalChoiceResponse(mappingRules, initialDataTypeKey)
-        : null,
-    [initialDataTypeKey, mappingRules],
-  );
-  const initialChoiceResponse = useMemo(
-    () =>
-      mergeChoiceResponses(serverChoiceResponse, initialLocalChoiceResponse),
-    [initialLocalChoiceResponse, serverChoiceResponse],
-  );
-  const currentActionChoiceResponse = useMemo(
-    () =>
-      currentDataTypeKey
-        ? buildLocalActionResponse(mappingRules, currentDataTypeKey)
-        : null,
-    [currentDataTypeKey, mappingRules],
-  );
-  const activeActionChoiceResponse = useMemo(() => {
-    if (!currentActionChoiceResponse) {
-      return null;
-    }
-
-    if (
-      initialChoiceResponse &&
-      initialChoiceResponse.requiresProcessingMethod === false &&
-      currentDataTypeKey === initialDataTypeKey
-    ) {
-      return mergeChoiceResponses(
-        initialChoiceResponse,
-        currentActionChoiceResponse,
-      );
-    }
-
-    return currentActionChoiceResponse;
-  }, [
-    currentActionChoiceResponse,
-    currentDataTypeKey,
-    initialChoiceResponse,
-    initialDataTypeKey,
-  ]);
-
+  const activeMeta = activeNode ? NODE_REGISTRY[activeNode.data.type] : null;
   const outputDataLabel =
     activeNode?.data.outputTypes[0] !== undefined
       ? OUTPUT_DATA_LABELS[activeNode.data.outputTypes[0]]
       : "출력 데이터";
-  const activeMeta = activeNode ? NODE_REGISTRY[activeNode.data.type] : null;
-  const isWorkflowBusy =
-    isChoicesLoading ||
-    isAddNodePending ||
-    isDeleteNodePending ||
-    isUpdateNodePending ||
-    isSelectChoicePending;
+
   const closedTransform =
     layout.mode === "stacked"
       ? `translate3d(0, ${layout.canvasHeight - layout.outputPanelTop + 24}px, 0)`
@@ -433,516 +102,9 @@ export const OutputPanel = () => {
     ? `transform ${PANEL_TRANSITION_MS}ms ease, opacity ${PANEL_TRANSITION_MS}ms ease, visibility 0ms linear 0ms`
     : `transform ${PANEL_TRANSITION_MS}ms ease, opacity ${PANEL_TRANSITION_MS}ms ease, visibility 0ms linear ${PANEL_TRANSITION_MS}ms`;
 
-  const buildNodeConfig = useCallback(
-    ({
-      type,
-      baseConfig,
-      isConfigured,
-      overrides,
-      preserveExistingConfig = false,
-    }: {
-      type: NodeType;
-      baseConfig?: FlowNodeData["config"];
-      isConfigured: boolean;
-      overrides?: Partial<FlowNodeData["config"]>;
-      preserveExistingConfig?: boolean;
-    }) =>
-      ({
-        ...(preserveExistingConfig
-          ? (baseConfig ?? NODE_REGISTRY[type].defaultConfig)
-          : NODE_REGISTRY[type].defaultConfig),
-        ...overrides,
-        isConfigured,
-      }) as FlowNodeData["config"],
-    [],
-  );
-
-  const syncWorkflowFromResponse = useCallback(
-    (workflow: WorkflowResponse) => {
-      syncWorkflowGraph(hydrateStore(workflow), {
-        preserveActivePanelNodeId: true,
-        preserveActivePlaceholder: true,
-        preserveDirty: true,
-      });
-    },
-    [syncWorkflowGraph],
-  );
-
-  const syncUpdatedNode = useCallback(
-    (workflow: WorkflowResponse, nodeId: string) => {
-      const nextNode = workflow.nodes.find((node) => node.id === nodeId);
-      if (!nextNode) {
-        throw new Error("node was not updated");
-      }
-
-      syncWorkflowFromResponse(workflow);
-      return nextNode.id;
-    },
-    [syncWorkflowFromResponse],
-  );
-
-  const canSafelyDeleteWizardLeaf = useCallback(
-    (nodeId: string) => {
-      if (!sessionOwnedLeafNodeIds.includes(nodeId)) {
-        return false;
-      }
-
-      if (nodeId === stagingNodeId) {
-        return false;
-      }
-
-      if (resolveNodeRole(nodeId) !== "middle") {
-        return false;
-      }
-
-      return !edges.some((edge) => edge.source === nodeId);
-    },
-    [edges, resolveNodeRole, sessionOwnedLeafNodeIds, stagingNodeId],
-  );
-
-  const updatePersistedNode = useCallback(
-    async ({
-      node,
-      type,
-      config,
-      inputDataTypeKey,
-      outputDataTypeKey,
-      position,
-      role,
-    }: {
-      node: (typeof nodes)[number];
-      type: NodeType;
-      config: FlowNodeData["config"];
-      inputDataTypeKey?: MappingDataTypeKey | null;
-      outputDataTypeKey?: MappingDataTypeKey | null;
-      position?: { x: number; y: number };
-      role?: "start" | "middle" | "end";
-    }) => {
-      if (!workflowId) {
-        throw new Error("workflowId is required");
-      }
-
-      const nextWorkflow = await updateWorkflowNode({
-        workflowId,
-        nodeId: node.id,
-        body: {
-          category: toBackendNodeType(type).category,
-          type: toBackendNodeType(type).type,
-          config: config as unknown as Record<string, unknown>,
-          position: position ?? node.position,
-          dataType:
-            inputDataTypeKey !== undefined
-              ? inputDataTypeKey
-                ? toBackendDataType(toDataType(inputDataTypeKey))
-                : null
-              : node.data.inputTypes[0]
-                ? toBackendDataType(node.data.inputTypes[0])
-                : null,
-          outputDataType:
-            outputDataTypeKey !== undefined
-              ? outputDataTypeKey
-                ? toBackendDataType(toDataType(outputDataTypeKey))
-                : null
-              : node.data.outputTypes[0]
-                ? toBackendDataType(node.data.outputTypes[0])
-                : null,
-          role: role ?? resolveNodeRole(node.id),
-          authWarning: node.data.authWarning ?? false,
-        },
-      });
-
-      return syncUpdatedNode(nextWorkflow, node.id);
-    },
-    [resolveNodeRole, syncUpdatedNode, updateWorkflowNode, workflowId],
-  );
-
-  const placeWorkflowNode = useCallback(
-    async ({
-      type,
-      sourceNodeId,
-      position,
-      inputDataTypeKey,
-      outputDataTypeKey,
-      config,
-    }: {
-      type: NodeType;
-      sourceNodeId: string;
-      position: { x: number; y: number };
-      inputDataTypeKey?: MappingDataTypeKey | null;
-      outputDataTypeKey: MappingDataTypeKey | null;
-      config?: Partial<FlowNodeData["config"]>;
-    }) => {
-      if (!workflowId) {
-        throw new Error("workflowId is required");
-      }
-
-      const previousNodes = useWorkflowStore.getState().nodes;
-      const nextWorkflow = await addWorkflowNode({
-        workflowId,
-        body: toNodeAddRequest({
-          type,
-          position,
-          prevNodeId: sourceNodeId,
-          config,
-          inputTypes: inputDataTypeKey
-            ? [toDataType(inputDataTypeKey)]
-            : undefined,
-          outputTypes: outputDataTypeKey
-            ? [toDataType(outputDataTypeKey)]
-            : undefined,
-        }),
-      });
-
-      const addedNodeId =
-        findAddedNodeId(previousNodes, nextWorkflow.nodes) ??
-        nextWorkflow.nodes.at(-1)?.id ??
-        null;
-      const addedNode = nextWorkflow.nodes.find(
-        (node) => node.id === addedNodeId,
-      );
-
-      if (!addedNodeId || !addedNode) {
-        return null;
-      }
-
-      syncWorkflowFromResponse(nextWorkflow);
-      return addedNodeId;
-    },
-    [addWorkflowNode, syncWorkflowFromResponse, workflowId],
-  );
-
-  const removeWorkflowNode = useCallback(
-    async (nodeId: string) => {
-      if (!workflowId) {
-        throw new Error("workflowId is required");
-      }
-
-      const nextWorkflow = await deleteWorkflowNode({
-        workflowId,
-        nodeId,
-      });
-      syncWorkflowFromResponse(nextWorkflow);
-    },
-    [deleteWorkflowNode, syncWorkflowFromResponse, workflowId],
-  );
-
-  useEffect(() => {
-    if (!isWizardMode || !activeNode || !parentNode || initialDataTypeKey) {
-      return;
-    }
-
-    const parentOutputType = parentNode.data.outputTypes[0] ?? null;
-    if (!parentOutputType) {
-      return;
-    }
-
-    const mappingKey = toMappingKey(parentOutputType);
-    setStagingNodeId(activeNode.id);
-    setRootParentNodeId(parentNode.id);
-    setBaseStagingSnapshot(createSnapshot(activeNode));
-    setInitialDataTypeKey(mappingKey);
-    setCurrentDataTypeKey(mappingKey);
-  }, [
-    activeNode,
-    createSnapshot,
-    initialDataTypeKey,
-    isWizardMode,
-    parentNode,
-  ]);
-
-  useEffect(() => {
-    if (!isWizardMode || wizardStep || !initialChoiceResponse) {
-      return;
-    }
-
-    setWizardStep(
-      initialChoiceResponse.requiresProcessingMethod
-        ? "processing-method"
-        : "action",
-    );
-  }, [initialChoiceResponse, isWizardMode, wizardStep]);
-
   const handleClose = () => {
-    resetWizardState();
+    wizardController.reset();
     closePanel();
-  };
-
-  const finishWizard = () => {
-    resetWizardState();
-  };
-
-  const handleProcessingMethodSelect = async (option: WizardChoiceOption) => {
-    if (
-      !stagingNode ||
-      !rootParentNodeId ||
-      !currentDataTypeKey ||
-      !initialDataTypeKey
-    ) {
-      return;
-    }
-
-    setWizardError(null);
-    setSelectedProcessingOption(option);
-
-    try {
-      const selectionResult = await selectWorkflowChoice({
-        workflowId,
-        prevNodeId: rootParentNodeId,
-        optionId: option.id,
-        dataType: currentDataTypeKey,
-      });
-
-      const nextDataTypeKey = isMappingDataTypeKey(
-        mappingRules,
-        selectionResult.outputDataType,
-      )
-        ? selectionResult.outputDataType
-        : isMappingDataTypeKey(mappingRules, option.output_data_type)
-          ? option.output_data_type
-          : currentDataTypeKey;
-
-      const nextActions = buildLocalActionResponse(
-        mappingRules,
-        nextDataTypeKey,
-      );
-
-      const nextNodeType = selectionResult.nodeType
-        ? toChoiceNodeType(selectionResult.nodeType)
-        : toChoiceNodeType(option.node_type);
-      const isConfigured = nextActions.options.length === 0;
-
-      await updatePersistedNode({
-        node: stagingNode,
-        type: nextNodeType,
-        config: buildNodeConfig({
-          type: nextNodeType,
-          isConfigured,
-        }),
-        inputDataTypeKey: initialDataTypeKey,
-        outputDataTypeKey: nextDataTypeKey,
-        role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
-      });
-
-      openPanel(stagingNode.id);
-
-      if (nextActions.options.length > 0) {
-        setCurrentDataTypeKey(nextDataTypeKey);
-        setWizardStep("action");
-        return;
-      }
-
-      finishWizard();
-    } catch {
-      setWizardError("처리 방식을 반영하지 못했습니다.");
-    }
-  };
-
-  const handleActionSelect = async (action: WizardChoiceOption) => {
-    if (!stagingNode || !rootParentNodeId || !currentDataTypeKey) {
-      return;
-    }
-
-    setWizardError(null);
-
-    try {
-      const selectionResult = await selectWorkflowChoice({
-        workflowId,
-        prevNodeId: rootParentNodeId,
-        optionId: action.id,
-        dataType: currentDataTypeKey,
-      });
-
-      const nextDataTypeKey = isMappingDataTypeKey(
-        mappingRules,
-        selectionResult.outputDataType,
-      )
-        ? selectionResult.outputDataType
-        : isMappingDataTypeKey(mappingRules, action.output_data_type)
-          ? action.output_data_type
-          : currentDataTypeKey;
-
-      const followUp = selectionResult.followUp ?? action.followUp ?? null;
-      const branchConfig =
-        selectionResult.branchConfig ?? action.branchConfig ?? null;
-
-      const actionNodeType = selectionResult.nodeType
-        ? toChoiceNodeType(selectionResult.nodeType)
-        : toChoiceNodeType(action.node_type);
-      const hasFollowUp = Boolean(followUp || branchConfig);
-      const finalActionConfig = buildNodeConfig({
-        type: actionNodeType,
-        isConfigured: !hasFollowUp,
-        overrides: hasFollowUp
-          ? undefined
-          : {
-              choiceActionId: action.id,
-              choiceSelections: null,
-            },
-      });
-      const shouldUseActionLeaf = stagingNode.data.type === "loop";
-      let targetNodeId = stagingNode.id;
-
-      if (shouldUseActionLeaf) {
-        if (actionNode) {
-          await updatePersistedNode({
-            node: actionNode,
-            type: actionNodeType,
-            config: finalActionConfig,
-            inputDataTypeKey: currentDataTypeKey,
-            outputDataTypeKey: nextDataTypeKey,
-          });
-          targetNodeId = actionNode.id;
-        } else {
-          const createdActionNodeId = await placeWorkflowNode({
-            type: actionNodeType,
-            sourceNodeId: stagingNode.id,
-            position: {
-              x: stagingNode.position.x + DEFAULT_FLOW_NODE_WIDTH + NODE_GAP_X,
-              y: stagingNode.position.y,
-            },
-            inputDataTypeKey: currentDataTypeKey,
-            outputDataTypeKey: nextDataTypeKey,
-            config: finalActionConfig,
-          });
-
-          if (!createdActionNodeId) {
-            throw new Error("action node was not created");
-          }
-
-          setActionNodeId(createdActionNodeId);
-          setSessionOwnedLeafNodeIds((current) =>
-            current.includes(createdActionNodeId)
-              ? current
-              : [...current, createdActionNodeId],
-          );
-          targetNodeId = createdActionNodeId;
-        }
-      } else {
-        await updatePersistedNode({
-          node: stagingNode,
-          type: actionNodeType,
-          config: finalActionConfig,
-          inputDataTypeKey: currentDataTypeKey,
-          outputDataTypeKey: nextDataTypeKey,
-          role: baseStagingSnapshot?.role ?? resolveNodeRole(stagingNode.id),
-        });
-        setActionNodeId(null);
-      }
-
-      setSelectedAction(action);
-      setSelectedFollowUp(followUp);
-      setSelectedBranchConfig(branchConfig);
-      setCurrentDataTypeKey(nextDataTypeKey);
-      openPanel(targetNodeId);
-
-      if (followUp || branchConfig) {
-        setWizardStep("follow-up");
-        return;
-      }
-
-      finishWizard();
-    } catch {
-      setWizardError("작업 노드를 반영하지 못했습니다.");
-    }
-  };
-
-  const handleBackToProcessingMethod = async () => {
-    if (!initialDataTypeKey || !stagingNode || !baseStagingSnapshot) {
-      return;
-    }
-
-    setWizardError(null);
-
-    try {
-      if (actionNodeId && actionNode) {
-        if (!canSafelyDeleteWizardLeaf(actionNode.id)) {
-          setWizardError(
-            "이미 후속 연결이 생겨 이전 단계로 되돌릴 수 없습니다.",
-          );
-          return;
-        }
-
-        await removeWorkflowNode(actionNode.id);
-        setSessionOwnedLeafNodeIds((current) =>
-          current.filter((nodeId) => nodeId !== actionNode.id),
-        );
-      }
-
-      await updatePersistedNode({
-        node: stagingNode,
-        type: baseStagingSnapshot.type,
-        config: baseStagingSnapshot.config,
-        inputDataTypeKey: baseStagingSnapshot.inputTypes[0]
-          ? toMappingKey(baseStagingSnapshot.inputTypes[0])
-          : null,
-        outputDataTypeKey: baseStagingSnapshot.outputTypes[0]
-          ? toMappingKey(baseStagingSnapshot.outputTypes[0])
-          : null,
-        position: baseStagingSnapshot.position,
-        role: baseStagingSnapshot.role,
-      });
-
-      openPanel(stagingNode.id);
-      setActionNodeId(null);
-      setSelectedAction(null);
-      setSelectedFollowUp(null);
-      setSelectedBranchConfig(null);
-      setSelectedProcessingOption(null);
-      setCurrentDataTypeKey(initialDataTypeKey);
-      setWizardStep("processing-method");
-    } catch {
-      setWizardError("이전 단계로 돌아가지 못했습니다.");
-    }
-  };
-
-  const handleBackToAction = () => {
-    const targetNodeId = actionNodeId ?? stagingNodeId;
-    if (!targetNodeId) {
-      return;
-    }
-
-    setWizardError(null);
-    openPanel(targetNodeId);
-    setSelectedAction(null);
-    setSelectedFollowUp(null);
-    setSelectedBranchConfig(null);
-    setWizardStep("action");
-  };
-  const handleFollowUpComplete = async (
-    selections: Record<string, string | string[]>,
-  ) => {
-    const targetNode = actionNode ?? stagingNode;
-    if (!targetNode || !selectedAction) {
-      return;
-    }
-
-    setWizardError(null);
-
-    try {
-      await updatePersistedNode({
-        node: targetNode,
-        type: targetNode.data.type,
-        config: buildNodeConfig({
-          type: targetNode.data.type,
-          baseConfig: targetNode.data.config,
-          isConfigured: true,
-          overrides: {
-            choiceActionId: selectedAction.id,
-            choiceSelections: selections,
-          },
-          preserveExistingConfig: true,
-        }),
-        role:
-          targetNode.id === stagingNode?.id
-            ? (baseStagingSnapshot?.role ?? resolveNodeRole(targetNode.id))
-            : resolveNodeRole(targetNode.id),
-      });
-
-      openPanel(targetNode.id);
-      finishWizard();
-    } catch {
-      setWizardError("후속 설정을 반영하지 못했습니다.");
-    }
   };
 
   return (
@@ -971,7 +133,7 @@ export const OutputPanel = () => {
       flexDirection="column"
       gap={3}
     >
-      {isWizardMode && wizardStep ? (
+      {wizardController.isWizardMode && wizardController.wizardStep ? (
         <>
           <Box
             display="flex"
@@ -997,48 +159,54 @@ export const OutputPanel = () => {
                 borderColor="gray.200"
               >
                 <Text fontSize="sm" color="text.secondary">
-                  공유된 워크플로우는 읽기 전용입니다. 이 노드 설정은 소유자만
+                  공유된 워크플로우는 읽기 전용입니다. 노드 설정은 소유자만
                   변경할 수 있습니다.
                 </Text>
               </Box>
             ) : null}
 
             {canEditNodes &&
-            wizardStep === "processing-method" &&
-            initialChoiceResponse ? (
+            wizardController.wizardStep === "processing-method" &&
+            wizardController.initialChoiceResponse ? (
               <ProcessingMethodStep
-                question={initialChoiceResponse.question}
-                options={initialChoiceResponse.options}
-                onSelect={(option) => void handleProcessingMethodSelect(option)}
+                question={wizardController.initialChoiceResponse.question}
+                options={wizardController.initialChoiceResponse.options}
+                onSelect={(option) =>
+                  void wizardController.selectProcessingMethod(option)
+                }
               />
             ) : null}
 
             {canEditNodes &&
-            wizardStep === "action" &&
-            activeActionChoiceResponse ? (
+            wizardController.wizardStep === "action" &&
+            wizardController.activeActionChoiceResponse ? (
               <ActionStep
-                question={activeActionChoiceResponse.question}
-                actions={activeActionChoiceResponse.options}
-                onSelect={(action) => void handleActionSelect(action)}
+                question={wizardController.activeActionChoiceResponse.question}
+                actions={wizardController.activeActionChoiceResponse.options}
+                onSelect={(action) =>
+                  void wizardController.selectAction(action)
+                }
                 onBack={
-                  selectedProcessingOption
-                    ? () => void handleBackToProcessingMethod()
+                  wizardController.selectedProcessingOption
+                    ? () => void wizardController.backToProcessingMethod()
                     : undefined
                 }
               />
             ) : null}
 
-            {canEditNodes && wizardStep === "follow-up" ? (
+            {canEditNodes && wizardController.wizardStep === "follow-up" ? (
               <FollowUpStep
-                followUp={selectedFollowUp}
-                branchConfig={selectedBranchConfig}
-                onComplete={handleFollowUpComplete}
-                onBack={() => void handleBackToAction()}
+                followUp={wizardController.selectedFollowUp}
+                branchConfig={wizardController.selectedBranchConfig}
+                onComplete={(selections) =>
+                  void wizardController.completeFollowUp(selections)
+                }
+                onBack={() => void wizardController.backToAction()}
               />
             ) : null}
           </Box>
 
-          {isWorkflowBusy ? (
+          {wizardController.isWorkflowBusy ? (
             <Box display="flex" alignItems="center" gap={2} px={6}>
               <Spinner size="sm" color="gray.500" />
               <Text fontSize="sm" color="gray.500">
@@ -1047,15 +215,16 @@ export const OutputPanel = () => {
             </Box>
           ) : null}
 
-          {isChoicesError && !serverChoiceResponse ? (
+          {wizardController.isChoicesError &&
+          !wizardController.serverChoiceResponse ? (
             <Text px={6} fontSize="sm" color="orange.500">
               서버 선택지를 가져오지 못해 로컬 규칙으로 이어갑니다.
             </Text>
           ) : null}
 
-          {wizardError ? (
+          {wizardController.wizardError ? (
             <Text px={6} fontSize="sm" color="red.500">
-              {wizardError}
+              {wizardController.wizardError}
             </Text>
           ) : null}
         </>
@@ -1088,7 +257,7 @@ export const OutputPanel = () => {
                 {outputDataLabel}
               </Text>
               <Text fontSize="sm" color="text.secondary">
-                처리된 데이터 미리보기는 백엔드 실행 연동 뒤 더 풍부하게 보여줄
+                처리된 데이터 미리보기는 백엔드 실행 연동 뒤에 자연스럽게 보여줄
                 예정입니다.
               </Text>
             </Box>

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -49,6 +49,9 @@ type OutputPanelWizardController = {
   selectedBranchConfig: ChoiceBranchConfig | null;
   wizardError: string | null;
   isWorkflowBusy: boolean;
+  isChoiceStepLoading: boolean;
+  isChoiceStepUnavailable: boolean;
+  isUsingChoiceFallback: boolean;
   isChoicesError: boolean;
   serverChoiceResponse: ChoiceResponse | null | undefined;
   selectProcessingMethod: (option: WizardChoiceOption) => Promise<void>;
@@ -66,6 +69,32 @@ type Props = {
 };
 
 const PANEL_TRANSITION_MS = 240;
+
+const ChoiceStepStatus = ({
+  message,
+  showSpinner = false,
+  tone = "muted",
+}: {
+  message: string;
+  showSpinner?: boolean;
+  tone?: "muted" | "error";
+}) => (
+  <Box
+    display="flex"
+    alignItems="center"
+    gap={2}
+    p={4}
+    borderRadius="xl"
+    bg={tone === "error" ? "red.50" : "gray.50"}
+    border="1px solid"
+    borderColor={tone === "error" ? "red.100" : "gray.200"}
+  >
+    {showSpinner ? <Spinner size="sm" color="gray.500" /> : null}
+    <Text fontSize="sm" color={tone === "error" ? "red.500" : "gray.500"}>
+      {message}
+    </Text>
+  </Box>
+);
 
 export const OutputPanel = ({ wizardController }: Props) => {
   const nodes = useWorkflowStore((state) => state.nodes);
@@ -106,6 +135,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
     wizardController.reset();
     closePanel();
   };
+  const shouldShowChoiceStepLoading =
+    canEditNodes && wizardController.isChoiceStepLoading;
+  const shouldShowChoiceStepUnavailable =
+    canEditNodes && wizardController.isChoiceStepUnavailable;
+  const canShowWizardStepContent =
+    canEditNodes &&
+    !shouldShowChoiceStepLoading &&
+    !shouldShowChoiceStepUnavailable;
 
   return (
     <Box
@@ -133,7 +170,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
       flexDirection="column"
       gap={3}
     >
-      {wizardController.isWizardMode && wizardController.wizardStep ? (
+      {wizardController.isWizardMode ? (
         <>
           <Box
             display="flex"
@@ -165,7 +202,21 @@ export const OutputPanel = ({ wizardController }: Props) => {
               </Box>
             ) : null}
 
-            {canEditNodes &&
+            {shouldShowChoiceStepLoading ? (
+              <ChoiceStepStatus
+                message="선택지를 불러오는 중입니다."
+                showSpinner
+              />
+            ) : null}
+
+            {shouldShowChoiceStepUnavailable ? (
+              <ChoiceStepStatus
+                message="선택지를 불러오지 못했습니다."
+                tone="error"
+              />
+            ) : null}
+
+            {canShowWizardStepContent &&
             wizardController.wizardStep === "processing-method" &&
             wizardController.initialChoiceResponse ? (
               <ProcessingMethodStep
@@ -177,7 +228,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
               />
             ) : null}
 
-            {canEditNodes &&
+            {canShowWizardStepContent &&
             wizardController.wizardStep === "action" &&
             wizardController.activeActionChoiceResponse ? (
               <ActionStep
@@ -194,7 +245,8 @@ export const OutputPanel = ({ wizardController }: Props) => {
               />
             ) : null}
 
-            {canEditNodes && wizardController.wizardStep === "follow-up" ? (
+            {canShowWizardStepContent &&
+            wizardController.wizardStep === "follow-up" ? (
               <FollowUpStep
                 followUp={wizardController.selectedFollowUp}
                 branchConfig={wizardController.selectedBranchConfig}
@@ -206,7 +258,8 @@ export const OutputPanel = ({ wizardController }: Props) => {
             ) : null}
           </Box>
 
-          {wizardController.isWorkflowBusy ? (
+          {wizardController.isWorkflowBusy &&
+          !wizardController.isChoiceStepLoading ? (
             <Box display="flex" alignItems="center" gap={2} px={6}>
               <Spinner size="sm" color="gray.500" />
               <Text fontSize="sm" color="gray.500">
@@ -215,8 +268,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           ) : null}
 
-          {wizardController.isChoicesError &&
-          !wizardController.serverChoiceResponse ? (
+          {wizardController.isUsingChoiceFallback ? (
             <Text px={6} fontSize="sm" color="orange.500">
               서버 선택지를 가져오지 못해 로컬 규칙으로 이어갑니다.
             </Text>

--- a/src/widgets/output-panel/ui/WizardStepContent.test.tsx
+++ b/src/widgets/output-panel/ui/WizardStepContent.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ChakraProvider } from "@chakra-ui/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { system } from "@/shared";
+
+import { FollowUpStep } from "./WizardStepContent";
+
+const renderFollowUpStep = (props: React.ComponentProps<typeof FollowUpStep>) =>
+  renderToStaticMarkup(
+    <ChakraProvider value={system}>
+      <FollowUpStep {...props} />
+    </ChakraProvider>,
+  );
+
+const getCompleteButtonTag = (html: string) => {
+  const match = html.match(/<button[^>]*>완료<\/button>/);
+  return match?.[0] ?? "";
+};
+
+describe("FollowUpStep", () => {
+  it("blocks completion when dynamic options are unresolved", () => {
+    const html = renderFollowUpStep({
+      followUp: {
+        question: "필드를 선택하세요",
+        options: [],
+        options_source: "fields_from_service",
+        multi_select: true,
+      },
+      branchConfig: null,
+      onBack: vi.fn(),
+      onComplete: vi.fn(),
+    });
+
+    expect(html).toContain(
+      "이전 노드의 서비스 또는 필드 정보가 부족해 옵션을 불러오지 못했습니다.",
+    );
+    expect(getCompleteButtonTag(html)).toContain("disabled");
+  });
+
+  it("allows completion when an empty static follow-up has no options source", () => {
+    const html = renderFollowUpStep({
+      followUp: {
+        question: "추가 설정",
+        options: [],
+        options_source: null,
+        multi_select: false,
+      },
+      branchConfig: null,
+      onBack: vi.fn(),
+      onComplete: vi.fn(),
+    });
+
+    expect(html).toContain("현재 단계에서 보여줄 추가 옵션이 없습니다.");
+    expect(getCompleteButtonTag(html)).not.toContain("disabled");
+  });
+});

--- a/src/widgets/output-panel/ui/WizardStepContent.tsx
+++ b/src/widgets/output-panel/ui/WizardStepContent.tsx
@@ -150,8 +150,14 @@ type QuestionBlock = {
   question: string;
   multiSelect: boolean;
   options: ChoiceOption[];
+  isDynamicOptionsUnresolved: boolean;
   description?: string | null;
 };
+
+const isDynamicOptionsUnresolved = (
+  optionsSource: string | null | undefined,
+  options: ChoiceOption[],
+) => Boolean(optionsSource && options.length === 0);
 
 const buildQuestionBlocks = (
   followUp: ChoiceFollowUp | null,
@@ -165,6 +171,10 @@ const buildQuestionBlocks = (
       question: followUp.question,
       multiSelect: followUp.multi_select ?? false,
       options: followUp.options ?? [],
+      isDynamicOptionsUnresolved: isDynamicOptionsUnresolved(
+        followUp.options_source,
+        followUp.options ?? [],
+      ),
       description: followUp.description,
     });
   }
@@ -175,6 +185,10 @@ const buildQuestionBlocks = (
       question: branchConfig.question,
       multiSelect: branchConfig.multi_select ?? false,
       options: branchConfig.options ?? [],
+      isDynamicOptionsUnresolved: isDynamicOptionsUnresolved(
+        branchConfig.options_source,
+        branchConfig.options ?? [],
+      ),
       description: branchConfig.description,
     });
   }
@@ -196,6 +210,9 @@ export const FollowUpStep = ({
     {},
   );
   const [customInputs, setCustomInputs] = useState<Record<string, string>>({});
+  const hasUnresolvedDynamicOptions = questionBlocks.some(
+    (block) => block.isDynamicOptionsUnresolved,
+  );
 
   const updateSelection = (
     blockId: string,
@@ -236,6 +253,10 @@ export const FollowUpStep = ({
   };
 
   const handleComplete = () => {
+    if (hasUnresolvedDynamicOptions) {
+      return;
+    }
+
     const mergedSelections = {
       ...selections,
       ...Object.fromEntries(
@@ -274,9 +295,16 @@ export const FollowUpStep = ({
           ) : null}
 
           {block.options.length === 0 ? (
-            <Text fontSize="sm" color="text.secondary">
-              현재 단계에서 보여줄 추가 옵션이 없습니다.
-            </Text>
+            block.isDynamicOptionsUnresolved ? (
+              <Text fontSize="sm" color="red.500">
+                이전 노드의 서비스 또는 필드 정보가 부족해 옵션을 불러오지
+                못했습니다.
+              </Text>
+            ) : (
+              <Text fontSize="sm" color="text.secondary">
+                현재 단계에서 보여줄 추가 옵션이 없습니다.
+              </Text>
+            )
           ) : (
             <VStack align="stretch" gap={3}>
               {block.options.map((option) => {
@@ -327,7 +355,11 @@ export const FollowUpStep = ({
         </VStack>
       ))}
 
-      <Button alignSelf="flex-start" onClick={handleComplete}>
+      <Button
+        alignSelf="flex-start"
+        disabled={hasUnresolvedDynamicOptions}
+        onClick={handleComplete}
+      >
         완료
       </Button>
     </VStack>


### PR DESCRIPTION
## 📝 요약 (Summary)

백엔드 choice wizard 계약에 맞춰 프론트의 choice 조회/선택 흐름, context 전달, fallback 정책을 정렬했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- GET choices 요청에 `service`, `file_subtype` query context를 반영했습니다.
- POST select 요청은 `actionId` 계약을 유지하고, `service`, `file_subtype`, `fields` context를 함께 전달하도록 정리했습니다.
- processing/action 선택 후 새로 생성된 anchor node 기준으로 다음 choice를 조회하도록 wizard 흐름을 수정했습니다.
- 서버 choice 로딩 중 로컬 fallback이 먼저 노출되지 않도록 fallback 정책을 분리했습니다.
- `options_source` 기반 동적 옵션 resolve 실패 시 완료 버튼이 비활성화되도록 처리하고 테스트를 추가했습니다.

## 💻 상세 구현 내용 (Implementation Details)

- `ChoiceQueryContext`, `ChoiceSelectContext` 타입을 추가하고 query key에 context를 포함했습니다.
- upstream node 정보를 기반으로 choice 요청 context를 만드는 `choiceWizardContext`를 추가했습니다.
- `useChoiceWizardController`에서 `anchorNodeId`, choice loading/unavailable/fallback 상태를 관리하도록 변경했습니다.
- `OutputPanel`은 wizard mode에서 step이 아직 없어도 wizard shell을 유지하고 상태별 UI를 표시합니다.
- `WizardStepContent`는 `options_source`가 있는데 options가 비어 있는 경우 동적 옵션 미해결 상태로 판단해 완료를 막습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

- 기존에는 첫 선택 이후에도 최초 parent 기준으로 choice 흐름이 이어져 백엔드의 “새 node 기준 다음 choice 조회” 흐름과 어긋날 수 있었습니다.
- 서버 응답이 오기 전에 fallback action이 먼저 보이면 stale option POST로 400이 재발할 수 있어, 서버 실패가 확정된 뒤에만 fallback을 허용하도록 변경했습니다.
- `options_source`가 존재하지만 options가 비어 있는 응답은 “선택지 없음”이 아니라 context 부족/resolve 실패로 해석하도록 분기했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 백엔드 POST `/select`는 현재 `applicable_when` 재검증까지는 하지 않아, 수동 요청으로 숨겨진 option을 보낼 수 있습니다. 프론트 이슈를 막지는 않지만 백엔드 후속 개선 후보입니다.
- 백엔드 검토 참고 문서 `docs/backend/CHOICE_WIZARD_BACKEND_FIX_REPORT (2).md`는 PR 커밋 범위에서 제외했습니다.

## 📸 스크린샷 (Screenshots)

- UI 구조 변경보다 choice wizard 상태 흐름 변경 중심이라 생략합니다.

## #️⃣ 관련 이슈 (Related Issues)

- #116
