### PR TITLE
[PR] 워크플로우 리스트 실행 버튼 동작 수정

### DIFF
--- a/docs/WORKFLOW_LIST_RUN_STOP_ACTION_DESIGN.md
+++ b/docs/WORKFLOW_LIST_RUN_STOP_ACTION_DESIGN.md
@@ -1,0 +1,387 @@
+# Workflow List Run/Stop Action Design
+
+## 배경
+
+워크플로우 리스트의 실행/일시정지 버튼은 현재 실제 실행 API가 아니라 `active` 값을 토글한다.
+
+- 리스트 버튼: `WorkflowRow`에서 `workflow.active` 기준으로 재생/일시정지 아이콘 표시
+- 액션 훅: `useWorkflowListActions.handleToggleWorkflow()`
+- API 호출: `PUT /api/workflows/{workflowId}` with `{ active }`
+
+백엔드에서 `active`는 워크플로우 실행 상태가 아니라 스케줄 트리거 활성화 여부에 가깝다. 실제 수동 실행/중지는 별도 API로 제공된다.
+
+- 실행: `POST /api/workflows/{workflowId}/execute`
+- 최신 실행 조회: `GET /api/workflows/{workflowId}/executions/latest`
+- 실행 중지: `POST /api/workflows/{workflowId}/executions/{executionId}/stop`
+
+최신 실행이 없는 경우의 응답은 프론트 계약상 `200 OK`와 `null`을 기대한다. 백엔드가 `404`를 반환하는 구조라면 프론트 API 어댑터에서 `null`로 정규화하거나, 백엔드 계약을 `200 null`로 맞춰야 한다.
+
+따라서 리스트의 실행 버튼은 `active` 토글이 아니라 실행/중지 API를 사용하도록 분리해야 한다.
+
+## 목표
+
+- 워크플로우 리스트에서 재생 버튼을 누르면 해당 워크플로우를 즉시 실행한다.
+- 최신 실행이 `pending` 또는 `running` 상태라면 같은 위치의 버튼은 중지 버튼으로 동작한다.
+- `active` 토글은 실행/중지 동작에서 제거한다.
+- 워크플로우 리스트와 대시보드의 빠른 실행 액션이 동일한 의미를 갖도록 정리한다.
+- 백엔드 API 변경 없이 현재 제공된 실행 API 계약에 맞춘다.
+
+## 비목표
+
+- 스케줄 활성화/비활성화 UI는 이번 범위에 포함하지 않는다.
+- 일시정지/재개 기능은 구현하지 않는다. 현재 백엔드 계약은 pause/resume이 아니라 stop이다.
+- 실행 전 설정 검증 UI를 새로 만들지 않는다. 리스트 실행 실패는 백엔드 오류 메시지를 그대로 사용자에게 전달한다.
+
+## 현재 문제 지점
+
+### 프론트
+
+- `src/pages/workflows/ui/WorkflowRow.tsx`
+  - `workflow.active` 값으로 `MdPlayArrow` 또는 `MdPause`를 표시한다.
+  - 버튼 의미가 실행 상태와 섞여 있다.
+
+- `src/pages/workflows/model/useWorkflowListActions.ts`
+  - `handleToggleWorkflow()`가 `useToggleWorkflowActiveMutation()`을 호출한다.
+  - 사용자가 실행 버튼이라고 인식하는 액션이 실제로는 `active` 토글이다.
+
+- `src/entities/workflow/model/useToggleWorkflowActiveMutation.ts`
+  - `workflowApi.update(workflowId, { active })`를 호출한다.
+
+- `src/pages/dashboard/model/useDashboardActions.ts`
+  - 대시보드에서도 같은 `active` 토글 훅을 사용한다.
+  - 리스트와 동일하게 빠른 실행 액션 의미가 어긋날 가능성이 있다.
+
+### 백엔드
+
+백엔드의 `active` 업데이트는 실행 상태 변경이 아니라 스케줄 트리거 이벤트 발행과 연결된다.
+
+- `WorkflowUpdateRequest.active`
+- `WorkflowService.updateWorkflow()`
+- `publishScheduleEvent()`
+  - `trigger.type === "schedule"`일 때만 스케줄 등록/해제 이벤트를 발행한다.
+
+즉, 현재 리스트 버튼이 기대하는 “워크플로우 실행/중지”와 백엔드의 `active` 의미가 다르다.
+
+## 설계 방향
+
+### 1. 실행 상태 기준 모델 추가
+
+리스트 행은 `workflow.active`가 아니라 최신 실행 상태를 기준으로 버튼 상태를 결정한다.
+
+실행 중으로 판단할 상태:
+
+- `pending`
+- `running`
+
+상태별 버튼:
+
+- 최신 실행 없음 또는 완료/실패/중지 상태: 실행 버튼
+- 최신 실행이 `pending` 또는 `running`: 중지 버튼
+- 실행/중지 요청 중: 로딩 상태
+
+표시 문구는 “일시정지”가 아니라 “중지”로 맞춘다. 백엔드 API가 stop 계약이기 때문이다.
+
+행에서 필요한 실행 상태 모델은 다음 정도로 제한한다.
+
+```ts
+type WorkflowRowExecutionActionState =
+  | "idle"
+  | "starting"
+  | "running"
+  | "stopping";
+```
+
+- `idle`: 최신 실행이 없거나 완료/실패/중지 상태
+- `starting`: 실행 mutation pending
+- `running`: 최신 실행이 `pending` 또는 `running`
+- `stopping`: 중지 mutation pending
+
+`success`, `failed`, `stopped`는 버튼 관점에서는 모두 다시 실행 가능한 상태이므로 `idle`로 취급한다.
+
+### 2. 리스트 행 단위 실행 액션 분리
+
+`WorkflowRow`는 가능하면 표시 전용 컴포넌트로 유지한다.
+
+권장 구조:
+
+- `WorkflowRowItem`
+  - 각 워크플로우 행의 latest execution query와 mutation을 소유한다.
+  - `WorkflowRow`에 실행 상태, 로딩 상태, 클릭 핸들러를 전달한다.
+
+- `WorkflowRow`
+  - 아이콘, 버튼 disabled, aria-label, 표시 문구만 담당한다.
+  - API 훅을 직접 알지 않는다.
+
+예상 데이터 흐름:
+
+1. `WorkflowListSection`이 워크플로우 목록을 렌더링한다.
+2. 각 행은 `WorkflowRowItem`으로 감싼다.
+3. `WorkflowRowItem`은 `useLatestWorkflowExecutionQuery(workflow.id)`로 최신 실행 상태를 조회한다.
+4. 버튼 클릭 시:
+   - 최신 실행이 in-flight면 `useStopExecutionMutation()`으로 중지한다.
+   - 아니면 `useExecuteWorkflowMutation()`으로 실행한다.
+5. 성공 후 latest execution query와 목록 관련 query를 invalidate한다.
+
+구현 시 `WorkflowRow` props는 `active` 용어를 제거하고 실행 의미로 바꾼다.
+
+예상 props:
+
+```ts
+type Props = {
+  workflow: WorkflowResponse;
+  executionActionLabel: string;
+  executionActionKind: "run" | "stop";
+  isExecutionActionPending: boolean;
+  onOpen: () => void;
+  onExecutionAction: () => void;
+};
+```
+
+`WorkflowRow` 내부에서는 `workflow.active`를 직접 보지 않는다. 아이콘은 `executionActionKind`로 결정한다.
+
+### 3. 최신 실행 조회 전략
+
+리스트 행마다 최신 실행을 조회하면 요청 수가 늘 수 있다. 다만 일반 리스트 페이지의 행 개수는 제한되어 있고, 실행 상태를 정확히 표시하려면 최신 실행 상태가 필요하다.
+
+권장 전략:
+
+- 행별 latest execution query를 사용한다.
+- in-flight 상태일 때만 polling한다.
+- 완료/실패/중지 상태에서는 polling을 멈춘다.
+- 쿼리 stale time을 짧게 유지하되 불필요한 상시 refetch는 피한다.
+- 리스트 진입 시 캐시된 latest execution이 오래 남아 실행 상태가 틀어지지 않도록 mount 시 최신 조회를 보장한다.
+
+이미 에디터 원격 바에서 사용하는 실행 관련 훅과 유틸을 우선 재사용한다.
+
+- `useExecuteWorkflowMutation`
+- `useStopExecutionMutation`
+- `useLatestWorkflowExecutionQuery`
+- `isExecutionInFlight`
+- `executionPollInterval`
+
+현재 `QueryClient` 기본값은 `refetchOnMount: false`다. 따라서 단순히 `useLatestWorkflowExecutionQuery(workflow.id)`만 연결하면 이전 캐시가 남아 있을 때 리스트 재진입 시 최신 상태를 다시 확인하지 않을 수 있다.
+
+구현 선택지는 둘 중 하나로 한다.
+
+1. `QueryPolicyOptions`에 `refetchOnMount`를 추가하고 `useLatestWorkflowExecutionQuery`에서 전달한다.
+   - 장점: React Query 옵션 흐름과 일관된다.
+   - 단점: shared query policy 타입 변경이 필요하다.
+
+2. 행 전용 훅에서 mount 또는 workflow id 변경 시 `latestExecutionQuery.refetch()`를 명시적으로 호출한다.
+   - 장점: 변경 범위가 작다.
+   - 단점: 훅 내부 side effect가 생긴다.
+
+권장안은 1번이다. 이미 여러 query hook이 `QueryPolicyOptions`를 공유하고 있으므로, `refetchOnMount`를 정책 옵션으로 확장하면 다른 query에서도 같은 패턴을 재사용할 수 있다.
+
+리스트 행에서는 다음 옵션을 사용한다.
+
+```ts
+useLatestWorkflowExecutionQuery(workflow.id, {
+  refetchOnMount: "always",
+  staleTime: 0,
+});
+```
+
+polling은 기존 `useLatestWorkflowExecutionQuery`의 `refetchInterval` 기본값을 유지한다. 즉 latest execution이 in-flight일 때만 polling한다.
+
+### 4. `active` 토글 제거 또는 분리
+
+리스트의 재생/중지 버튼에서는 `active` 토글을 호출하지 않는다.
+
+스케줄 자동 실행 활성화가 필요하다면 별도 이슈에서 다음처럼 분리한다.
+
+- 스케줄 워크플로우에만 표시
+- 명칭은 “자동 실행 켜기/끄기”로 구분
+- 실행/중지 아이콘과 다른 UI로 제공
+
+이번 이슈에서는 혼동을 막기 위해 리스트 빠른 액션에서 `useToggleWorkflowActiveMutation()` 사용을 제거한다.
+
+### 5. 대시보드 액션 정리
+
+대시보드도 현재 `active` 토글을 빠른 액션처럼 사용하고 있다면 동일한 기준으로 맞춘다.
+
+우선순위:
+
+1. 리스트 실행/중지 동작을 먼저 수정한다.
+2. 실행/중지 mutation과 latest execution 판단 로직은 대시보드에서도 재사용한다.
+3. 대시보드 카드 UI는 리스트 행과 구조가 다르므로 `WorkflowRow`를 재사용하지 않는다.
+4. 대시보드 범위가 커질 경우 최소한 `active` 토글을 실행 버튼처럼 보이지 않게 분리한다.
+
+대시보드는 `DashboardIssue`로 워크플로우 데이터를 한 번 가공해서 사용한다. 따라서 공통화 단위는 UI 컴포넌트가 아니라 실행 액션 훅이다.
+
+권장 공통 훅:
+
+```ts
+type UseWorkflowExecutionActionResult = {
+  actionKind: "run" | "stop";
+  actionLabel: string;
+  isActionPending: boolean;
+  isRunning: boolean;
+  handleAction: () => Promise<void>;
+};
+```
+
+위 훅은 `workflowId`만 받아 실행/중지 판단과 mutation을 처리한다.
+
+- 리스트: `WorkflowRowItem`에서 사용
+- 대시보드: `DashboardErrorCard`를 감싸는 컨테이너 또는 `DashboardSection`에서 사용
+
+단, React Hook 규칙 때문에 `map()` 내부에서 공통 훅을 직접 호출하지 않는다. 리스트와 대시보드 모두 행/카드 단위 컨테이너 컴포넌트를 만들어 그 내부에서 훅을 호출한다.
+
+예상 구조:
+
+```text
+src/pages/workflows/ui/WorkflowRowItem.tsx
+src/pages/dashboard/ui/DashboardIssueCardItem.tsx
+src/features/workflow-execution/model/useWorkflowExecutionAction.ts
+```
+
+리스트와 대시보드가 함께 사용하는 실행/중지 액션은 특정 페이지의 전용 로직이 아니다. 따라서 page slice 내부가 아니라 `features/workflow-execution`으로 둔다. page는 feature를 참조할 수 있지만, dashboard page가 workflows page 내부 훅을 참조하면 FSD 의존 방향을 어기게 된다.
+
+## 구체 구현 설계
+
+### 1. QueryPolicyOptions 확장
+
+`src/shared/api/query-policy.ts`에 `refetchOnMount`를 추가한다.
+
+```ts
+refetchOnMount?: UseQueryOptions<
+  TQueryFnData,
+  ApiError,
+  TData
+>["refetchOnMount"];
+```
+
+그리고 `useLatestWorkflowExecutionQuery`에서 해당 옵션을 전달한다.
+
+```ts
+refetchOnMount: options?.refetchOnMount,
+```
+
+이 변경은 shared query policy 타입 확장이지만 기존 호출부에는 영향을 주지 않는다.
+
+### 2. 실행 액션 훅 추가
+
+`src/features/workflow-execution/model/useWorkflowExecutionAction.ts`를 추가한다.
+
+책임:
+
+- latest execution 조회
+- in-flight 판단
+- execute mutation 호출
+- stop mutation 호출
+- 실행/중지 성공 후 latest query invalidate 또는 refetch
+- toast 오류 처리
+
+처리 흐름:
+
+```text
+handleAction()
+  ├─ latestExecution이 in-flight
+  │   ├─ executionId 없음 -> 오류 toast
+  │   └─ stopExecution({ workflowId, executionId })
+  └─ 그 외
+      └─ executeWorkflow(workflowId)
+```
+
+`executeWorkflow`가 execution id를 반환하므로, 실행 직후 latest query를 invalidate하고 필요하면 refetch한다.
+
+공개 API:
+
+```text
+src/features/workflow-execution/index.ts
+src/features/workflow-execution/model/index.ts
+```
+
+페이지에서는 내부 파일을 직접 deep import하지 않고 feature 공개 API를 통해 가져온다.
+
+### 3. 리스트 행 컨테이너 추가
+
+`src/pages/workflows/ui/WorkflowRowItem.tsx`를 추가한다.
+
+책임:
+
+- `workflow`를 받는다.
+- `useWorkflowExecutionAction(workflow.id)`을 호출한다.
+- `WorkflowRow`에 실행 상태 props를 전달한다.
+
+`WorkflowListSection`은 `WorkflowRow` 대신 `WorkflowRowItem`을 렌더링한다.
+
+### 4. WorkflowRow 표시 책임 축소
+
+`WorkflowRow`에서 제거할 것:
+
+- `workflow.active` 기반 quick action label
+- `isTogglePending`
+- `onToggle`
+
+`WorkflowRow`에 추가할 것:
+
+- `executionActionLabel`
+- `executionActionKind`
+- `isExecutionActionPending`
+- `onExecutionAction`
+
+아이콘:
+
+- `executionActionKind === "run"`: `MdPlayArrow`
+- `executionActionKind === "stop"`: `MdStop` 또는 기존 `MdPause` 대신 stop 의미 아이콘
+
+가능하면 `MdStop`을 사용한다. 현재 UI가 pause처럼 보이면 백엔드 stop 계약과 다시 어긋난다.
+
+### 5. 대시보드 카드 컨테이너 추가
+
+대시보드까지 이번 이슈에 포함한다면 `DashboardIssueCardItem`을 추가한다.
+
+책임:
+
+- `DashboardIssue`를 받는다.
+- `useWorkflowExecutionAction(issue.id)`을 호출한다.
+- `DashboardErrorCard`에 실행 상태 props를 전달한다.
+
+`DashboardErrorCard`도 `isActive` 대신 실행 액션 props를 받도록 정리한다.
+
+이번 이슈에서 대시보드 구현 범위를 줄여야 한다면 최소 조치로 대시보드의 실행/중지 아이콘 버튼을 제거하거나 “자동화 활성화” 의미로 이름을 바꾼다. 다만 사용자 관점의 혼동을 줄이려면 리스트와 동일하게 실행/중지로 맞추는 편이 낫다.
+
+## 오류 처리
+
+- 실행 실패: 백엔드 오류 메시지를 toast로 표시한다.
+- 중지 실패: 백엔드 오류 메시지를 toast로 표시한다.
+- 중지 버튼 클릭 시 최신 실행 ID가 없으면 “중지할 실행이 없습니다.” 메시지를 표시한다.
+- 실행 중 버튼 중복 클릭은 mutation pending 상태로 막는다.
+- latest execution 조회 실패는 실행 버튼 자체를 막지 않는다. 조회 실패 상태에서는 기본값을 실행 가능 상태로 두고, 실제 실행 API 오류를 사용자에게 표시한다.
+
+## 검증 기준
+
+- 리스트에서 실행 버튼 클릭 시 `PUT /api/workflows/{id}`가 아니라 `POST /api/workflows/{id}/execute`가 호출된다.
+- 실행 중인 워크플로우의 버튼은 중지 상태로 표시된다.
+- 중지 버튼 클릭 시 `GET /api/workflows/{id}/executions/latest`로 확인한 execution id를 사용해 `POST /api/workflows/{id}/executions/{executionId}/stop`이 호출된다.
+- 실행 완료/실패/중지 후 버튼은 다시 실행 상태로 돌아온다.
+- `workflow.active`가 false여도 수동 실행 버튼은 실행 API를 호출한다.
+- 대시보드 빠른 액션이 실행/중지 의미와 `active` 토글 의미를 섞지 않는다.
+- 리스트 재진입 시 이전 캐시 때문에 실행 중/중지 상태가 틀어지지 않는다.
+- 최신 실행이 없는 워크플로우도 오류 없이 실행 버튼으로 표시된다.
+- `pnpm run build`가 통과한다.
+
+## 구현 단계
+
+1. Query policy와 latest execution 조회 보강
+   - `QueryPolicyOptions`에 `refetchOnMount`를 추가한다.
+   - `useLatestWorkflowExecutionQuery`에서 mount refetch 옵션을 전달한다.
+
+2. 실행 액션 훅 추가
+   - execute/stop/latest 판단 로직을 `useWorkflowExecutionAction`으로 묶는다.
+   - 오류 toast와 pending 상태를 처리한다.
+
+3. 리스트 실행/중지 액션 교체
+   - `WorkflowRowItem`을 추가한다.
+   - `active` 토글 대신 execute/stop mutation을 호출한다.
+   - 버튼 라벨과 아이콘을 실행/중지 의미로 정리한다.
+
+4. 대시보드 빠른 액션 정리
+   - `DashboardIssueCardItem`을 추가하거나 동일한 액션 훅을 연결한다.
+   - 리스트와 동일한 실행/중지 동작을 재사용하거나, `active` 토글 UI를 분리한다.
+
+5. 검증
+   - 빌드와 수동 API 호출 흐름을 확인한다.
+   - 실행/중지/완료/실패 상태별 버튼 변화를 확인한다.

