### PR TITLE
[PR] 다음 단계 placeholder로 중간 노드와 도착 노드 설정 통합

### DIFF
--- a/docs/NODE_SETUP_WIZARD_DESIGN.md
+++ b/docs/NODE_SETUP_WIZARD_DESIGN.md
@@ -1,9 +1,16 @@
 # 노드 설정 위자드 상세 설계
 
 > **작성일:** 2026-04-05
-> **최종 수정:** 2026-04-08 (v4.3 — 반응형 듀얼 패널 유지 + 화살표형 custom edge 설계 추가)
+> **최종 수정:** 2026-05-03 (v4.4 — 다음 단계 placeholder 통합 설계 반영)
 > **선행 문서:** [FRONTEND_DESIGN_DOCUMENT.md](./FRONTEND_DESIGN_DOCUMENT.md), [FOUNDATION_IMPLEMENTATION_PLAN.md](./FOUNDATION_IMPLEMENTATION_PLAN.md)
 > **목적:** 시작/도착 노드 및 중간 노드의 설정 위자드 흐름을 설계한다.
+>
+> **v4.4 변경 요약:**
+> - `다음` placeholder와 `도착` placeholder를 **`다음 단계` placeholder 하나로 통합**
+> - `다음 단계` 클릭 시 캔버스 노드에서 `중간 처리 추가` / `보낼 곳 설정`을 선택
+> - `보낼 곳 설정` 선택 시 ServiceSelectionPanel이 `sourceNodeId`를 받아 해당 노드 뒤에 도착 노드를 생성
+> - 도착 노드가 생성되면 terminal로 간주하고 후속 `다음 단계` placeholder를 숨김
+> - `CreationMethodNode`, `creationMethod` 기반 수동/AI 생성 방식 분기는 제거 대상
 >
 > **v4.3 변경 요약:**
 > - 시작/도착 노드 위자드: **실제 캔버스 placeholder/node 기준**으로 SSP 카드가 오른쪽 `48px`에 anchor됨 (`[실제 캔버스 placeholder 또는 노드] —48px— [위자드 카드]`)
@@ -13,7 +20,7 @@
 > - Edge 렌더링: `smoothstep` 선 중심 표현에서 **화살표형 custom edge**로 전환
 > - 일반 직렬 연결과 분기 연결 모두 **EdgeLabelRenderer 기반 방향 표시** 사용
 > - 설정 중 노드 위 불필요한 서비스 아이콘 완전 제거
-> - "생성 방식을 결정하세요" → 모든 위자드 단계 완료 후에만 표시
+> - "생성 방식을 결정하세요" → 모든 위자드 단계 완료 후에만 표시 (v4.4에서 제거 대상)
 > - 패널 사이에 설정 중인 노드 체인만 표시 (다른 노드 숨김)
 > - SSP 내부에 placeholder나 선택된 서비스 preview를 **중복 렌더링하지 않음**
 > - 시작/도착 위자드 step 전환 시 **패널 외곽 위치는 고정**되고, 카드 내부 내용만 변경됨
@@ -68,7 +75,7 @@
                                       내부 내용만 교체
 ```
 
-- **앵커 대상:** 실제 캔버스의 `placeholder-start`, `placeholder-end`, 또는 service 선택 후 배치된 미완료 노드
+- **앵커 대상:** 실제 캔버스의 `placeholder-start`, `다음 단계`에서 `보낼 곳 설정`을 선택한 위치, 또는 service 선택 후 배치된 미완료 노드
 - **앵커 ↔ 위자드 카드 간격:** 48px (시작·도착 동일)
 - **위자드 카드:** 흰 배경, border `#f2f2f2`, `border-radius: 20px`, `box-shadow: 0 4px 4px rgba(0,0,0,0.25)`, padding 48px
 - **가이드라인 제목:** 카드 상단 중앙, bold 24px, padding-bottom 24px
