### PR TITLE
[PR] 선택 위저드 노드 의미 타입 보존

### DIFF
--- a/src/entities/node/model/types.ts
+++ b/src/entities/node/model/types.ts
@@ -26,6 +26,14 @@ export type NodeType = DomainNodeType | ProcessingNodeType | AINodeType;
 
 export type NodeCategory = "domain" | "processing" | "ai";
 
+export type ChoiceNodeType =
+  | "LOOP"
+  | "CONDITION_BRANCH"
+  | "AI"
+  | "DATA_FILTER"
+  | "AI_FILTER"
+  | "PASSTHROUGH";
+
 // ─── Config 기반 인터페이스 ──────────────────────────────────
 interface BaseNodeConfig {
   /** 설정 완료 여부 — 캔버스에서 경고 표시 기준 */
@@ -40,6 +48,8 @@ interface BaseNodeConfig {
   trigger_kind?: string | null;
   /** 중간 노드 위자드에서 선택한 액션 ID */
   choiceActionId?: string | null;
+  /** choice wizard runtime semantic node type */
+  choiceNodeType?: ChoiceNodeType | null;
   /** 중간 노드 위자드 후속 설정 값 */
   choiceSelections?: Record<string, string | string[]> | null;
   /** source target display label */

--- a/src/features/choice-panel/model/types.ts
+++ b/src/features/choice-panel/model/types.ts
@@ -1,3 +1,5 @@
+import { type ChoiceNodeType } from "@/entities/node";
+
 /** 매핑 규칙에서 사용하는 데이터 타입 키 (백엔드 형식) */
 export type MappingDataTypeKey =
   | "FILE_LIST"
@@ -10,13 +12,7 @@ export type MappingDataTypeKey =
   | "TEXT";
 
 /** 매핑 규칙에서 사용하는 노드 타입 (백엔드 형식) */
-export type MappingNodeType =
-  | "LOOP"
-  | "CONDITION_BRANCH"
-  | "AI"
-  | "DATA_FILTER"
-  | "AI_FILTER"
-  | "PASSTHROUGH";
+export type MappingNodeType = ChoiceNodeType;
 
 /** follow_up / branch_config 옵션 */
 export interface FollowUpOption {

--- a/src/pages/workflow-editor/model/choiceSelectionPipeline.ts
+++ b/src/pages/workflow-editor/model/choiceSelectionPipeline.ts
@@ -7,6 +7,7 @@ import {
 import {
   MAPPING_NODE_TYPE_MAP,
   type MappingDataTypeKey,
+  type MappingNodeType,
   type MappingRules,
   type ResolvedChoiceOption,
   type ResolvedChoiceResponse,
@@ -24,9 +25,32 @@ const toChoiceNodeType = (value: string | null | undefined): NodeType =>
     ? MAPPING_NODE_TYPE_MAP[value as keyof typeof MAPPING_NODE_TYPE_MAP]
     : "data-process";
 
+const isMappingNodeType = (
+  value: string | null | undefined,
+): value is MappingNodeType => Boolean(value && value in MAPPING_NODE_TYPE_MAP);
+
+const toChoiceSemanticNodeType = ({
+  option,
+  selectionResult,
+}: {
+  option: ResolvedChoiceOption;
+  selectionResult: NodeSelectionResult;
+}): MappingNodeType => {
+  if (isMappingNodeType(selectionResult.nodeType)) {
+    return selectionResult.nodeType;
+  }
+
+  if (isMappingNodeType(option.node_type)) {
+    return option.node_type;
+  }
+
+  return "PASSTHROUGH";
+};
+
 export type ProcessingMethodSelectionIntent = {
   isConfigured: boolean;
   nextActionChoice: ResolvedChoiceResponse;
+  nextChoiceNodeType: MappingNodeType;
   nextDataTypeKey: MappingDataTypeKey;
   nextNodeType: NodeType;
   nextStep: "action" | "complete";
@@ -36,6 +60,7 @@ export type ActionSelectionIntent = {
   branchConfig: ChoiceBranchConfig | null;
   followUp: ChoiceFollowUp | null;
   hasFollowUp: boolean;
+  nextChoiceNodeType: MappingNodeType;
   nextDataTypeKey: MappingDataTypeKey;
   nextNodeType: NodeType;
   nextStep: "follow-up" | "complete";
@@ -68,14 +93,17 @@ export const deriveProcessingMethodSelectionIntent = ({
     "action",
   );
   const nextStep = nextActionChoice.options.length > 0 ? "action" : "complete";
+  const nextChoiceNodeType = toChoiceSemanticNodeType({
+    option,
+    selectionResult,
+  });
 
   return {
     isConfigured: nextStep === "complete",
     nextActionChoice,
+    nextChoiceNodeType,
     nextDataTypeKey,
-    nextNodeType: selectionResult.nodeType
-      ? toChoiceNodeType(selectionResult.nodeType)
-      : toChoiceNodeType(option.node_type),
+    nextNodeType: toChoiceNodeType(nextChoiceNodeType),
     nextStep,
   };
 };
@@ -106,15 +134,18 @@ export const deriveActionSelectionIntent = ({
   const branchConfig =
     selectionResult.branchConfig ?? option.branchConfig ?? null;
   const hasFollowUp = Boolean(followUp || branchConfig);
+  const nextChoiceNodeType = toChoiceSemanticNodeType({
+    option,
+    selectionResult,
+  });
 
   return {
     branchConfig,
     followUp,
     hasFollowUp,
+    nextChoiceNodeType,
     nextDataTypeKey,
-    nextNodeType: selectionResult.nodeType
-      ? toChoiceNodeType(selectionResult.nodeType)
-      : toChoiceNodeType(option.node_type),
+    nextNodeType: toChoiceNodeType(nextChoiceNodeType),
     nextStep: hasFollowUp ? "follow-up" : "complete",
     shouldUseActionLeaf: stagingNodeType === "loop",
   };

--- a/src/pages/workflow-editor/model/useChoiceWizardController.ts
+++ b/src/pages/workflow-editor/model/useChoiceWizardController.ts
@@ -464,6 +464,9 @@ export const useChoiceWizardController = () => {
           config: buildChoiceWizardNodeConfig({
             type: selectionIntent.nextNodeType,
             isConfigured: selectionIntent.isConfigured,
+            overrides: {
+              choiceNodeType: selectionIntent.nextChoiceNodeType,
+            },
           }),
           inputDataTypeKey: initialDataTypeKey,
           outputDataTypeKey: selectionIntent.nextDataTypeKey,
@@ -563,12 +566,11 @@ export const useChoiceWizardController = () => {
         const finalActionConfig = buildChoiceWizardNodeConfig({
           type: selectionIntent.nextNodeType,
           isConfigured: !selectionIntent.hasFollowUp,
-          overrides: selectionIntent.hasFollowUp
-            ? undefined
-            : {
-                choiceActionId: action.id,
-                choiceSelections: null,
-              },
+          overrides: {
+            choiceActionId: action.id,
+            choiceNodeType: selectionIntent.nextChoiceNodeType,
+            choiceSelections: null,
+          },
         });
         let targetNodeId = stagingNode.id;
 
@@ -785,6 +787,7 @@ export const useChoiceWizardController = () => {
             isConfigured: true,
             overrides: {
               choiceActionId: selectedAction.id,
+              choiceNodeType: targetNode.data.config.choiceNodeType,
               choiceSelections: selections,
             },
             preserveExistingConfig: true,


### PR DESCRIPTION
## 🧾 요약 (Summary)

루프에서 파일 목록을 하나씩 처리한 뒤 Google Drive 같은 파일 기반 출력 노드로 전달할 때, 반복 결과가 하나의 텍스트로 합쳐져 파일 하나만 생성되던 문제를 수정했습니다.

## 🔑 주요 변경 사항 (Key Changes)

- 루프 본문 결과가 `TEXT`이고 다음 출력 노드가 `FILE_LIST`를 지원하면 반복 결과를 파일 목록으로 보존
- Google Drive 출력 노드에서는 반복 결과별 텍스트 파일이 각각 생성되도록 집계 방식 분기
- Slack처럼 `FILE_LIST`를 지원하지 않는 출력 노드는 기존 텍스트 집계 방식 유지
- 루프 결과 집계 분기 테스트 추가

## 🛠 상세 구현 내용 (Implementation Details)

- `WorkflowExecutor._aggregate_loop_outputs()`에서 downstream output sink의 accepted input type을 확인하도록 보강
- `TEXT` 반복 결과를 `FILE_LIST` item으로 변환할 때 `filename`, `mime_type`, `content`, `source_*` 메타데이터를 포함
- Google Drive downstream 케이스와 Slack downstream 케이스를 테스트로 분리해 기존 동작 회귀 방지

## 🧯 트러블 슈팅 (Trouble Shooting)

루프에서 여러 파일을 하나씩 처리해도 결과가 `TEXT` 하나로 합쳐져 Google Drive에는 파일 하나만 생성되는 문제가 있었습니다.

원인은 루프 집계 로직이 downstream 출력 노드의 요구 타입을 고려하지 않고 동일 타입 결과를 단순 집계하던 구조였습니다. 출력 노드가 `FILE_LIST`를 받을 수 있는 경우에는 반복 결과를 파일 목록으로 보존하도록 분기해 해결했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 전체 테스트 중 MongoDB 로컬 연결이 필요한 일부 trigger API 테스트는 환경 의존으로 실패할 수 있습니다.
- 이번 PR은 루프 결과 전달 형식 보존에 집중하며, 외부 서비스 실계정 업로드 E2E 검증은 별도 확인이 필요합니다.

## 📸 스크린샷 (Screenshots)

- 없음

## 🔗 관련 이슈 (Related Issues)

- #134 