--- a/src/entities/execution/model/useExecutionNodeDataQuery.ts
+++ b/src/entities/execution/model/useExecutionNodeDataQuery.ts
@@ -39,6 +39,7 @@ export const useExecutionNodeDataQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval:
       options?.refetchInterval ??
       ((query) => {

--- a/src/entities/execution/model/useLatestExecutionNodeDataQuery.ts
+++ b/src/entities/execution/model/useLatestExecutionNodeDataQuery.ts
@@ -38,6 +38,7 @@ export const useLatestExecutionNodeDataQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval:
       options?.refetchInterval ??
       ((query) => {

--- a/src/entities/execution/model/useLatestWorkflowExecutionQuery.ts
+++ b/src/entities/execution/model/useLatestWorkflowExecutionQuery.ts
@@ -34,6 +34,7 @@ export const useLatestWorkflowExecutionQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval:
       options?.refetchInterval ??
       ((query) => {

--- a/src/entities/execution/model/useWorkflowExecutionQuery.ts
+++ b/src/entities/execution/model/useWorkflowExecutionQuery.ts
@@ -36,6 +36,7 @@ export const useWorkflowExecutionQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval:
       options?.refetchInterval ??
       ((query) => {
@@ -53,4 +54,3 @@ export const useWorkflowExecutionQuery = (
     throwOnError: false,
   });
 };
-

--- a/src/entities/execution/model/useWorkflowExecutionsQuery.ts
+++ b/src/entities/execution/model/useWorkflowExecutionsQuery.ts
@@ -34,6 +34,7 @@ export const useWorkflowExecutionsQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval:
       options?.refetchInterval ??
       ((query) => {
@@ -53,4 +54,3 @@ export const useWorkflowExecutionsQuery = (
     throwOnError: false,
   });
 };
-

--- a/src/entities/oauth-token/model/useOAuthTokensQuery.ts
+++ b/src/entities/oauth-token/model/useOAuthTokensQuery.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type QueryPolicyOptions, toQueryMeta } from "@/shared/api";
 
 import { oauthApi } from "../api";
+
 import { oauthKeys } from "./query-keys";
 
 export const useOAuthTokensQuery = (
@@ -15,9 +16,9 @@ export const useOAuthTokensQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),
     throwOnError: false,
   });
-

--- a/src/entities/template/model/useTemplateListQuery.ts
+++ b/src/entities/template/model/useTemplateListQuery.ts
@@ -17,6 +17,7 @@ export const useTemplateListQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/template/model/useTemplateQuery.ts
+++ b/src/entities/template/model/useTemplateQuery.ts
@@ -23,6 +23,7 @@ export const useTemplateQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useMappingRulesQuery.ts
+++ b/src/entities/workflow/model/useMappingRulesQuery.ts
@@ -26,6 +26,7 @@ export const useMappingRulesQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useSinkCatalogQuery.ts
+++ b/src/entities/workflow/model/useSinkCatalogQuery.ts
@@ -26,6 +26,7 @@ export const useSinkCatalogQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useSinkSchemaQuery.ts
+++ b/src/entities/workflow/model/useSinkSchemaQuery.ts
@@ -35,6 +35,7 @@ export const useSinkSchemaQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useSourceCatalogQuery.ts
+++ b/src/entities/workflow/model/useSourceCatalogQuery.ts
@@ -26,6 +26,7 @@ export const useSourceCatalogQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useSourceTargetOptionsQuery.ts
+++ b/src/entities/workflow/model/useSourceTargetOptionsQuery.ts
@@ -38,6 +38,7 @@ export const useSourceTargetOptionsQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useWorkflowChoicesQuery.ts
+++ b/src/entities/workflow/model/useWorkflowChoicesQuery.ts
@@ -37,6 +37,7 @@ export const useWorkflowChoicesQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useWorkflowListQuery.ts
+++ b/src/entities/workflow/model/useWorkflowListQuery.ts
@@ -30,6 +30,7 @@ export const useWorkflowListQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useWorkflowNodeSchemaPreviewQuery.ts
+++ b/src/entities/workflow/model/useWorkflowNodeSchemaPreviewQuery.ts
@@ -37,6 +37,7 @@ export const useWorkflowNodeSchemaPreviewQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/entities/workflow/model/useWorkflowQuery.ts
+++ b/src/entities/workflow/model/useWorkflowQuery.ts
@@ -23,9 +23,9 @@ export const useWorkflowQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),
     throwOnError: false,
   });