@@ -196,14 +203,16 @@ node.data.config = {
 - 중간 노드: 설정 완료 전까지 별도 아이콘 없음
 - 서비스 아이콘은 **위자드가 완전히 끝나고 isConfigured: true가 된 후에만** 노드 위에 표시
 
-### 1.8 "생성 방식을 결정하세요" 표시 규칙
+### 1.8 다음 단계 placeholder 통합 규칙
 
-도착 노드 설정 후 나타나는 "생성 방식을 결정하세요" (CreationMethodNode) UI는 **도착 노드의 모든 위자드 단계가 완료된 후에만** 표시한다.
+도착 노드 설정 전에는 leaf 노드마다 `다음 단계` placeholder 하나만 표시한다. 이 placeholder를 클릭하면 캔버스 위에서 다음 두 선택지를 제공한다.
 
-```
-위자드 진행 중 → CreationMethodNode 숨김
-위자드 완료 (isConfigured: true) → CreationMethodNode 표시
-```
+| 선택지 | 동작 |
+|--------|------|
+| `중간 처리 추가` | 해당 leaf 뒤에 중간 노드를 생성하고 `OutputPanel` 위자드로 진입 |
+| `보낼 곳 설정` | 해당 leaf를 `sourceNodeId`로 넘겨 `ServiceSelectionPanel` 도착 노드 설정으로 진입 |
+
+`CreationMethodNode`와 `creationMethod` 상태는 더 이상 사용하지 않는다. 도착 노드가 생성되면 워크플로우의 terminal로 간주하여 후속 `다음 단계` placeholder를 숨긴다.
 
 ---
 
@@ -212,6 +221,8 @@ node.data.config = {
 ### 2.1 시작/도착 노드 설정 흐름
 
 시작/도착 노드는 **ServiceSelectionPanel 내부**에서 모든 단계를 완료한다. 단, SSP는 별도의 왼쪽 노드 영역을 만들지 않고 **실제 캔버스 placeholder/node를 기준으로 오른쪽 48px에 카드만 띄운다**.
+
+v4.4 기준 도착 노드 설정은 독립 `placeholder-end`를 클릭해서 시작하지 않는다. 사용자는 leaf 노드 뒤의 `다음 단계` placeholder를 클릭하고, `보낼 곳 설정`을 선택한다. 이때 Canvas는 `activePlaceholder.kind = "sink"`와 `sourceNodeId`를 저장하고, SSP는 이 `sourceNodeId` 뒤에 도착 노드를 생성한다.
 
 1. Placeholder 클릭  
 레이아웃: `[실제 캔버스 placeholder] ─48px─ [카테고리 카드]`
@@ -349,10 +360,20 @@ v1에서 사용하던 다음 3개 필드를 **store에서 제거**한다:
 
 | 필드 | 용도 |
 |------|------|
-| `activePlaceholder` | ServiceSelectionPanel 표시 여부 + 위치 정보 |
+| `activePlaceholder` | ServiceSelectionPanel 표시 여부 + `kind`, 위치, 도착 source 정보 |
 | `activePanelNodeId` | InputPanel/OutputPanel 표시 대상 노드 |
 | `startNodeId` / `endNodeId` | 시작/도착 노드 추적 |
-| `creationMethod` | 수동/AI 생성 모드 |
+
+```typescript
+type PlaceholderInfo = {
+  id: string;
+  kind: "start" | "sink";
+  position: { x: number; y: number };
+  sourceNodeId?: string | null;
+};
+```
+
+`kind: "sink"`는 `다음 단계` 선택 노드에서 `보낼 곳 설정`을 고른 경우에만 만들어진다. 이때 `sourceNodeId`는 도착 노드의 `prevNodeId`가 된다.
 
 ### 3.3 v4 추가 상태 — 중간 노드 위자드 모드
 
@@ -421,7 +442,6 @@ updateNodeConfig: (nodeId, config) =>
 - `activePanelNodeId`
 - `startNodeId`
 - `endNodeId`
-- `creationMethod`
 
 ---
 
@@ -433,7 +453,8 @@ ServiceSelectionPanel은 **시작/도착 노드 전용**이다. 중간 노드는
 
 | 진입 조건 | 처리 단계 |
 |-----------|-----------|
-| 시작/도착 placeholder 클릭 (`placeholder-start` 또는 `placeholder-end`) | category → service → requirement → auth (전체) |
+| 시작 placeholder 클릭 (`kind: "start"`) | source service → auth → mode → target → confirm |
+| `다음 단계`에서 `보낼 곳 설정` 선택 (`kind: "sink"`) | sink service → auth → confirm |
 
 **표시 원칙:**
 - SSP는 실제 캔버스의 placeholder 또는 미완료 노드를 기준으로 카드만 anchor한다
@@ -485,12 +506,14 @@ ServiceSelectionPanel은 **시작/도착 노드 전용**이다. 중간 노드는
 
 ```typescript
 const isStartOrEndPlaceholder =
-  activePlaceholder?.id === "placeholder-start" ||
-  activePlaceholder?.id === "placeholder-end";
+  activePlaceholder?.kind === "start" ||
+  activePlaceholder?.kind === "sink";
 
 // ServiceSelectionPanel은 isStartOrEndPlaceholder일 때만 렌더링
 if (!isStartOrEndPlaceholder) return null;
 ```
+
+도착 노드 생성 시에는 leaf 재계산보다 `activePlaceholder.sourceNodeId`를 우선 사용한다. fallback leaf 계산은 기존 데이터 복구용으로만 둔다.
 
 ### 4.4 로컬 상태
 
@@ -1124,28 +1147,33 @@ interface FollowUpStepProps {
 // UI: follow_up 또는 branch_config 기반 선택/입력
 ```
 
-### 5.12 중간 placeholder 클릭 시 진입 흐름
+### 5.12 다음 단계 placeholder 클릭 시 진입 흐름
 
-v3에서는 중간 placeholder 클릭 시 ChoicePanel이 열렸다. v4에서는:
+v4.4에서는 중간 placeholder와 도착 placeholder를 분리하지 않는다. leaf 뒤의 `다음 단계` placeholder를 클릭하면 Canvas가 선택 노드를 띄우고, 사용자의 선택에 따라 중간 노드 생성 또는 도착 노드 설정으로 분기한다.
 
 ```typescript
-// Canvas.tsx — handlePlaceholderClick (중간 placeholder)
-const handleMiddlePlaceholderClick = (placeholderId: string) => {
-  const leafId = placeholderId.replace("placeholder-", "");
+// Canvas.tsx — 다음 단계 선택
+const handleNextStepClick = (sourceNodeId: string, position: XYPosition) => {
+  setActiveNextStep({ sourceNodeId, position });
+};
 
-  // 1. 노드 배치 (isConfigured: false)
-  const meta = getDefaultMiddleNodeMeta(); // 또는 적절한 기본 meta
-  const nodeId = placeNode(meta);
-  if (!nodeId) return;
-
-  // 2. 듀얼 패널 열기
-  openPanel(nodeId);
-
+const handleSelectMiddleNode = () => {
+  // 1. sourceNodeId 뒤에 중간 노드 생성 (isConfigured: false)
+  // 2. openPanel(addedNodeId)
   // 3. OutputPanel은 isConfigured === false를 감지하여 위자드 모드 진입
+};
+
+const handleSelectSinkNode = () => {
+  setActivePlaceholder({
+    id: `placeholder-sink-${sourceNodeId}`,
+    kind: "sink",
+    position,
+    sourceNodeId,
+  });
 };
 ```
 
-> **activePlaceholder는 사용하지 않는다.** 중간 노드는 `activePanelNodeId`를 통해 듀얼 패널을 열고, OutputPanel의 위자드 모드를 활성화한다.
+> 중간 노드 생성에는 `activePlaceholder`를 사용하지 않는다. 도착 노드 설정에만 `activePlaceholder.kind = "sink"`를 사용한다.
 
 ### 5.13 applicable_when 필터링
 
@@ -1557,24 +1585,26 @@ const showServiceIcon = node.data.config.isConfigured;
 )}
 ```
 
-### 9.8 CreationMethodNode 표시 조건
+### 9.8 다음 단계 placeholder 표시 조건
 
-"생성 방식을 결정하세요" (CreationMethodNode)는 **도착 노드의 설정이 완전히 완료된 후에만** 표시한다:
+`다음 단계` placeholder는 시작 노드가 있고 도착 노드가 없을 때만 leaf 노드 뒤에 표시한다. 도착 노드가 생성되면 워크플로우 terminal이 확정된 상태이므로 더 이상 후속 placeholder를 표시하지 않는다.
 
 ```typescript
 // Canvas.tsx — nodesWithPlaceholders
-const showCreationMethod = useMemo(() => {
-  if (!endNodeId) return false;
+if (startNodeId && !endNodeId) {
+  const leafIds = getLeafNodeIds(nodes.map((node) => node.id), edges);
 
-  const endNode = nodes.find((n) => n.id === endNodeId);
-  return endNode?.data.config.isConfigured === true;
-}, [endNodeId, nodes]);
-
-// CreationMethodNode는 showCreationMethod가 true일 때만 추가
-if (showCreationMethod) {
-  placeholderNodes.push(creationMethodNode);
+  leafIds.forEach((leafId) => {
+    placeholderNodes.push({
+      id: `placeholder-next-${leafId}`,
+      type: "placeholder",
+      data: { label: "다음 단계", sourceNodeId: leafId },
+    });
+  });
 }
 ```
+
+`CreationMethodNode`는 v4.4에서 사용하지 않는다.
 
 ---
 
@@ -1902,9 +1932,10 @@ removeNode: (id) =>
 | **추가** | 듀얼 패널 레이아웃 컨테이너 (`useDualPanelLayout(canvasRect)` 기반, `wide/compact/stacked`) |
 | **추가** | 패널 열림 시 관련 노드만 표시 (나머지 hidden) |
 | **추가** | 노드 체인 표시 (이전→현재→다음, 화살표) |
+| **추가** | `다음 단계` 선택 노드 — `중간 처리 추가` / `보낼 곳 설정` 분기 |
 | **변경** | edge 렌더링 → `smoothstep` 대신 `flow-arrow` custom edge 적용 |
-| **변경** | 중간 placeholder 클릭 → `activePlaceholder` 대신 `openPanel()` 사용 |
-| **변경** | CreationMethodNode 표시 조건 → 도착 노드 `isConfigured: true` 이후에만 |
+| **변경** | 중간 placeholder와 도착 placeholder → leaf 뒤 `다음 단계` placeholder 하나로 통합 |
+| **변경** | `CreationMethodNode` 표시 흐름 제거 |
 | **변경** | 설정 중 서비스 아이콘 미표시 |
 | 유지 | `onPaneClick`, ESC 키 리스너, 노드 중앙 고정, 드래그 비활성화 |
 
@@ -1929,6 +1960,8 @@ removeNode: (id) =>
 | 변경 | 내용 |
 |------|------|
 | 유지 | wizard 상태 제거 (v2에서 완료) |
+| **변경** | `activePlaceholder.kind`와 `sourceNodeId`로 시작/도착 진입 맥락 구분 |
+| **제거** | `creationMethod` 상태 |
 | 유지 | `updateNodeConfig` merge 방식 |
 | 유지 | `removeNode` 패널 정리 |
 

--- a/src/entities/node/ui/custom-nodes/NextStepChoiceNode.tsx
+++ b/src/entities/node/ui/custom-nodes/NextStepChoiceNode.tsx
@@ -1,0 +1,89 @@
+import { type MouseEvent } from "react";
+import { MdArrowForward, MdCallSplit } from "react-icons/md";
+
+import { Box, Button, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { type Node, type NodeProps } from "@xyflow/react";
+
+type NextStepChoiceNodeData = {
+  disabled?: boolean;
+  onSelectMiddle?: () => void;
+  onSelectSink?: () => void;
+};
+
+export const NextStepChoiceNode = ({
+  data,
+}: NodeProps<Node<NextStepChoiceNodeData>>) => {
+  const handleSelectMiddle = (event: MouseEvent) => {
+    event.stopPropagation();
+    if (data.disabled) return;
+    data.onSelectMiddle?.();
+  };
+
+  const handleSelectSink = (event: MouseEvent) => {
+    event.stopPropagation();
+    if (data.disabled) return;
+    data.onSelectSink?.();
+  };
+
+  return (
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="2xl"
+      boxShadow="0 10px 24px rgba(15, 23, 42, 0.12)"
+      minW="244px"
+      p={4}
+    >
+      <Text fontSize="sm" fontWeight="bold" mb={3} textAlign="center">
+        다음 단계 선택
+      </Text>
+
+      <VStack align="stretch" gap={2}>
+        <Button
+          disabled={data.disabled}
+          h="auto"
+          justifyContent="flex-start"
+          px={4}
+          py={3}
+          variant="ghost"
+          onClick={handleSelectMiddle}
+        >
+          <HStack gap={3}>
+            <Icon as={MdCallSplit} boxSize={5} color="gray.700" />
+            <Box textAlign="left">
+              <Text fontSize="sm" fontWeight="semibold">
+                중간 처리 추가
+              </Text>
+              <Text color="text.secondary" fontSize="xs">
+                처리 노드 설정
+              </Text>
+            </Box>
+          </HStack>
+        </Button>
+
+        <Button
+          disabled={data.disabled}
+          h="auto"
+          justifyContent="flex-start"
+          px={4}
+          py={3}
+          variant="ghost"
+          onClick={handleSelectSink}
+        >
+          <HStack gap={3}>
+            <Icon as={MdArrowForward} boxSize={5} color="gray.700" />
+            <Box textAlign="left">
+              <Text fontSize="sm" fontWeight="semibold">
+                보낼 곳 설정
+              </Text>
+              <Text color="text.secondary" fontSize="xs">
+                도착 노드 설정
+              </Text>
+            </Box>
+          </HStack>
+        </Button>
+      </VStack>
+    </Box>
+  );
+};

--- a/src/entities/node/ui/custom-nodes/index.ts
+++ b/src/entities/node/ui/custom-nodes/index.ts
@@ -8,6 +8,7 @@ export * from "./FilterNode";
 export * from "./LLMNode";
 export * from "./LoopNode";
 export * from "./MultiOutputNode";
+export * from "./NextStepChoiceNode";
 export * from "./NotificationNode";
 export * from "./OutputFormatNode";
 export * from "./PlaceholderNode";

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -675,6 +675,8 @@ export const ServiceSelectionPanel = () => {
     useSourceCatalogQuery();
   const { flowToScreenPosition } = useReactFlow();
   const viewport = useViewport();
+  const activePlaceholderKind = activePlaceholder?.kind ?? null;
+  const activeSinkSourceNodeId = activePlaceholder?.sourceNodeId ?? null;
 
   const [endStep, setEndStep] = useState<EndWizardStep>("service");
   const [searchQuery, setSearchQuery] = useState("");
@@ -734,6 +736,16 @@ export const ServiceSelectionPanel = () => {
   );
 
   const endSourceNode = useMemo(() => {
+    if (activePlaceholderKind === "sink" && activeSinkSourceNodeId) {
+      const sourceNode = nodes.find(
+        (node) => node.id === activeSinkSourceNodeId,
+      );
+
+      if (sourceNode) {
+        return sourceNode;
+      }
+    }
+
     const nodeIds = nodes
       .map((node) => node.id)
       .filter((id) => id !== endNodeId);
@@ -754,7 +766,14 @@ export const ServiceSelectionPanel = () => {
         ? (nodes.find((node) => node.id === startNodeId) ?? null)
         : null)
     );
-  }, [edges, endNodeId, nodes, startNodeId]);
+  }, [
+    activePlaceholderKind,
+    activeSinkSourceNodeId,
+    edges,
+    endNodeId,
+    nodes,
+    startNodeId,
+  ]);
 
   const sinkInputType = endSourceNode?.data.outputTypes[0] ?? null;
   const sinkInputTypeKey = sinkInputType
@@ -775,14 +794,12 @@ export const ServiceSelectionPanel = () => {
 
   const filteredCatalogServices = useMemo(() => {
     const targetServices =
-      activePlaceholder?.id === "placeholder-end"
-        ? sinkServices
-        : sourceServices;
+      activePlaceholderKind === "sink" ? sinkServices : sourceServices;
 
     return targetServices.filter((service) =>
       service.label.toLowerCase().includes(searchQuery.toLowerCase()),
     );
-  }, [activePlaceholder?.id, searchQuery, sinkServices, sourceServices]);
+  }, [activePlaceholderKind, searchQuery, sinkServices, sourceServices]);
 
   const resetWizard = useCallback(() => {
     setEndStep("service");
@@ -863,8 +880,8 @@ export const ServiceSelectionPanel = () => {
     return null;
   }
 
-  const isStartPlaceholder = activePlaceholder.id === "placeholder-start";
-  const isEndPlaceholder = activePlaceholder.id === "placeholder-end";
+  const isStartPlaceholder = activePlaceholderKind === "start";
+  const isEndPlaceholder = activePlaceholderKind === "sink";
 
   if (!isStartPlaceholder && !isEndPlaceholder) {
     return null;

--- a/src/features/workflow-editor/model/workflow-editor-adapter.ts
+++ b/src/features/workflow-editor/model/workflow-editor-adapter.ts
@@ -36,7 +36,6 @@ export interface WorkflowHydratedState {
   nodeStatuses: WorkflowNodeStatusMap;
   startNodeId: string | null;
   endNodeId: string | null;
-  creationMethod: "manual" | null;
 }
 
 const toNodeStatusMap = (
@@ -76,6 +75,5 @@ export const hydrateStore = (
     nodeStatuses: toNodeStatusMap(workflow.nodeStatuses),
     startNodeId: startNode?.id ?? null,
     endNodeId: endNode?.id ?? null,
-    creationMethod: startNode ? "manual" : null,
   };
 };

--- a/src/features/workflow-editor/model/workflow-node-ui-state.ts
+++ b/src/features/workflow-editor/model/workflow-node-ui-state.ts
@@ -31,17 +31,3 @@ export const isMiddleWizardPending = (
 ) =>
   isMiddleWorkflowNode(node, startNodeId, endNodeId) &&
   !isMiddleWizardCompleted(node);
-
-export const canStartProcessingAfterSinkSelection = ({
-  creationMethod,
-  endNode,
-  startNodeId,
-}: {
-  creationMethod: string | null;
-  endNode: WorkflowNode;
-  startNodeId: string | null;
-}) =>
-  startNodeId !== null &&
-  endNode !== null &&
-  hasSelectedSinkService(endNode) &&
-  !creationMethod;

--- a/src/features/workflow-editor/model/workflowStore.ts
+++ b/src/features/workflow-editor/model/workflowStore.ts
@@ -17,9 +17,11 @@ import {
   type WorkflowNodeStatusMap,
 } from "./workflow-editor-adapter";
 
-type PlaceholderInfo = {
+export type PlaceholderInfo = {
   id: string;
+  kind: "start" | "sink";
   position: { x: number; y: number };
+  sourceNodeId?: string | null;
 };
 
 type NodePosition = {
@@ -41,7 +43,6 @@ interface WorkflowEditorState {
   activePanelNodeId: string | null;
   startNodeId: string | null;
   endNodeId: string | null;
-  creationMethod: "manual" | null;
   activePlaceholder: PlaceholderInfo | null;
   workflowId: string;
   workflowName: string;
@@ -76,7 +77,6 @@ interface WorkflowEditorActions {
   setEditorCapabilities: (capabilities: WorkflowEditorCapabilities) => void;
   setStartNodeId: (id: string | null) => void;
   setEndNodeId: (id: string | null) => void;
-  setCreationMethod: (method: "manual" | null) => void;
   setActivePlaceholder: (placeholder: PlaceholderInfo | null) => void;
   applyLayoutPositions: (
     updates: Array<{ nodeId: string; position: NodePosition }>,
@@ -93,7 +93,6 @@ const initialState: WorkflowEditorState = {
   activePanelNodeId: null,
   startNodeId: null,
   endNodeId: null,
-  creationMethod: null,
   activePlaceholder: null,
   workflowId: "",
   workflowName: "",
@@ -254,14 +253,6 @@ export const useWorkflowStore = create<
         }
       }),
 
-    setCreationMethod: (method) =>
-      set((state) => {
-        state.creationMethod = method;
-        if (!state._isSyncing) {
-          state.isDirty = true;
-        }
-      }),
-
     setActivePlaceholder: (placeholder) =>
       set((state) => {
         state.activePlaceholder = placeholder;
@@ -317,7 +308,6 @@ export const useWorkflowStore = create<
         state.nodeStatuses = payload.nodeStatuses;
         state.startNodeId = payload.startNodeId;
         state.endNodeId = payload.endNodeId;
-        state.creationMethod = payload.creationMethod;
         state.activePanelNodeId = null;
         state.activePlaceholder = null;
         state.unsavedNodePositions = {};
@@ -349,7 +339,6 @@ export const useWorkflowStore = create<
         state.nodeStatuses = payload.nodeStatuses;
         state.startNodeId = payload.startNodeId;
         state.endNodeId = payload.endNodeId;
-        state.creationMethod = payload.creationMethod;
         state.unsavedNodePositions = preservedUnsavedNodePositions;
         state.activePanelNodeId = preserveActivePanelNodeId
           ? hasNode(payload.nodes, state.activePanelNodeId)

--- a/src/widgets/canvas/ui/Canvas.tsx
+++ b/src/widgets/canvas/ui/Canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { type MouseEvent } from "react";
 
 import {
@@ -23,13 +23,13 @@ import {
   CalendarNode,
   CommunicationNode,
   ConditionNode,
-  CreationMethodNode,
   DataProcessNode,
   EarlyExitNode,
   FilterNode,
   LLMNode,
   LoopNode,
   MultiOutputNode,
+  NextStepChoiceNode,
   NodeEditorProvider,
   NotificationNode,
   OutputFormatNode,
@@ -47,11 +47,7 @@ import {
   useAddWorkflowNodeMutation,
   useDeleteWorkflowNodeMutation,
 } from "@/entities/workflow";
-import {
-  canStartProcessingAfterSinkSelection,
-  hydrateStore,
-  useWorkflowStore,
-} from "@/features/workflow-editor";
+import { hydrateStore, useWorkflowStore } from "@/features/workflow-editor";
 import { getLeafNodeIds } from "@/shared";
 import { toaster } from "@/shared/utils/toaster/toaster";
 
@@ -61,8 +57,17 @@ const DEFAULT_FLOW_NODE_WIDTH = 172;
 const DEFAULT_FLOW_NODE_HEIGHT = 176;
 const PLACEHOLDER_NODE_WIDTH = 100;
 const PLACEHOLDER_NODE_HEIGHT = 134;
-const CREATION_METHOD_NODE_WIDTH = 244;
-const CREATION_METHOD_NODE_HEIGHT = 112;
+const NEXT_STEP_CHOICE_NODE_WIDTH = 244;
+const NEXT_STEP_CHOICE_NODE_HEIGHT = 148;
+
+type ActiveNextStep = {
+  centerY: number;
+  position: { x: number; y: number };
+  sourceNodeId: string;
+};
+
+const getNextStepPlaceholderId = (nodeId: string) =>
+  `placeholder-next-${nodeId}`;
 
 const getTopYFromCenter = (centerY: number, height: number) =>
   centerY - height / 2;
@@ -77,13 +82,13 @@ const getNodeHeight = (node: Node, fallbackHeight = DEFAULT_FLOW_NODE_HEIGHT) =>
 
 const getNodeFallbackWidth = (node: Node) => {
   if (node.type === "placeholder") return PLACEHOLDER_NODE_WIDTH;
-  if (node.type === "creation-method") return CREATION_METHOD_NODE_WIDTH;
+  if (node.type === "next-step-choice") return NEXT_STEP_CHOICE_NODE_WIDTH;
   return DEFAULT_FLOW_NODE_WIDTH;
 };
 
 const getNodeFallbackHeight = (node: Node) => {
   if (node.type === "placeholder") return PLACEHOLDER_NODE_HEIGHT;
-  if (node.type === "creation-method") return CREATION_METHOD_NODE_HEIGHT;
+  if (node.type === "next-step-choice") return NEXT_STEP_CHOICE_NODE_HEIGHT;
   return DEFAULT_FLOW_NODE_HEIGHT;
 };
 
@@ -137,7 +142,7 @@ const createVirtualPlaceholderNode = (
   hidden: true,
 });
 
-type CanvasNodeType = NodeType | "placeholder" | "creation-method";
+type CanvasNodeType = NodeType | "placeholder" | "next-step-choice";
 
 const nodeTypes = {
   communication: CommunicationNode,
@@ -156,7 +161,7 @@ const nodeTypes = {
   notification: NotificationNode,
   llm: LLMNode,
   placeholder: PlaceholderNode,
-  "creation-method": CreationMethodNode,
+  "next-step-choice": NextStepChoiceNode,
 } satisfies Record<CanvasNodeType, NodeTypes[string]>;
 
 const edgeTypes = {
@@ -180,10 +185,6 @@ export const Canvas = () => {
   const onConnect = useWorkflowStore((state) => state.onConnect);
   const startNodeId = useWorkflowStore((state) => state.startNodeId);
   const endNodeId = useWorkflowStore((state) => state.endNodeId);
-  const creationMethod = useWorkflowStore((state) => state.creationMethod);
-  const setCreationMethod = useWorkflowStore(
-    (state) => state.setCreationMethod,
-  );
   const canEditNodes = useWorkflowStore(
     (state) => state.editorCapabilities.canEditNodes,
   );
@@ -202,6 +203,9 @@ export const Canvas = () => {
   );
   const openPanel = useWorkflowStore((state) => state.openPanel);
   const closePanel = useWorkflowStore((state) => state.closePanel);
+  const [activeNextStep, setActiveNextStep] = useState<ActiveNextStep | null>(
+    null,
+  );
   const { mutateAsync: addWorkflowNode, isPending: isAddNodePending } =
     useAddWorkflowNodeMutation();
   const { mutateAsync: deleteWorkflowNode, isPending: isDeleteNodePending } =
@@ -265,7 +269,12 @@ export const Canvas = () => {
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
       const filtered = changes.filter(
-        (change) => !("id" in change && change.id.startsWith("placeholder-")),
+        (change) =>
+          !(
+            "id" in change &&
+            (change.id.startsWith("placeholder-") ||
+              change.id.startsWith("next-step-choice-"))
+          ),
       );
       if (filtered.length > 0) {
         onNodesChange(filtered);
@@ -276,16 +285,102 @@ export const Canvas = () => {
 
   const { getZoom, setCenter } = useReactFlow();
 
+  const handleCreateMiddleNode = useCallback(
+    async ({
+      position,
+      sourceNodeId,
+    }: {
+      position: { x: number; y: number };
+      sourceNodeId: string;
+    }) => {
+      if (isAddNodePending || isDeleteNodePending) {
+        return;
+      }
+
+      const sourceNode = nodes.find(
+        (currentNode) => currentNode.id === sourceNodeId,
+      );
+      const sourceOutputType = sourceNode?.data.outputTypes[0] ?? null;
+
+      if (!workflowId) {
+        toaster.create({
+          title: "워크플로우 정보를 불러오지 못했습니다",
+          description: "페이지를 새로고침해주세요.",
+          type: "error",
+        });
+        return;
+      }
+
+      try {
+        const previousNodes = useWorkflowStore.getState().nodes;
+        const nextWorkflow = await addWorkflowNode({
+          workflowId,
+          body: toNodeAddRequest({
+            type: "data-process",
+            position,
+            role: "middle",
+            prevNodeId: sourceNodeId,
+            inputTypes: sourceNode
+              ? [...sourceNode.data.outputTypes]
+              : undefined,
+            outputTypes: sourceOutputType ? [sourceOutputType] : undefined,
+          }),
+        });
+
+        const addedNodeId =
+          findAddedNodeId(previousNodes, nextWorkflow.nodes) ??
+          nextWorkflow.nodes.at(-1)?.id ??
+          null;
+        const addedNode =
+          addedNodeId !== null
+            ? (nextWorkflow.nodes.find(
+                (currentNode) => currentNode.id === addedNodeId,
+              ) ?? null)
+            : null;
+
+        if (!addedNodeId || !addedNode) {
+          toaster.create({
+            title: "노드 추가 실패",
+            description: "서버 응답을 해석하지 못했습니다.",
+            type: "error",
+          });
+          return;
+        }
+
+        syncWorkflowFromResponse(nextWorkflow);
+        setActivePlaceholder(null);
+        setActiveNextStep(null);
+        openPanel(addedNodeId);
+      } catch {
+        toaster.create({
+          title: "노드 추가 실패",
+          description: "노드를 추가하지 못했습니다. 잠시 후 다시 시도해주세요.",
+          type: "error",
+        });
+      }
+    },
+    [
+      addWorkflowNode,
+      isAddNodePending,
+      isDeleteNodePending,
+      nodes,
+      openPanel,
+      setActivePlaceholder,
+      syncWorkflowFromResponse,
+      workflowId,
+    ],
+  );
+
   const handleNodeClick = useCallback(
     async (_event: MouseEvent, node: Node) => {
       if (
         !canEditNodes &&
-        (node.type === "creation-method" || node.type === "placeholder")
+        (node.type === "next-step-choice" || node.type === "placeholder")
       ) {
         return;
       }
 
-      if (node.type === "creation-method") {
+      if (node.type === "next-step-choice") {
         return;
       }
 
@@ -297,117 +392,51 @@ export const Canvas = () => {
           y: getTopYFromCenter(centerY, DEFAULT_FLOW_NODE_HEIGHT),
         };
 
-        const isStartOrEndPlaceholder =
-          node.id === "placeholder-start" || node.id === "placeholder-end";
-        const isMiddlePlaceholder = !isStartOrEndPlaceholder;
-
-        if (isMiddlePlaceholder && (isAddNodePending || isDeleteNodePending)) {
-          return;
-        }
-
         closePanel();
 
-        if (isStartOrEndPlaceholder) {
+        if (node.id === "placeholder-start") {
+          setActiveNextStep(null);
           setActivePlaceholder({
             id: node.id,
+            kind: "start",
             position: panelNodePosition,
           });
-        } else {
-          const sourceNodeId = node.id.replace("placeholder-", "");
-          const sourceNode = nodes.find(
-            (currentNode) => currentNode.id === sourceNodeId,
-          );
-          const sourceOutputType = sourceNode?.data.outputTypes[0] ?? null;
 
-          if (!workflowId) {
-            toaster.create({
-              title: "워크플로우 정보를 불러오지 못했습니다",
-              description: "페이지를 새로고침해주세요.",
-              type: "error",
-            });
-            return;
-          }
-
-          try {
-            const previousNodes = useWorkflowStore.getState().nodes;
-            const nextWorkflow = await addWorkflowNode({
-              workflowId,
-              body: toNodeAddRequest({
-                type: "data-process",
-                position: panelNodePosition,
-                role: "middle",
-                prevNodeId: sourceNodeId,
-                inputTypes: sourceNode
-                  ? [...sourceNode.data.outputTypes]
-                  : undefined,
-                outputTypes: sourceOutputType ? [sourceOutputType] : undefined,
-              }),
-            });
-
-            const addedNodeId =
-              findAddedNodeId(previousNodes, nextWorkflow.nodes) ??
-              nextWorkflow.nodes.at(-1)?.id ??
-              null;
-            const addedNode =
-              addedNodeId !== null
-                ? (nextWorkflow.nodes.find(
-                    (currentNode) => currentNode.id === addedNodeId,
-                  ) ?? null)
-                : null;
-
-            if (!addedNodeId || !addedNode) {
-              toaster.create({
-                title: "노드 추가 실패",
-                description: "서버 응답을 해석하지 못했습니다.",
-                type: "error",
-              });
-              return;
-            }
-
-            syncWorkflowFromResponse(nextWorkflow);
-            setActivePlaceholder(null);
-            openPanel(addedNodeId);
-          } catch {
-            toaster.create({
-              title: "노드 추가 실패",
-              description:
-                "노드를 추가하지 못했습니다. 잠시 후 다시 시도해주세요.",
-              type: "error",
-            });
-            return;
-          }
-        }
-
-        const viewportWidth = window.innerWidth;
-        const offsetX = viewportWidth * 0.2;
-
-        if (isStartOrEndPlaceholder) {
+          const viewportWidth = window.innerWidth;
+          const offsetX = viewportWidth * 0.2;
           setCenter(node.position.x + offsetX, centerY, {
             zoom: 1,
             duration: 300,
           });
+          return;
         }
+
+        const rawSourceNodeId = node.data?.sourceNodeId;
+        const sourceNodeId =
+          typeof rawSourceNodeId === "string"
+            ? rawSourceNodeId
+            : node.id.replace("placeholder-next-", "");
+
+        setActivePlaceholder(null);
+        setActiveNextStep({
+          centerY,
+          position: panelNodePosition,
+          sourceNodeId,
+        });
       } else {
+        setActiveNextStep(null);
         setActivePlaceholder(null);
         openPanel(node.id);
       }
     },
-    [
-      addWorkflowNode,
-      canEditNodes,
-      closePanel,
-      isAddNodePending,
-      isDeleteNodePending,
-      nodes,
-      openPanel,
-      setActivePlaceholder,
-      setCenter,
-      syncWorkflowFromResponse,
-      workflowId,
-    ],
+    [canEditNodes, closePanel, openPanel, setActivePlaceholder, setCenter],
   );
 
   const handlePaneClick = useCallback(() => {
+    if (activeNextStep) {
+      setActiveNextStep(null);
+    }
+
     if (activePlaceholder) {
       setActivePlaceholder(null);
     }
@@ -415,15 +444,13 @@ export const Canvas = () => {
     if (activePanelNodeId) {
       closePanel();
     }
-  }, [activePanelNodeId, activePlaceholder, closePanel, setActivePlaceholder]);
-
-  const handleSelectManual = useCallback(() => {
-    if (!canEditNodes) {
-      return;
-    }
-
-    setCreationMethod("manual");
-  }, [canEditNodes, setCreationMethod]);
+  }, [
+    activeNextStep,
+    activePanelNodeId,
+    activePlaceholder,
+    closePanel,
+    setActivePlaceholder,
+  ]);
 
   const handleConnect = useCallback(
     (connection: Parameters<typeof onConnect>[0]) => {
@@ -450,12 +477,50 @@ export const Canvas = () => {
     [canEditNodes, nodes, onConnect],
   );
 
+  const handleSelectMiddleNode = useCallback(() => {
+    if (!activeNextStep) {
+      return;
+    }
+
+    void handleCreateMiddleNode({
+      position: activeNextStep.position,
+      sourceNodeId: activeNextStep.sourceNodeId,
+    });
+  }, [activeNextStep, handleCreateMiddleNode]);
+
+  const handleSelectSinkNode = useCallback(() => {
+    if (!activeNextStep) {
+      return;
+    }
+
+    closePanel();
+    setActivePlaceholder({
+      id: `placeholder-sink-${activeNextStep.sourceNodeId}`,
+      kind: "sink",
+      position: activeNextStep.position,
+      sourceNodeId: activeNextStep.sourceNodeId,
+    });
+    setActiveNextStep(null);
+
+    const viewportWidth = window.innerWidth;
+    const offsetX = viewportWidth * 0.2;
+    setCenter(activeNextStep.position.x + offsetX, activeNextStep.centerY, {
+      zoom: 1,
+      duration: 300,
+    });
+  }, [activeNextStep, closePanel, setActivePlaceholder, setCenter]);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
 
       if (activePlaceholder) {
         setActivePlaceholder(null);
+        return;
+      }
+
+      if (activeNextStep) {
+        setActiveNextStep(null);
         return;
       }
 
@@ -466,20 +531,17 @@ export const Canvas = () => {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [activePanelNodeId, activePlaceholder, closePanel, setActivePlaceholder]);
+  }, [
+    activeNextStep,
+    activePanelNodeId,
+    activePlaceholder,
+    closePanel,
+    setActivePlaceholder,
+  ]);
 
   const nodesWithPlaceholders = useMemo(() => {
     const result: Node[] = [...nodes];
-    const endNode = endNodeId
-      ? (nodes.find((node) => node.id === endNodeId) ?? null)
-      : null;
-    const showCreationMethod = canStartProcessingAfterSinkSelection({
-      creationMethod,
-      endNode,
-      startNodeId,
-    });
 
-    // 분기 1: 시작/도착 미설정 → placeholder 표시
     if (!startNodeId) {
       result.push({
         id: "placeholder-start",
@@ -496,94 +558,23 @@ export const Canvas = () => {
       });
     }
 
-    if (!endNodeId && !creationMethod) {
-      // 도착 노드 미설정 & 수동 모드 아님 → 시작 노드 옆에 도착 placeholder
-      const startNode = nodes.find((n) => n.id === startNodeId);
-      const anchorX = startNode
-        ? startNode.position.x + getNodeWidth(startNode) + NODE_GAP_X
-        : PLACEHOLDER_NODE_WIDTH + NODE_GAP_X;
-      const anchorCenterY = startNode
-        ? getNodeCenterY(startNode)
-        : DEFAULT_ROW_CENTER_Y;
-
-      result.push({
-        id: "placeholder-end",
-        type: "placeholder",
-        position: {
-          x: anchorX,
-          y: getTopYFromCenter(anchorCenterY, PLACEHOLDER_NODE_HEIGHT),
-        },
-        data: { label: "도착" },
-        initialWidth: PLACEHOLDER_NODE_WIDTH,
-        initialHeight: PLACEHOLDER_NODE_HEIGHT,
-        selectable: false,
-        draggable: false,
-      });
-    }
-
-    // 분기 2: 둘 다 설정됨 + 생성 방식 미결정
-    if (showCreationMethod) {
-      const startNode = nodes.find((n) => n.id === startNodeId);
-      const startX = startNode?.position.x ?? 0;
-      const startWidth = startNode
-        ? getNodeWidth(startNode)
-        : DEFAULT_FLOW_NODE_WIDTH;
-      const startCenterY = startNode
-        ? getNodeCenterY(startNode)
-        : DEFAULT_ROW_CENTER_Y;
-
-      // 도착 노드를 오른쪽으로 밀어 겹침 방지
-      const endNodeIndex = result.findIndex((n) => n.id === endNodeId);
-      if (endNodeIndex !== -1) {
-        result[endNodeIndex] = {
-          ...result[endNodeIndex],
-          position: {
-            x:
-              startX +
-              startWidth +
-              NODE_GAP_X +
-              CREATION_METHOD_NODE_WIDTH +
-              NODE_GAP_X,
-            y: result[endNodeIndex].position.y,
-          },
-        };
-      }
-
-      result.push({
-        id: "placeholder-creation-method",
-        type: "creation-method",
-        position: {
-          x: startX + startWidth + NODE_GAP_X,
-          y: getTopYFromCenter(startCenterY, CREATION_METHOD_NODE_HEIGHT),
-        },
-        data: { onSelectManual: handleSelectManual },
-        initialWidth: CREATION_METHOD_NODE_WIDTH,
-        initialHeight: CREATION_METHOD_NODE_HEIGHT,
-        selectable: false,
-        draggable: false,
-      });
-    }
-
-    // 분기 3: 수동 생성 모드
-    if (startNodeId && creationMethod === "manual") {
-      // endNode가 있으면 제외하고 leaf 계산
-      const nodeIds = nodes.map((n) => n.id).filter((id) => id !== endNodeId);
+    if (startNodeId && !endNodeId) {
+      const nodeIds = nodes.map((node) => node.id);
       const leafIds = getLeafNodeIds(nodeIds, edges);
 
-      let maxPlaceholderX = 0;
-
       for (const leafId of leafIds) {
-        const leafNode = nodes.find((n) => n.id === leafId);
+        if (activeNextStep?.sourceNodeId === leafId) {
+          continue;
+        }
+
+        const leafNode = nodes.find((node) => node.id === leafId);
         if (!leafNode) continue;
 
         const placeholderX =
           leafNode.position.x + getNodeWidth(leafNode) + NODE_GAP_X;
-        if (placeholderX > maxPlaceholderX) {
-          maxPlaceholderX = placeholderX;
-        }
 
         result.push({
-          id: `placeholder-${leafId}`,
+          id: getNextStepPlaceholderId(leafId),
           type: "placeholder",
           position: {
             x: placeholderX,
@@ -592,7 +583,7 @@ export const Canvas = () => {
               PLACEHOLDER_NODE_HEIGHT,
             ),
           },
-          data: { label: "다음" },
+          data: { label: "다음 단계", sourceNodeId: leafId },
           initialWidth: PLACEHOLDER_NODE_WIDTH,
           initialHeight: PLACEHOLDER_NODE_HEIGHT,
           selectable: false,
@@ -600,41 +591,24 @@ export const Canvas = () => {
         });
       }
 
-      if (endNodeId) {
-        // 도착 노드를 "다음" placeholder 뒤로 밀기
-        const endNodeIndex = result.findIndex((n) => n.id === endNodeId);
-        if (endNodeIndex !== -1) {
-          result[endNodeIndex] = {
-            ...result[endNodeIndex],
-            position: {
-              x: maxPlaceholderX + PLACEHOLDER_NODE_WIDTH + NODE_GAP_X,
-              y: result[endNodeIndex].position.y,
-            },
-          };
-        }
-      } else {
-        // 도착 노드 삭제됨 → 체인 끝에 도착 placeholder 표시
-        const lastLeaf =
-          leafIds.length > 0 ? nodes.find((n) => n.id === leafIds[0]) : null;
-        const placeholderEndX =
-          maxPlaceholderX + PLACEHOLDER_NODE_WIDTH + NODE_GAP_X;
-        const placeholderEndCenterY = lastLeaf
-          ? getNodeCenterY(lastLeaf)
-          : DEFAULT_ROW_CENTER_Y;
-
+      if (activeNextStep && leafIds.includes(activeNextStep.sourceNodeId)) {
         result.push({
-          id: "placeholder-end",
-          type: "placeholder",
+          id: `next-step-choice-${activeNextStep.sourceNodeId}`,
+          type: "next-step-choice",
           position: {
-            x: placeholderEndX,
+            x: activeNextStep.position.x,
             y: getTopYFromCenter(
-              placeholderEndCenterY,
-              PLACEHOLDER_NODE_HEIGHT,
+              activeNextStep.centerY,
+              NEXT_STEP_CHOICE_NODE_HEIGHT,
             ),
           },
-          data: { label: "도착" },
-          initialWidth: PLACEHOLDER_NODE_WIDTH,
-          initialHeight: PLACEHOLDER_NODE_HEIGHT,
+          data: {
+            disabled: isAddNodePending || isDeleteNodePending,
+            onSelectMiddle: handleSelectMiddleNode,
+            onSelectSink: handleSelectSinkNode,
+          },
+          initialWidth: NEXT_STEP_CHOICE_NODE_WIDTH,
+          initialHeight: NEXT_STEP_CHOICE_NODE_HEIGHT,
           selectable: false,
           draggable: false,
         });
@@ -643,12 +617,15 @@ export const Canvas = () => {
 
     return result;
   }, [
-    nodes,
+    activeNextStep,
     edges,
-    startNodeId,
     endNodeId,
-    creationMethod,
-    handleSelectManual,
+    handleSelectMiddleNode,
+    handleSelectSinkNode,
+    isAddNodePending,
+    isDeleteNodePending,
+    nodes,
+    startNodeId,
   ]);
 
   const nodesWithDragControl = useMemo(
@@ -679,7 +656,7 @@ export const Canvas = () => {
     if (outgoingEdge) {
       relatedIds.add(outgoingEdge.target);
     } else {
-      relatedIds.add(`placeholder-${activePanelNodeId}`);
+      relatedIds.add(getNextStepPlaceholderId(activePanelNodeId));
     }
 
     return relatedIds;
@@ -747,10 +724,8 @@ export const Canvas = () => {
       } else {
         const nextPlaceholder =
           nodesWithDragControl.find(
-            (node) => node.id === `placeholder-${nodeId}`,
-          ) ??
-          nodesWithDragControl.find((node) => node.id === "placeholder-end") ??
-          null;
+            (node) => node.id === getNextStepPlaceholderId(nodeId),
+          ) ?? null;
 
         if (nextPlaceholder) {
           chainNodes.push(nextPlaceholder);


### PR DESCRIPTION
## 📝 요약 (Summary)

노드 생성 흐름에서 `다음` placeholder와 `도착` placeholder가 분리되어 보이던 UX를 `다음 단계` placeholder 하나로 통합했습니다.

사용자는 `다음 단계`에서 `중간 처리 추가` 또는 `보낼 곳 설정`을 선택할 수 있고, 도착 노드는 선택한 leaf 노드 뒤에 생성됩니다.

## ✅ 주요 변경 사항 (Key Changes)

- `다음 단계` 선택 노드 추가
- 중간 노드 추가 / 도착 노드 설정 흐름 통합
- 도착 노드 생성 위치를 선택한 이전 노드 기준으로 보정
- 도착 노드 생성 후 후속 placeholder 숨김
- legacy `creationMethod` 기반 흐름 제거
- 노드 설정 위자드 설계 문서 갱신

## 💻 상세 구현 내용 (Implementation Details)

### 다음 단계 placeholder 통합

기존에는 중간 노드 추가용 `다음` placeholder와 도착 노드 설정용 `도착` placeholder가 별도로 렌더링되었습니다.

이번 변경에서는 leaf 노드 뒤에 `다음 단계` placeholder 하나만 표시하고, 클릭 시 `NextStepChoiceNode`를 통해 다음 동작을 선택하도록 변경했습니다.

선택지는 다음과 같습니다.

- `중간 처리 추가`: 기존 중간 노드 생성 흐름으로 진입 후 `OutputPanel` 위자드 오픈
- `보낼 곳 설정`: `ServiceSelectionPanel` 도착 노드 설정 흐름으로 진입

### 도착 노드 위치 기준 개선

`ServiceSelectionPanel`에서 도착 노드를 만들 때 leaf 재계산에만 의존하지 않고, `activePlaceholder.sourceNodeId`를 우선 사용하도록 변경했습니다.

이를 통해 사용자가 선택한 노드 뒤에 도착 노드가 생성됩니다.

### legacy 상태 제거

`creationMethod`, `setCreationMethod`, `canStartProcessingAfterSinkSelection` 기반 흐름을 제거하고, Canvas의 placeholder 렌더링 조건을 단순화했습니다.

도착 노드가 존재하면 워크플로우 terminal로 간주하여 `다음 단계` placeholder를 더 이상 표시하지 않습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

기존 구조에서는 도착 노드 placeholder가 별도로 존재해, 중간 노드 뒤가 아니라 시작 노드 기준 흐름에 붙는 것처럼 보이는 문제가 있었습니다.

이를 해결하기 위해 도착 노드 설정 진입 시점에 `sourceNodeId`를 명시적으로 저장하고, 도착 노드 생성 요청의 `prevNodeId`로 사용하도록 정리했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 도착 노드 생성 후에는 후속 `다음 단계` placeholder가 표시되지 않습니다.
- 도착 노드 앞에 중간 노드를 삽입하는 기능은 이번 범위에 포함하지 않았습니다.
- 빌드 시 Vite chunk size warning이 표시되지만, 이번 변경과 직접 관련된 blocker는 아닙니다.

검증 완료:

```bash
pnpm lint
pnpm test
pnpm build
```

## 📸 스크린샷 (Screenshots)

> 첨부 예정

## #️⃣ 관련 이슈 (Related Issues)

- #125 
