### PR TITLE
[PR] 도착 노드 생성 후 위치 보정 오류 수정

### DIFF
--- a/src/shared/libs/graph.test.ts
+++ b/src/shared/libs/graph.test.ts
@@ -1,0 +1,47 @@
+import { type Edge } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import { getLeafNodeIds } from "./graph";
+
+const createEdge = (source: string, target: string): Edge => ({
+  id: `${source}-${target}`,
+  source,
+  target,
+});
+
+describe("getLeafNodeIds", () => {
+  it("returns nodes without outgoing edges inside the candidate set", () => {
+    const leaves = getLeafNodeIds(
+      ["start", "middle"],
+      [createEdge("start", "middle")],
+    );
+
+    expect(leaves).toEqual(["middle"]);
+  });
+
+  it("ignores outgoing edges to nodes outside the candidate set", () => {
+    const leaves = getLeafNodeIds(
+      ["start", "middle", "ai"],
+      [
+        createEdge("start", "middle"),
+        createEdge("middle", "ai"),
+        createEdge("ai", "end"),
+      ],
+    );
+
+    expect(leaves).toEqual(["ai"]);
+  });
+
+  it("keeps branch leaves when one branch already points to an excluded end node", () => {
+    const leaves = getLeafNodeIds(
+      ["start", "branch-a", "branch-b"],
+      [
+        createEdge("start", "branch-a"),
+        createEdge("start", "branch-b"),
+        createEdge("branch-b", "end"),
+      ],
+    );
+
+    expect(leaves).toEqual(["branch-a", "branch-b"]);
+  });
+});

--- a/src/shared/libs/graph.ts
+++ b/src/shared/libs/graph.ts
@@ -30,6 +30,14 @@ export const collectDescendantIds = (
  * outgoing edge가 없는 끝단(leaf) 노드의 ID 목록을 반환한다.
  */
 export const getLeafNodeIds = (nodeIds: string[], edges: Edge[]): string[] => {
-  const sourcesWithOutgoing = new Set(edges.map((e) => e.source));
+  const nodeIdSet = new Set(nodeIds);
+  const sourcesWithOutgoing = new Set(
+    edges
+      .filter(
+        (edge) => nodeIdSet.has(edge.source) && nodeIdSet.has(edge.target),
+      )
+      .map((edge) => edge.source),
+  );
+
   return nodeIds.filter((id) => !sourcesWithOutgoing.has(id));
 };


### PR DESCRIPTION

## 📝 요약 (Summary)

도착 노드 생성 후 Canvas 재렌더링 시 도착 노드가 마지막 노드 뒤가 아니라 시작 노드 근처로 이동하는 문제를 수정했습니다.

leaf 노드 계산을 후보 노드 집합 내부 기준으로 바로잡아, 도착 노드로 향하는 edge가 마지막 중간 노드 판단을 방해하지 않도록 했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- `getLeafNodeIds`가 전달받은 후보 `nodeIds` 내부 subgraph 기준으로 leaf를 계산하도록 수정
- 도착 노드가 후보 노드에서 제외된 상태에서도 마지막 중간 노드가 leaf로 유지되도록 개선
- 도착 노드 위치 보정 회귀 방지를 위한 graph 유틸 단위 테스트 추가

## 💻 상세 구현 내용 (Implementation Details)

### Leaf 계산 기준 수정

기존에는 모든 edge의 `source`를 기준으로 outgoing 여부를 판단했습니다.

```ts
const sourcesWithOutgoing = new Set(edges.map((e) => e.source));
```

이 방식은 `endNodeId`를 후보 노드에서 제외해도 `마지막 노드 -> 도착 노드` edge 때문에 마지막 노드가 leaf에서 빠지는 문제가 있었습니다.

수정 후에는 `source`와 `target`이 모두 후보 `nodeIds`에 포함된 edge만 outgoing 판단에 사용합니다.

```ts
const nodeIdSet = new Set(nodeIds);
const sourcesWithOutgoing = new Set(
  edges
    .filter((edge) => nodeIdSet.has(edge.source) && nodeIdSet.has(edge.target))
    .map((edge) => edge.source),
);
```

### 회귀 테스트 추가

다음 케이스를 검증했습니다.

- 후보 집합 내부 edge가 있는 경우 기존 leaf 계산 유지
- 후보 집합 밖의 도착 노드로 향하는 edge는 leaf 판단에서 제외
- 분기 노드 중 한 branch가 도착 노드로 연결되어 있어도 branch leaf 유지

## 🚀 트러블 슈팅 (Trouble Shooting)

도착 노드 생성 요청의 `prevNodeId`와 edge 연결은 정상에 가까웠지만, 생성 후 Canvas가 도착 노드 위치를 다시 보정하는 과정에서 leaf 계산이 깨졌습니다.

특히 `endNodeId`는 `nodeIds`에서 제외했지만, `endNodeId`로 향하는 edge는 그대로 leaf 계산에 포함되어 마지막 중간 노드가 leaf에서 빠졌습니다. 이로 인해 `maxPlaceholderX`가 0으로 남고, 도착 노드가 시작 노드 근처로 이동했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 현재 worktree의 docker compose 삭제 및 docs untracked 변경은 이번 PR 범위가 아니며 포함하지 않았습니다.
- 실제 화면에서는 `시작 노드 -> 중간 노드 -> AI -> 도착 노드` 흐름에서 도착 노드가 마지막 노드 뒤에 유지되는지 확인하면 됩니다.

## 📸 스크린샷 (Screenshots)

> 필요 시 도착 노드 위치 보정 전/후 화면 첨부

## #️⃣ 관련 이슈 (Related Issues)

- #123 