-

--- a/src/entities/workflow/model/useWorkflowSchemaPreviewQuery.ts
+++ b/src/entities/workflow/model/useWorkflowSchemaPreviewQuery.ts
@@ -27,6 +27,7 @@ export const useWorkflowSchemaPreviewQuery = (
     select: options?.select,
     retry: options?.retry,
     staleTime: options?.staleTime,
+    refetchOnMount: options?.refetchOnMount,
     refetchInterval: options?.refetchInterval,
     placeholderData: options?.placeholderData,
     meta: toQueryMeta(options),

--- a/src/features/workflow-execution/index.ts
+++ b/src/features/workflow-execution/index.ts
@@ -1,0 +1,1 @@
+export * from "./model";

--- a/src/features/workflow-execution/model/index.ts
+++ b/src/features/workflow-execution/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./useWorkflowExecutionAction";

--- a/src/features/workflow-execution/model/useWorkflowExecutionAction.ts
+++ b/src/features/workflow-execution/model/useWorkflowExecutionAction.ts
@@ -34,8 +34,14 @@ export const useWorkflowExecutionAction = (
 
   const latestExecution = latestExecutionQuery.data ?? null;
   const isRunning = isExecutionInFlight(latestExecution?.state);
+  const isCheckingLatestExecution =
+    latestExecutionQuery.isFetching &&
+    !latestExecutionQuery.isFetchedAfterMount;
   const isActionPending =
-    latestExecutionQuery.isLoading || isExecutePending || isStopPending;
+    latestExecutionQuery.isLoading ||
+    isCheckingLatestExecution ||
+    isExecutePending ||
+    isStopPending;
   const actionKind: WorkflowExecutionActionKind = isRunning ? "stop" : "run";
   const actionLabel = isRunning ? "워크플로우 중지" : "워크플로우 실행";
 

--- a/src/features/workflow-execution/model/useWorkflowExecutionAction.ts
+++ b/src/features/workflow-execution/model/useWorkflowExecutionAction.ts
@@ -1,0 +1,93 @@
+import {
+  isExecutionInFlight,
+  useExecuteWorkflowMutation,
+  useLatestWorkflowExecutionQuery,
+  useStopExecutionMutation,
+} from "@/entities";
+import { getApiErrorMessage, toaster } from "@/shared/utils";
+
+export type WorkflowExecutionActionKind = "run" | "stop";
+
+type UseWorkflowExecutionActionResult = {
+  actionKind: WorkflowExecutionActionKind;
+  actionLabel: string;
+  isActionPending: boolean;
+  isRunning: boolean;
+  handleAction: () => Promise<void>;
+};
+
+export const useWorkflowExecutionAction = (
+  workflowId: string | undefined,
+): UseWorkflowExecutionActionResult => {
+  const latestExecutionQuery = useLatestWorkflowExecutionQuery(workflowId, {
+    refetchOnMount: "always",
+    staleTime: 0,
+  });
+  const { mutateAsync: executeWorkflow, isPending: isExecutePending } =
+    useExecuteWorkflowMutation({
+      showErrorToast: false,
+    });
+  const { mutateAsync: stopExecution, isPending: isStopPending } =
+    useStopExecutionMutation({
+      showErrorToast: false,
+    });
+
+  const latestExecution = latestExecutionQuery.data ?? null;
+  const isRunning = isExecutionInFlight(latestExecution?.state);
+  const isActionPending =
+    latestExecutionQuery.isLoading || isExecutePending || isStopPending;
+  const actionKind: WorkflowExecutionActionKind = isRunning ? "stop" : "run";
+  const actionLabel = isRunning ? "워크플로우 중지" : "워크플로우 실행";
+
+  const handleAction = async () => {
+    if (!workflowId || isActionPending) {
+      return;
+    }
+
+    if (isExecutionInFlight(latestExecution?.state)) {
+      if (!latestExecution?.id) {
+        toaster.create({
+          title: "중지 실패",
+          description: "중지할 실행이 없습니다.",
+          type: "error",
+        });
+        return;
+      }
+
+      try {
+        await stopExecution({
+          workflowId,
+          executionId: latestExecution.id,
+        });
+        await latestExecutionQuery.refetch();
+      } catch (error) {
+        toaster.create({
+          title: "중지 실패",
+          description: getApiErrorMessage(error),
+          type: "error",
+        });
+      }
+
+      return;
+    }
+
+    try {
+      await executeWorkflow(workflowId);
+      await latestExecutionQuery.refetch();
+    } catch (error) {
+      toaster.create({
+        title: "실행 실패",
+        description: getApiErrorMessage(error),
+        type: "error",
+      });
+    }
+  };
+
+  return {
+    actionKind,
+    actionLabel,
+    isActionPending,
+    isRunning,
+    handleAction,
+  };
+};

--- a/src/pages/dashboard/model/useDashboardActions.ts
+++ b/src/pages/dashboard/model/useDashboardActions.ts
@@ -1,17 +1,7 @@
 import { useState } from "react";
 
-import { useToggleWorkflowActiveMutation } from "@/entities/workflow";
-
 export const useDashboardActions = () => {
   const [expandedIssueId, setExpandedIssueId] = useState<string | null>(null);
-  const [togglingWorkflowId, setTogglingWorkflowId] = useState<string | null>(
-    null,
-  );
-  const [issueActiveOverrides, setIssueActiveOverrides] = useState<
-    Record<string, boolean>
-  >({});
-  const { mutateAsync: toggleWorkflowActive } =
-    useToggleWorkflowActiveMutation();
 
   const handleToggleIssue = (issueId: string) => {
     setExpandedIssueId((currentIssueId) =>
@@ -19,45 +9,8 @@ export const useDashboardActions = () => {
     );
   };
 
-  const handleToggleWorkflow = async (
-    issueId: string,
-    currentIsActive: boolean,
-  ) => {
-    const nextActive = !currentIsActive;
-
-    setIssueActiveOverrides((currentOverrides) => ({
-      ...currentOverrides,
-      [issueId]: nextActive,
-    }));
-
-    const variables = {
-      workflowId: issueId,
-      active: nextActive,
-    };
-
-    setTogglingWorkflowId(issueId);
-
-    try {
-      await toggleWorkflowActive(variables);
-    } catch (error) {
-      setIssueActiveOverrides((currentOverrides) => ({
-        ...currentOverrides,
-        [issueId]: currentIsActive,
-      }));
-      throw error;
-    } finally {
-      setTogglingWorkflowId(null);
-    }
-  };
-
-  const getIssueIsActive = (issueId: string, issueIsActive: boolean) =>
-    issueActiveOverrides[issueId] ?? issueIsActive;
-
   return {
     expandedIssueId,
-    getIssueIsActive,
-    togglingWorkflowId,
     handleToggleIssue,
-    handleToggleWorkflow,
   };
 };

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -1,5 +1,5 @@
 import { type KeyboardEvent, type MouseEvent } from "react";
-import { MdPause, MdPlayArrow } from "react-icons/md";
+import { MdPlayArrow, MdStop } from "react-icons/md";
 
 import {
   Box,
@@ -17,20 +17,22 @@ import { type DashboardIssue } from "../model";
 
 type Props = {
   issue: DashboardIssue;
-  isActive: boolean;
+  executionActionKind: "run" | "stop";
+  executionActionLabel: string;
+  isExecutionActionPending: boolean;
   isExpanded: boolean;
   onToggle: () => void;
-  isTogglePending: boolean;
-  onToggleWorkflow: () => void;
+  onExecutionAction: () => void;
 };
 
 export const DashboardErrorCard = ({
   issue,
-  isActive,
+  executionActionKind,
+  executionActionLabel,
+  isExecutionActionPending,
   isExpanded,
   onToggle,
-  isTogglePending,
-  onToggleWorkflow,
+  onExecutionAction,
 }: Props) => {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter" || event.key === " ") {
@@ -39,12 +41,10 @@ export const DashboardErrorCard = ({
     }
   };
 
-  const handleToggleWorkflowClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleExecutionActionClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    onToggleWorkflow();
+    onExecutionAction();
   };
-
-  const toggleButtonLabel = isActive ? "자동화 중지" : "자동화 실행";
 
   return (
     <Box
@@ -94,17 +94,17 @@ export const DashboardErrorCard = ({
         </HStack>
 
         <IconButton
-          aria-label={toggleButtonLabel}
+          aria-label={executionActionLabel}
           variant="ghost"
           size="sm"
           flexShrink={0}
-          disabled={isTogglePending}
-          onClick={handleToggleWorkflowClick}
+          disabled={isExecutionActionPending}
+          onClick={handleExecutionActionClick}
         >
-          {isTogglePending ? (
+          {isExecutionActionPending ? (
             <Spinner size="xs" />
-          ) : isActive ? (
-            <MdPause />
+          ) : executionActionKind === "stop" ? (
+            <MdStop />
           ) : (
             <MdPlayArrow />
           )}

--- a/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
+++ b/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
@@ -1,0 +1,32 @@
+import { useWorkflowExecutionAction } from "@/features/workflow-execution";
+
+import { type DashboardIssue } from "../model";
+
+import { DashboardErrorCard } from "./DashboardErrorCard";
+
+type Props = {
+  issue: DashboardIssue;
+  isExpanded: boolean;
+  onToggle: () => void;
+};
+
+export const DashboardIssueCardItem = ({
+  issue,
+  isExpanded,
+  onToggle,
+}: Props) => {
+  const { actionKind, actionLabel, isActionPending, handleAction } =
+    useWorkflowExecutionAction(issue.id);
+
+  return (
+    <DashboardErrorCard
+      issue={issue}
+      executionActionKind={actionKind}
+      executionActionLabel={actionLabel}
+      isExecutionActionPending={isActionPending}
+      isExpanded={isExpanded}
+      onToggle={onToggle}
+      onExecutionAction={() => void handleAction()}
+    />
+  );
+};

--- a/src/pages/dashboard/ui/index.ts
+++ b/src/pages/dashboard/ui/index.ts
@@ -1,4 +1,5 @@
 export * from "./DashboardErrorCard";
+export * from "./DashboardIssueCardItem";
 export * from "./DashboardMetricCard";
 export * from "./section";
 export * from "./ServiceConnectionCard";

--- a/src/pages/dashboard/ui/section/DashboardSection.tsx
+++ b/src/pages/dashboard/ui/section/DashboardSection.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/react";
 
 import {
-  DashboardErrorCard,
+  DashboardIssueCardItem,
   DashboardMetricCard,
   ServiceConnectionCard,
 } from "..";
@@ -118,13 +118,7 @@ export const DashboardSection = () => {
     handleConnectService,
     handleDisconnectService,
   } = useDashboardData();
-  const {
-    expandedIssueId,
-    getIssueIsActive,
-    togglingWorkflowId,
-    handleToggleIssue,
-    handleToggleWorkflow,
-  } = useDashboardActions();
+  const { expandedIssueId, handleToggleIssue } = useDashboardActions();
 
   return (
     <VStack align="stretch" gap={12}>
@@ -167,19 +161,11 @@ export const DashboardSection = () => {
           issues.length > 0 ? (
             <VStack align="stretch" gap={3}>
               {issues.map((issue) => (
-                <DashboardErrorCard
+                <DashboardIssueCardItem
                   key={issue.id}
                   issue={issue}
-                  isActive={getIssueIsActive(issue.id, issue.isActive)}
                   isExpanded={expandedIssueId === issue.id}
-                  isTogglePending={togglingWorkflowId === issue.id}
                   onToggle={() => handleToggleIssue(issue.id)}
-                  onToggleWorkflow={() =>
-                    void handleToggleWorkflow(
-                      issue.id,
-                      getIssueIsActive(issue.id, issue.isActive),
-                    )
-                  }
                 />
               ))}
             </VStack>

--- a/src/pages/workflows/model/useWorkflowListActions.ts
+++ b/src/pages/workflows/model/useWorkflowListActions.ts
@@ -1,22 +1,12 @@
-import { useState } from "react";
 import { useNavigate } from "react-router";
 
-import {
-  type WorkflowResponse,
-  useToggleWorkflowActiveMutation,
-} from "@/entities/workflow";
 import { useCreateWorkflowShortcut } from "@/features/create-workflow";
 import { buildPath } from "@/shared";
 
 export const useWorkflowListActions = () => {
   const navigate = useNavigate();
-  const [togglingWorkflowId, setTogglingWorkflowId] = useState<string | null>(
-    null,
-  );
   const { createWorkflow, isPending: isCreatePending } =
     useCreateWorkflowShortcut();
-  const { mutateAsync: toggleWorkflowActive } =
-    useToggleWorkflowActiveMutation();
 
   const handleCreateWorkflow = () => {
     void createWorkflow();
@@ -26,24 +16,9 @@ export const useWorkflowListActions = () => {
     navigate(buildPath.workflowEditor(workflowId));
   };
 
-  const handleToggleWorkflow = async (workflow: WorkflowResponse) => {
-    setTogglingWorkflowId(workflow.id);
-
-    try {
-      await toggleWorkflowActive({
-        workflowId: workflow.id,
-        active: !workflow.active,
-      });
-    } finally {
-      setTogglingWorkflowId(null);
-    }
-  };
-
   return {
     isCreatePending,
-    togglingWorkflowId,
     handleCreateWorkflow,
     handleOpenWorkflow,
-    handleToggleWorkflow,
   };
 };

--- a/src/pages/workflows/ui/WorkflowRow.tsx
+++ b/src/pages/workflows/ui/WorkflowRow.tsx
@@ -2,8 +2,8 @@ import { type KeyboardEvent, type MouseEvent } from "react";
 import {
   MdErrorOutline,
   MdMoreHoriz,
-  MdPause,
   MdPlayArrow,
+  MdStop,
 } from "react-icons/md";
 
 import {
@@ -31,16 +31,20 @@ import { ServiceBadge } from "./ServiceBadge";
 
 type Props = {
   workflow: WorkflowResponse;
-  isTogglePending: boolean;
+  executionActionKind: "run" | "stop";
+  executionActionLabel: string;
+  isExecutionActionPending: boolean;
   onOpen: () => void;
-  onToggle: () => void;
+  onExecutionAction: () => void;
 };
 
 export const WorkflowRow = ({
   workflow,
-  isTogglePending,
+  executionActionKind,
+  executionActionLabel,
+  isExecutionActionPending,
   onOpen,
-  onToggle,
+  onExecutionAction,
 }: Props) => {
   const { startNode, endNode } = getEndpointNodes(workflow);
   const startBadgeKey = getServiceBadgeKey(startNode);
@@ -48,7 +52,6 @@ export const WorkflowRow = ({
   const relativeUpdate = getRelativeUpdateLabel(workflow.updatedAt);
   const buildProgress = getBuildProgressLabel(workflow);
   const warningMessages = getWorkflowWarningMessages(workflow);
-  const quickActionLabel = workflow.active ? "자동화 중지" : "자동화 실행";
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter" || event.key === " ") {
@@ -120,16 +123,16 @@ export const WorkflowRow = ({
 
         <HStack gap={0} flexShrink={0}>
           <IconButton
-            aria-label={quickActionLabel}
+            aria-label={executionActionLabel}
             variant="ghost"
             size="sm"
-            disabled={isTogglePending}
-            onClick={(event) => handleInnerAction(event, onToggle)}
+            disabled={isExecutionActionPending}
+            onClick={(event) => handleInnerAction(event, onExecutionAction)}
           >
-            {isTogglePending ? (
+            {isExecutionActionPending ? (
               <Spinner size="xs" />
-            ) : workflow.active ? (
-              <MdPause />
+            ) : executionActionKind === "stop" ? (
+              <MdStop />
             ) : (
               <MdPlayArrow />
             )}

--- a/src/pages/workflows/ui/WorkflowRowItem.tsx
+++ b/src/pages/workflows/ui/WorkflowRowItem.tsx
@@ -1,0 +1,25 @@
+import { type WorkflowResponse } from "@/entities/workflow";
+import { useWorkflowExecutionAction } from "@/features/workflow-execution";
+
+import { WorkflowRow } from "./WorkflowRow";
+
+type Props = {
+  workflow: WorkflowResponse;
+  onOpen: () => void;
+};
+
+export const WorkflowRowItem = ({ workflow, onOpen }: Props) => {
+  const { actionKind, actionLabel, isActionPending, handleAction } =
+    useWorkflowExecutionAction(workflow.id);
+
+  return (
+    <WorkflowRow
+      workflow={workflow}
+      executionActionKind={actionKind}
+      executionActionLabel={actionLabel}
+      isExecutionActionPending={isActionPending}
+      onOpen={onOpen}
+      onExecutionAction={() => void handleAction()}
+    />
+  );
+};

--- a/src/pages/workflows/ui/index.ts
+++ b/src/pages/workflows/ui/index.ts
@@ -6,3 +6,4 @@ export * from "./WorkflowFilterTabs";
 export * from "./WorkflowListHeader";
 export * from "./WorkflowListLoadingState";
 export * from "./WorkflowRow";
+export * from "./WorkflowRowItem";

--- a/src/pages/workflows/ui/section/WorkflowListSection.tsx
+++ b/src/pages/workflows/ui/section/WorkflowListSection.tsx
@@ -10,7 +10,7 @@ import { WorkflowListEmptyState } from "../WorkflowListEmptyState";
 import { WorkflowListErrorState } from "../WorkflowListErrorState";
 import { WorkflowListHeader } from "../WorkflowListHeader";
 import { WorkflowListLoadingState } from "../WorkflowListLoadingState";
-import { WorkflowRow } from "../WorkflowRow";
+import { WorkflowRowItem } from "../WorkflowRowItem";
 
 export const WorkflowListSection = () => {
   const {
@@ -25,13 +25,8 @@ export const WorkflowListSection = () => {
     isFetchingNextPage,
     handleReload,
   } = useWorkflowListData();
-  const {
-    isCreatePending,
-    togglingWorkflowId,
-    handleCreateWorkflow,
-    handleOpenWorkflow,
-    handleToggleWorkflow,
-  } = useWorkflowListActions();
+  const { isCreatePending, handleCreateWorkflow, handleOpenWorkflow } =
+    useWorkflowListActions();
   const loadMoreRef = useWorkflowListInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
@@ -58,12 +53,10 @@ export const WorkflowListSection = () => {
         {!isLoading && !isError ? (
           <VStack align="stretch" gap={3}>
             {filteredWorkflows.map((workflow) => (
-              <WorkflowRow
+              <WorkflowRowItem
                 key={workflow.id}
                 workflow={workflow}
-                isTogglePending={togglingWorkflowId === workflow.id}
                 onOpen={() => handleOpenWorkflow(workflow.id)}
-                onToggle={() => void handleToggleWorkflow(workflow)}
               />
             ))}
 

--- a/src/shared/api/query-policy.ts
+++ b/src/shared/api/query-policy.ts
@@ -21,6 +21,11 @@ export type QueryPolicyOptions<
   select?: UseQueryOptions<TQueryFnData, ApiError, TData>["select"];
   retry?: UseQueryOptions<TQueryFnData, ApiError, TData>["retry"];
   staleTime?: UseQueryOptions<TQueryFnData, ApiError, TData>["staleTime"];
+  refetchOnMount?: UseQueryOptions<
+    TQueryFnData,
+    ApiError,
+    TData
+  >["refetchOnMount"];
   refetchInterval?: UseQueryOptions<
     TQueryFnData,
     ApiError,


### PR DESCRIPTION
## 📝 요약 (Summary)

워크플로우 리스트와 대시보드의 실행 버튼이 `active` 토글이 아니라 실제 실행/중지 API를 호출하도록 수정했습니다. 최신 실행 상태를 기준으로 실행/중지 버튼을 표시하고, 상태 확인 중 중복 실행 요청이 발생하지 않도록 보강했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 워크플로우 리스트 실행 버튼을 `execute` / `latest execution` / `stop` 흐름으로 변경
- 대시보드 빠른 실행 버튼도 동일한 실행/중지 액션 흐름으로 정리
- 공통 실행 액션 훅 `features/workflow-execution` 추가
- latest execution 조회 시 mount refetch 옵션을 지원하도록 query policy 보강
- 실행 버튼 동작 설계 문서 추가

## 💻 상세 구현 내용 (Implementation Details)

### 실행/중지 액션 공통화

- `useWorkflowExecutionAction`을 추가해 실행 상태 판단과 API 호출을 한 곳으로 모았습니다.
- 최신 실행이 `pending` 또는 `running`이면 중지 버튼으로 동작합니다.
- 그 외 상태에서는 실행 버튼으로 동작합니다.

### 워크플로우 리스트 수정

- `WorkflowRowItem`을 추가해 row 단위로 최신 실행 상태를 조회합니다.
- `WorkflowRow`는 API 훅을 직접 알지 않는 표시 컴포넌트로 정리했습니다.
- 기존 `workflow.active` 기반 버튼 표시와 `useToggleWorkflowActiveMutation` 연결을 제거했습니다.

### 대시보드 수정

- `DashboardIssueCardItem`을 추가해 대시보드 카드도 같은 실행 액션 훅을 사용하게 했습니다.
- 대시보드의 빠른 실행 버튼에서도 `active` 토글 흐름을 제거했습니다.

### 최신 실행 상태 보강

- `refetchOnMount` 옵션을 query policy에 추가했습니다.
- 캐시가 있는 상태에서 latest execution을 다시 확인 중일 때 실행 버튼을 잠깐 막아 중복 실행 가능성을 줄였습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

- 기존 리스트/대시보드 버튼은 실제 실행 상태가 아니라 `workflow.active`를 기준으로 동작했습니다.
- 백엔드에서 `active`는 수동 실행 상태가 아니라 스케줄 자동화 활성화에 가까운 값이라, 사용자가 기대하는 실행/중지 동작과 달랐습니다.
- 최신 실행 상태를 기준으로 버튼 의미를 재정의하고, 실제 실행 API와 중지 API를 연결해 해결했습니다.
- 캐시된 latest execution이 남아 있을 때 중복 실행 버튼이 잠깐 활성화될 수 있어, mount refetch 중에는 버튼을 pending 처리했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 스케줄 자동 실행 활성화/비활성화 UI는 이번 PR 범위에서 분리했습니다.
- 백엔드 API는 pause/resume이 아니라 stop 계약이므로, UI도 “중지” 의미로 맞췄습니다.
- 작업 전부터 존재하던 compose 파일 삭제 상태와 미추적 문서들은 이번 PR에 포함하지 않았습니다.

## 📸 스크린샷 (Screenshots)

> 없음

## #️⃣ 관련 이슈 (Related Issues)

- #136