### PR TITLE
[PR] 노드 설정 및 입출력 패널 사용자용 표시 개선

### DIFF
--- a/docs/WORKFLOW_NODE_PREVIEW_DRY_RUN_DESIGN.md
+++ b/docs/WORKFLOW_NODE_PREVIEW_DRY_RUN_DESIGN.md
@@ -131,29 +131,43 @@ Response:
 ```json
 {
   "workflowId": "workflow_1",
-  "nodeId": "node_ai",
-  "status": "success",
-  "inputData": {
-    "type": "SINGLE_FILE",
-    "filename": "lecture.pdf",
-    "mime_type": "application/pdf",
-    "url": "https://drive.google.com/file/d/..."
-  },
+  "nodeId": "node_source",
+  "status": "available",
+  "available": true,
+  "reason": null,
   "outputData": {
-    "type": "TEXT",
-    "content": "요약 결과..."
+    "type": "FILE_LIST",
+    "items": [
+      {
+        "file_id": "file_1",
+        "filename": "lecture.pdf",
+        "mime_type": "application/pdf",
+        "size": "2048",
+        "modified_time": "2026-05-01T00:00:00Z",
+        "url": "https://drive.google.com/file/d/file_1"
+      }
+    ],
+    "truncated": false
   },
-  "previewMeta": {
-    "saved": false,
-    "sideEffect": false,
-    "sampled": true,
-    "sampleIndex": 0,
-    "sampleReason": "하나씩 처리 미리보기는 첫 번째 항목만 사용합니다.",
-    "truncated": false,
+  "previewData": {
+    "type": "FILE_LIST",
+    "items": [
+      {
+        "file_id": "file_1",
+        "filename": "lecture.pdf",
+        "mime_type": "application/pdf",
+        "size": "2048",
+        "modified_time": "2026-05-01T00:00:00Z",
+        "url": "https://drive.google.com/file/d/file_1"
+      }
+    ],
+    "truncated": false
+  },
+  "missingFields": null,
+  "metadata": {
     "limit": 50,
-    "executedNodeIds": ["node_source", "node_loop", "node_ai"]
-  },
-  "error": null
+    "preview_scope": "source_metadata"
+  }
 }
 ```
 
@@ -164,22 +178,14 @@ Response:
   "workflowId": "workflow_1",
   "nodeId": "node_ai",
   "status": "unavailable",
+  "available": false,
+  "reason": "PREVIEW_NOT_IMPLEMENTED",
   "inputData": null,
   "outputData": null,
-  "previewMeta": {
-    "saved": false,
-    "sideEffect": false,
-    "sampled": false,
-    "truncated": false,
-    "limit": 50,
-    "executedNodeIds": []
-  },
-  "error": {
-    "code": "NODE_NOT_CONFIGURED",
-    "message": "노드 설정이 완료되지 않았습니다.",
-    "context": {
-      "missingFields": ["prompt"]
-    }
+  "previewData": null,
+  "missingFields": null,
+  "metadata": {
+    "preview_scope": "source_metadata"
   }
 }
 ```
@@ -202,14 +208,13 @@ Request:
   "service_tokens": {
     "google_drive": "ya29..."
   },
-  "options": {
-    "limit": 50,
-    "include_content": false
-  }
+  "limit": 50,
+  "include_content": false
 }
 ```
 
-Response는 Spring response와 동일한 shape를 사용한다.
+Response는 Spring response와 의미상 동일한 shape를 사용하되, FastAPI 모델은 snake_case를 사용한다.
+Spring `FastApiClient.previewNode()`가 이를 camelCase `NodePreviewResponse`로 매핑한다.
 
 ## 6. Spring 설계
 
@@ -233,30 +238,59 @@ Response는 Spring response와 동일한 shape를 사용한다.
 1. `WorkflowService`로 workflow 조회
 2. workflow owner 확인
 3. nodeId 존재 확인
-4. `NodeLifecycleService.evaluate()`로 설정 상태 확인
-5. 설정이 불완전하면 FastAPI 호출 없이 `status=unavailable` 응답
-6. OAuth token 수집
-7. `WorkflowTranslator.toRuntimeModel()` 호출
-8. `FastApiClient.previewNode()` 호출
-9. FastAPI 응답 반환
+4. 1차 preview 지원 범위인지 먼저 확인
+5. 미지원 노드이면 lifecycle/OAuth token 검사 없이 `PREVIEW_NOT_IMPLEMENTED` 응답
+6. 지원 노드이면 `NodeLifecycleService.evaluate()`로 설정 상태 확인
+7. 설정이 불완전하면 FastAPI 호출 없이 `status=unavailable` 응답
+8. 필요한 OAuth token scope 결정
+9. `WorkflowTranslator.toRuntimeModel()` 호출
+10. `FastApiClient.previewNode()` 호출
+11. FastAPI 응답 반환
+
+1차 구현의 지원 범위:
+
+- 지원: `role=start` 또는 FastAPI runtime model 기준 `runtime_type=input`인 source node
+- 미지원: middle node dry-run, loop sample preview, output node no-write preview
+- 미지원 노드는 FastAPI 호출 없이 Spring에서 `status=unavailable`, `reason=PREVIEW_NOT_IMPLEMENTED`로 응답해도 된다.
+- 단, FastAPI가 같은 reason을 반환해도 프론트는 동일하게 처리한다.
+- 미지원 노드는 도착 노드 OAuth token 누락 같은 실행 준비 상태보다 preview 미지원 상태를 우선 반환한다.
 
 ### 6.3 OAuth token 수집
 
 현재 token 수집은 `ExecutionService.collectServiceTokens()` 내부에 묶여 있다.
 
-preview에서도 같은 정책이 필요하므로 다음 중 하나로 정리한다.
+execution과 preview는 토큰 사용 목적이 다르므로 수집 범위를 분리한다.
+
+- execution: 전체 workflow 실행에 필요한 모든 auth-required service token을 수집한다.
+- preview: 선택한 노드 preview에 필요한 service token만 수집한다.
+
+1차 source preview에서 Spring이 수집해야 하는 token:
+
+- 대상 노드가 source node이면 대상 노드의 service token만 수집한다.
+- 예: Google Drive 시작 노드 preview는 `google_drive` token만 필요하다.
+- workflow 뒤쪽에 Gmail, Slack, Notion, Google Drive sink가 있어도 source preview 요청을 막지 않는다.
+- 대상 노드가 preview 미지원 노드이면 token 수집과 FastAPI 호출을 생략하고 `PREVIEW_NOT_IMPLEMENTED`를 반환한다.
+
+후속 dry-run에서 token 수집이 필요한 경우:
+
+- target node까지 실제 preview path에 포함되는 source/service만 수집한다.
+- output node no-write preview는 외부 write를 하지 않으므로 sink token은 원칙적으로 필요하지 않다.
+- sink 설정 검증에 token이 필요한 service가 생기면 해당 service만 예외적으로 명시한다.
+
+구현 선택지:
 
 권장안:
 
 - token 수집 로직을 별도 service로 분리한다.
-- 예: `ExecutionTokenService.collectServiceTokens(userId, nodes)`
-- `ExecutionService`와 `WorkflowPreviewService`가 같이 사용한다.
+- 예: `ExecutionTokenService.collectExecutionTokens(userId, nodes)`
+- 예: `ExecutionTokenService.collectPreviewTokens(userId, targetNode, previewScope)`
+- `ExecutionService`와 `WorkflowPreviewService`가 같은 OAuth 오류 정책을 공유하되 수집 범위는 다르게 가져간다.
 
 임시안:
 
-- `ExecutionService`의 token 수집 로직을 package-private 메서드로 열어 재사용한다.
+- `WorkflowPreviewService` 내부에서 1차 source preview용 target service token만 수집한다.
 
-권장안이 더 낫다. preview와 execution이 같은 OAuth 정책을 공유해야 하기 때문이다.
+권장안이 더 낫다. 다만 1차 구현에서는 source preview 범위가 좁으므로 임시안으로 시작해도 된다.
 
 ### 6.4 Spring 오류 정책
 
@@ -282,7 +316,7 @@ preview는 사용자 보조 기능이므로 가능한 한 UI가 처리하기 쉬
 
 ### 7.2 WorkflowPreviewExecutor 책임
 
-`preview(workflow_id, node_id, workflow, service_tokens, options)` 흐름:
+`preview(workflow_id, node_id, workflow, service_tokens, limit, include_content)` 흐름:
 
 1. node map, edge map 구성
 2. target node까지 필요한 upstream ancestor 계산
@@ -443,6 +477,14 @@ preview data와 execution data는 라벨을 분리한다.
 - AI 노드 preview는 비용이 발생할 수 있으므로 자동 호출하지 않는다.
 - source preview도 외부 API 호출이 있으므로 설정 저장 후 명시 액션으로 호출한다.
 
+1차 구현의 CTA 노출 범위:
+
+- 시작/source node에서만 `실행 전 미리보기` 버튼을 노출한다.
+- middle node와 output node는 dry-run/no-write preview가 구현되기 전까지 버튼을 숨기거나 비활성화한다.
+- middle/output node에는 schema preview, 설정 요약, 최신 실행 결과만 표시한다.
+- 프론트는 `PREVIEW_NOT_IMPLEMENTED`를 일반 오류처럼 노출하지 않고 "아직 지원하지 않는 미리보기" 안내로 처리한다.
+- dirty 상태에서는 1차 구현 기준으로 preview 버튼을 비활성화하고 저장 안내를 보여준다.
+
 ### 8.3 dirty 상태
 
 1차 구현은 저장된 workflow 기준으로 preview한다.
@@ -515,17 +557,24 @@ Raw JSON은 기본 화면에 노출하지 않고 상세 영역에만 둔다.
 - Google Drive, Canvas LMS, Gmail source metadata preview
 - source 목록은 `limit`을 적용하고 `truncated`를 응답한다.
 - 기본값은 metadata-only이며 파일 본문은 가져오지 않는다.
+- Spring은 target source node에 필요한 OAuth token만 수집한다.
+- workflow의 downstream node나 output node token 누락은 source preview를 막지 않는다.
+- 프론트는 시작/source node에만 preview CTA를 노출한다.
 
 제외:
 
 - 중간 노드 처리 결과 preview
 - LLM 호출
 - output no-write preview
+- 전체 workflow token 수집
+- dirty editor 상태의 draft preview
 
 완료 기준:
 
 - 시작 노드에서 Google Drive 폴더/Canvas 과목/Gmail label의 예상 입력 목록이 보인다.
 - preview 결과가 execution history에 저장되지 않는다.
+- 같은 workflow에 다른 OAuth service node가 있어도 대상 source token이 있으면 preview가 가능하다.
+- 중간/도착 노드에서 source preview 버튼이 잘못 노출되지 않는다.
 
 ### Milestone 3. 하나씩 처리 sample preview
 
@@ -625,7 +674,7 @@ preview-safe whitelist:
 권장 1차 범위:
 
 1. Milestone 1: 실행 후 canonical payload 표시 개선
-2. Milestone 2 중 일부: 시작 노드 source metadata preview API skeleton
+2. Milestone 2: 시작/source node metadata preview
 
 더 보수적인 1차 범위:
 
@@ -637,6 +686,15 @@ preview-safe whitelist:
 - 현재 백엔드는 실행 후 canonical payload를 이미 제공한다.
 - 사용자가 즉시 체감하는 문제인 JSON 원문 노출을 프론트만으로 줄일 수 있다.
 - preview/dry-run은 source, LLM, output no-write가 얽히므로 별도 백엔드 이슈로 분리하는 편이 안전하다.
+
+1차 계약 요약:
+
+- Preview endpoint는 저장된 workflow 기준으로 동작한다.
+- Spring은 소유자와 대상 노드 설정 상태를 검증한다.
+- Spring은 대상 source node의 token만 수집한다.
+- FastAPI는 source/start node metadata preview만 실제 구현한다.
+- Middle/output preview는 `PREVIEW_NOT_IMPLEMENTED`로 닫는다.
+- Frontend는 시작/source node에서만 preview 버튼을 보여준다.
 
 ## 11. 구현 단계
 
@@ -650,7 +708,8 @@ preview-safe whitelist:
 ### Step 2. Spring FastAPI bridge
 
 - `FastApiClient.previewNode()` 추가
-- token 수집 로직 공용화
+- 1차 구현에서는 대상 source node token만 수집
+- execution용 전체 token 수집과 preview용 token 수집 범위 분리
 - runtime model과 service token을 FastAPI에 전달
 
 ### Step 3. FastAPI preview endpoint
@@ -685,37 +744,52 @@ preview-safe whitelist:
 ### Step 8. Frontend 연결
 
 - preview API 타입과 hook 추가
-- 노드 패널에 preview 버튼 추가
+- 시작/source node 패널에 preview 버튼 추가
+- middle/output node는 preview-safe dry-run 구현 전까지 버튼 미노출 또는 비활성화
 - preview/execution/schema 표시 우선순위 적용
 - canonical type별 renderer 적용
 
 ## 12. 테스트 계획
 
-### 12.1 Spring 테스트
+테스트는 1차 source preview 계약과 후속 dry-run 계약을 분리한다.
+
+- 1차 테스트: Milestone 1, Milestone 2만 검증한다.
+- 후속 테스트: Milestone 3 이후 기능이 실제 구현될 때 추가한다.
+
+### 12.1 Spring 1차 테스트
 
 - 소유자가 preview 요청하면 FastAPI 호출
 - 공유 사용자는 preview 거부
 - nodeId가 없으면 오류
 - 설정 미완료 노드는 `status=unavailable`
 - OAuth token이 없으면 `status=unavailable`
+- source preview는 대상 source service token만 요청
+- workflow downstream service token 누락은 source preview를 막지 않음
+- preview 미지원 노드는 token 수집 없이 `PREVIEW_NOT_IMPLEMENTED`
 - FastAPI 오류는 `status=failed` 또는 기존 오류 정책에 맞게 변환
 
-### 12.2 FastAPI 테스트
+### 12.2 FastAPI 1차 테스트
 
 - source preview가 DB에 execution 기록을 만들지 않음
 - Google Drive folder preview가 `FILE_LIST` 반환
 - Canvas course preview가 `FILE_LIST` 반환
-- LLM preview가 `TEXT` 반환
-- `FILE_LIST -> loop -> LLM` preview에서 첫 번째 파일만 sample 처리
-- output preview에서 upload/send/create 메서드가 호출되지 않음
+- source/start node가 아니면 `PREVIEW_NOT_IMPLEMENTED` 반환
 
-### 12.3 Frontend 테스트
+### 12.3 Frontend 1차 테스트
 
-- 실행 전 preview 버튼으로 preview data 표시
+- 실행 전 preview 버튼으로 source preview data 표시
+- 1차 구현에서 시작/source node에만 preview 버튼 표시
+- middle/output node는 schema/설정 요약 또는 최신 실행 결과만 표시
 - preview 실패가 실제 실행 실패처럼 보이지 않음
 - 최신 실행 데이터와 preview data 라벨이 분리됨
 - dirty 상태에서 저장 안내 표시
 - canonical type별 renderer가 JSON 원문보다 우선 표시됨
+
+### 12.4 후속 dry-run 테스트
+
+- LLM preview가 `TEXT` 반환
+- `FILE_LIST -> loop -> LLM` preview에서 첫 번째 파일만 sample 처리
+- output preview에서 upload/send/create 메서드가 호출되지 않음
 
 ## 13. 결정 사항
 

--- a/docs/WORKFLOW_NODE_PREVIEW_DRY_RUN_DESIGN.md
+++ b/docs/WORKFLOW_NODE_PREVIEW_DRY_RUN_DESIGN.md
@@ -1,0 +1,738 @@
+# Workflow Node Preview Dry-run Design
+
+## 1. 배경
+
+현재 들어오는 데이터/나가는 데이터 패널은 최신 실행 기록의 `inputData`, `outputData`를 조회해 표시한다.
+따라서 워크플로우를 실행하기 전에는 노드를 연결하고 설정을 완료해도 실제 데이터 흐름을 확인하기 어렵다.
+
+이 문서는 실행 전에도 사용자가 선택한 노드 기준의 데이터 흐름을 이해할 수 있도록, 실제 실행 기록과 분리된 노드 미리보기/dry-run 기능을 정의한다.
+
+## 2. 요구사항 정리
+
+### 2.1 사용자 관점 요구사항
+
+- 시작 노드는 설정 완료 후 실제 source 데이터를 미리보기로 보여준다.
+- 중간 노드는 이전 preview 데이터를 입력으로 받아 처리 결과를 보여준다.
+- 하나씩 처리 노드는 전체 목록 중 첫 번째 항목만 다음 노드 preview 입력으로 전달한다.
+- AI 노드는 미리보기 시 실제 LLM 호출을 허용한다.
+- 도착 노드는 write 없이 전송/업로드 예정 데이터만 보여준다.
+- preview 결과는 저장하지 않고 사용자에게 보여주기 위한 응답으로만 사용한다.
+- 파일은 파일 목록/파일 카드로, 텍스트는 텍스트로, 표는 표로 표시할 수 있는 canonical payload를 반환한다.
+
+### 2.2 비목표
+
+- preview 결과를 실행 기록, `nodeLogs`, snapshot, MongoDB에 저장하지 않는다.
+- preview에서 Google Drive 업로드, Gmail 발송, Slack 전송 같은 외부 write 작업을 수행하지 않는다.
+- 실제 워크플로우 실행 semantics를 변경하지 않는다.
+- 전체 워크플로우를 항상 끝까지 실행하는 기능으로 만들지 않는다.
+- preview를 자동 반복 호출하는 실시간 실행 엔진으로 만들지 않는다.
+
+### 2.3 권한 정책
+
+preview는 실제 외부 서비스 데이터를 조회하고 OAuth token을 사용하므로 워크플로우 소유자만 사용할 수 있다.
+
+- 소유자: preview 가능
+- 공유 사용자: preview 불가, 기존 schema preview만 표시
+
+## 3. 현재 구현 기준 분석
+
+### 3.1 실행 후 데이터 흐름
+
+현재 실행 흐름은 다음과 같다.
+
+1. Spring `ExecutionService.executeWorkflow()`가 workflow를 FastAPI runtime model로 변환한다.
+2. Spring `FastApiClient.execute()`가 `POST /api/v1/workflows/{workflowId}/execute`를 호출한다.
+3. FastAPI `WorkflowExecutor.execute()`가 노드를 topological order로 실행한다.
+4. FastAPI는 각 노드 실행 결과를 `NodeExecutionLog.inputData`, `NodeExecutionLog.outputData`에 저장한다.
+5. Spring은 MongoDB의 `WorkflowExecution.nodeLogs`를 읽어 `NodeDataResponse`로 내려준다.
+6. Frontend는 `GET /api/workflows/{id}/executions/latest/nodes/{nodeId}/data`로 최신 실행 데이터를 표시한다.
+
+### 3.2 재사용 가능한 코드
+
+Spring:
+
+- `WorkflowService`: workflow 조회와 소유권 확인에 재사용
+- `NodeLifecycleService`: 노드 설정 상태 확인에 재사용
+- `OAuthTokenService`: service token 수집에 재사용
+- `WorkflowTranslator`: FastAPI runtime model 변환에 재사용
+- `FastApiClient`: FastAPI preview 호출 메서드 추가 위치로 재사용
+
+FastAPI:
+
+- `WorkflowDefinition`, `NodeDefinition`, `EdgeDefinition`: preview request의 workflow model로 재사용
+- `NodeFactory`: 중간 노드 strategy 생성에 재사용
+- `InputNodeStrategy`: source별 canonical payload 규칙 참고
+- `LLMNodeStrategy`, `DataFilterNodeStrategy`, `PassthroughNodeStrategy`, `IfElseNodeStrategy`: dry-run 실행에 재사용 가능
+- `WorkflowExecutor`의 graph helper 개념: upstream 경로 계산, loop item 변환 로직 참고
+
+### 3.3 그대로 재사용하면 안 되는 코드
+
+FastAPI `OutputNodeStrategy.execute()`는 실제 외부 write를 수행하므로 preview에서 호출하면 안 된다.
+
+예:
+
+- Google Drive: 실제 파일 업로드
+- Gmail: 실제 발송 또는 draft 생성
+- Slack: 실제 메시지 전송
+- Notion: 실제 페이지 생성
+
+Source node도 일부 주의가 필요하다.
+
+- Google Drive `single_file`은 현재 `download_file()`을 호출해 본문까지 다운로드한다.
+- preview 요구사항은 metadata 중심이어도 되므로 source preview에서는 metadata-only 경로를 우선 사용한다.
+
+## 4. 목표 구조
+
+### 4.1 신규 preview 흐름
+
+1. 사용자가 노드를 설정하거나 선택한다.
+2. Frontend가 명시적 preview 요청을 보낸다.
+3. Spring이 권한, workflow, 노드 설정, OAuth token을 확인한다.
+4. Spring이 workflow를 runtime model로 변환한다.
+5. Spring이 FastAPI preview endpoint를 호출한다.
+6. FastAPI가 target node까지 필요한 upstream만 dry-run한다.
+7. FastAPI가 preview 결과를 저장 없이 응답한다.
+8. Frontend가 preview 응답을 타입별 UI로 표시한다.
+
+### 4.2 기존 실행 흐름과 분리
+
+preview는 기존 execution API를 호출하지 않는다.
+
+- `WorkflowExecutor.execute()`를 직접 호출하지 않는다.
+- execution id를 만들지 않는다.
+- cancellation event를 등록하지 않는다.
+- `workflow_executions` 컬렉션에 저장하지 않는다.
+- Spring callback을 호출하지 않는다.
+
+## 5. API 설계
+
+### 5.1 Spring API
+
+```http
+POST /api/workflows/{workflowId}/nodes/{nodeId}/preview
+```
+
+Request:
+
+```json
+{
+  "limit": 50,
+  "includeContent": false
+}
+```
+
+필드 의미:
+
+- `limit`: source 목록 preview 최대 개수
+- `includeContent`: 파일 본문 포함 여부. 1차 구현 기본값은 `false`
+
+Response:
+
+```json
+{
+  "workflowId": "workflow_1",
+  "nodeId": "node_ai",
+  "status": "success",
+  "inputData": {
+    "type": "SINGLE_FILE",
+    "filename": "lecture.pdf",
+    "mime_type": "application/pdf",
+    "url": "https://drive.google.com/file/d/..."
+  },
+  "outputData": {
+    "type": "TEXT",
+    "content": "요약 결과..."
+  },
+  "previewMeta": {
+    "saved": false,
+    "sideEffect": false,
+    "sampled": true,
+    "sampleIndex": 0,
+    "sampleReason": "하나씩 처리 미리보기는 첫 번째 항목만 사용합니다.",
+    "truncated": false,
+    "limit": 50,
+    "executedNodeIds": ["node_source", "node_loop", "node_ai"]
+  },
+  "error": null
+}
+```
+
+실패 또는 미설정 응답:
+
+```json
+{
+  "workflowId": "workflow_1",
+  "nodeId": "node_ai",
+  "status": "unavailable",
+  "inputData": null,
+  "outputData": null,
+  "previewMeta": {
+    "saved": false,
+    "sideEffect": false,
+    "sampled": false,
+    "truncated": false,
+    "limit": 50,
+    "executedNodeIds": []
+  },
+  "error": {
+    "code": "NODE_NOT_CONFIGURED",
+    "message": "노드 설정이 완료되지 않았습니다.",
+    "context": {
+      "missingFields": ["prompt"]
+    }
+  }
+}
+```
+
+### 5.2 FastAPI API
+
+```http
+POST /api/v1/workflows/{workflowId}/nodes/{nodeId}/preview
+```
+
+Request:
+
+```json
+{
+  "workflow": {
+    "id": "workflow_1",
+    "nodes": [],
+    "edges": []
+  },
+  "service_tokens": {
+    "google_drive": "ya29..."
+  },
+  "options": {
+    "limit": 50,
+    "include_content": false
+  }
+}
+```
+
+Response는 Spring response와 동일한 shape를 사용한다.
+
+## 6. Spring 설계
+
+### 6.1 추가 컴포넌트
+
+권장 추가 파일:
+
+- `workflow/controller/WorkflowPreviewController.java`
+- `workflow/service/WorkflowPreviewService.java`
+- `workflow/dto/NodePreviewRequest.java`
+- `workflow/dto/NodePreviewResponse.java`
+- `workflow/dto/NodePreviewMeta.java`
+- `workflow/dto/NodePreviewError.java`
+
+기존 `WorkflowController`에 endpoint를 추가할 수도 있지만, preview는 workflow CRUD보다 실행 준비에 가까우므로 별도 controller가 더 읽기 쉽다.
+
+### 6.2 WorkflowPreviewService 책임
+
+`previewNode(userId, workflowId, nodeId, request)` 흐름:
+
+1. `WorkflowService`로 workflow 조회
+2. workflow owner 확인
+3. nodeId 존재 확인
+4. `NodeLifecycleService.evaluate()`로 설정 상태 확인
+5. 설정이 불완전하면 FastAPI 호출 없이 `status=unavailable` 응답
+6. OAuth token 수집
+7. `WorkflowTranslator.toRuntimeModel()` 호출
+8. `FastApiClient.previewNode()` 호출
+9. FastAPI 응답 반환
+
+### 6.3 OAuth token 수집
+
+현재 token 수집은 `ExecutionService.collectServiceTokens()` 내부에 묶여 있다.
+
+preview에서도 같은 정책이 필요하므로 다음 중 하나로 정리한다.
+
+권장안:
+
+- token 수집 로직을 별도 service로 분리한다.
+- 예: `ExecutionTokenService.collectServiceTokens(userId, nodes)`
+- `ExecutionService`와 `WorkflowPreviewService`가 같이 사용한다.
+
+임시안:
+
+- `ExecutionService`의 token 수집 로직을 package-private 메서드로 열어 재사용한다.
+
+권장안이 더 낫다. preview와 execution이 같은 OAuth 정책을 공유해야 하기 때문이다.
+
+### 6.4 Spring 오류 정책
+
+preview는 사용자 보조 기능이므로 가능한 한 UI가 처리하기 쉬운 응답을 반환한다.
+
+- workflow 접근 권한 없음: 기존처럼 HTTP error
+- nodeId 없음: 기존처럼 HTTP error
+- 노드 설정 미완료: `status=unavailable`
+- OAuth 연결 없음 또는 scope 부족: `status=unavailable`
+- FastAPI preview 실패: `status=failed`
+
+## 7. FastAPI 설계
+
+### 7.1 추가 컴포넌트
+
+권장 추가 파일:
+
+- `app/models/preview.py`
+- `app/core/engine/preview_executor.py`
+- `app/core/engine/preview_output.py`
+
+기존 `app/api/v1/endpoints/workflow.py`에는 preview route를 추가한다.
+
+### 7.2 WorkflowPreviewExecutor 책임
+
+`preview(workflow_id, node_id, workflow, service_tokens, options)` 흐름:
+
+1. node map, edge map 구성
+2. target node까지 필요한 upstream ancestor 계산
+3. topological order 중 ancestor와 target만 실행
+4. source node는 preview-safe source 조회
+5. middle node는 가능한 기존 strategy dry-run
+6. loop node는 첫 번째 item sample만 downstream에 전달
+7. output node는 no-write preview builder 사용
+8. 결과를 저장하지 않고 `NodePreviewResponse`로 반환
+
+### 7.3 upstream 경로 계산
+
+기본 알고리즘:
+
+1. `edges`에서 reverse adjacency를 만든다.
+2. target node에서 predecessor를 역추적해 ancestor node id 집합을 만든다.
+3. 전체 topological order를 계산한다.
+4. topological order 중 ancestor 또는 target에 포함된 노드만 실행한다.
+
+주의:
+
+- v1은 linear path 중심으로 처리한다.
+- branch가 있는 경우 실제 branch 결과에 따라 path를 제한하는 것은 후속 고도화로 둔다.
+- loop body는 기존 실행 구조처럼 loop 다음 한 개 body node를 대상으로 한다.
+
+### 7.4 source preview
+
+source preview는 가능한 metadata-only로 동작한다.
+
+Google Drive:
+
+- `folder_all_files`: `list_files()` 재사용
+- `single_file`: 신규 `get_file_metadata()` 추가 권장
+- `file_changed`, `new_file`, `folder_new_file`: `list_files(max_results=1)` 재사용
+
+Canvas LMS:
+
+- `course_files`: `get_course_files()` 재사용
+- `course_new_file`: `get_course_latest_file()` 재사용
+- `term_all_files`: `get_courses()`와 `get_course_files()` 재사용
+
+Gmail:
+
+- `label_emails`: `list_messages()` 재사용 가능
+- body는 길이를 제한해 preview용으로 반환
+- attachment는 metadata만 반환
+
+Source preview 응답에는 `truncated`, `limit` 정보를 포함한다.
+
+### 7.5 중간 노드 preview
+
+중간 노드는 기존 strategy를 최대한 재사용한다.
+
+재사용 가능:
+
+- `LLMNodeStrategy`
+- `DataFilterNodeStrategy`
+- `PassthroughNodeStrategy`
+- `IfElseNodeStrategy`
+
+주의:
+
+- AI 노드는 실제 LLM 호출이 발생한다.
+- preview 호출은 자동 호출보다 사용자 명시 액션으로 제한하는 것이 좋다.
+- 실패는 execution failure가 아니라 preview failure로 응답한다.
+
+### 7.6 하나씩 처리 preview
+
+목록형 payload에서 첫 번째 항목만 sample로 선택한다.
+
+대상 type:
+
+- `FILE_LIST`
+- `EMAIL_LIST`
+- `SCHEDULE_DATA`
+- `SPREADSHEET_DATA`
+
+변환 규칙:
+
+- `FILE_LIST` 첫 item -> `SINGLE_FILE`
+- `EMAIL_LIST` 첫 item -> `SINGLE_EMAIL`
+- `SCHEDULE_DATA` 첫 item -> `SCHEDULE_DATA` with single item
+- `SPREADSHEET_DATA` 첫 row -> `SPREADSHEET_DATA` with single row
+
+preview meta:
+
+```json
+{
+  "sampled": true,
+  "sampleIndex": 0,
+  "sampleReason": "하나씩 처리 미리보기는 첫 번째 항목만 사용합니다."
+}
+```
+
+### 7.7 output node no-write preview
+
+output node는 기존 `OutputNodeStrategy.execute()`를 호출하지 않는다.
+
+대신 input payload와 sink config를 기반으로 전송 예정 데이터를 만든다.
+
+Google Drive:
+
+```json
+{
+  "type": "OUTPUT_PREVIEW",
+  "service": "google_drive",
+  "action": "upload",
+  "target": {
+    "folder_id": "folder_123"
+  },
+  "items": [
+    {
+      "filename": "summary.txt",
+      "mime_type": "text/plain",
+      "size": 1200
+    }
+  ]
+}
+```
+
+Gmail:
+
+```json
+{
+  "type": "OUTPUT_PREVIEW",
+  "service": "gmail",
+  "action": "send",
+  "to": "user@example.com",
+  "subject": "요약 결과",
+  "body_preview": "본문 일부...",
+  "attachments": []
+}
+```
+
+Slack, Notion, Google Sheets, Google Calendar도 같은 원칙으로 실제 write 없이 예정 payload만 반환한다.
+
+## 8. Frontend 설계
+
+### 8.1 데이터 우선순위
+
+노드 패널 표시 우선순위:
+
+1. 사용자가 명시적으로 요청한 preview data
+2. 최신 실행 데이터
+3. schema preview
+4. 정적 node type fallback
+
+preview data와 execution data는 라벨을 분리한다.
+
+- preview: "실행 전 미리보기"
+- execution: "최근 실행 결과"
+
+### 8.2 호출 방식
+
+1차 구현에서는 자동 호출보다 명시적 액션을 권장한다.
+
+- 버튼 예: `미리보기`
+- AI 노드 preview는 비용이 발생할 수 있으므로 자동 호출하지 않는다.
+- source preview도 외부 API 호출이 있으므로 설정 저장 후 명시 액션으로 호출한다.
+
+### 8.3 dirty 상태
+
+1차 구현은 저장된 workflow 기준으로 preview한다.
+
+- dirty 상태에서는 preview 버튼을 비활성화하거나 저장 안내를 표시한다.
+- 후속으로 draft workflow body를 Spring에 보내는 preview를 검토할 수 있다.
+
+### 8.4 타입별 renderer
+
+canonical `type` 기준 renderer를 사용한다.
+
+- `FILE_LIST`: 파일 목록
+- `SINGLE_FILE`: 파일 카드
+- `TEXT`: 텍스트 preview
+- `EMAIL_LIST`: 메일 목록
+- `SINGLE_EMAIL`: 메일 카드
+- `SPREADSHEET_DATA`: 표
+- `SCHEDULE_DATA`: 일정 목록
+- `API_RESPONSE`: 요약 카드 + 상세 JSON
+- `OUTPUT_PREVIEW`: 전송/저장 예정 데이터
+
+Raw JSON은 기본 화면에 노출하지 않고 상세 영역에만 둔다.
+
+## 9. 구현 범위 분할
+
+전체 목표는 실행 전 노드 데이터 preview지만, 한 번에 모두 구현하면 source 조회, LLM 호출, loop sample, output no-write가 동시에 엮인다.
+따라서 실제 구현은 아래처럼 작은 milestone으로 나눈다.
+
+### Milestone 1. 실행 후 canonical payload 표시 개선
+
+목표:
+
+- 이미 존재하는 최신 실행 데이터 API를 그대로 사용한다.
+- `inputData`, `outputData`의 canonical `type`을 기준으로 사용자 친화적인 UI를 제공한다.
+- 백엔드 기능 추가 없이 프론트에서 즉시 체감 가능한 개선을 만든다.
+
+범위:
+
+- `FILE_LIST`: 파일 목록, 파일명, MIME 타입, 크기, 링크 표시
+- `SINGLE_FILE`: 파일 카드, 파일명, MIME 타입, 링크, 본문 일부 표시
+- `TEXT`: 텍스트 본문 preview
+- `EMAIL_LIST`: 메일 목록, 제목, 발신자, 날짜, 본문 일부 표시
+- `SINGLE_EMAIL`: 메일 카드, 제목, 발신자, 본문, 첨부 표시
+- `SPREADSHEET_DATA`: 헤더와 행을 표로 표시
+- `SCHEDULE_DATA`: 일정 목록 표시
+- `API_RESPONSE`: 요약 카드와 상세 JSON 표시
+
+제외:
+
+- 실행 전 실제 source 조회
+- LLM dry-run
+- 도착 노드 no-write preview
+
+완료 기준:
+
+- 실행 후 노드 클릭 시 JSON 원문보다 타입별 UI가 먼저 보인다.
+- Raw JSON은 상세 보기로만 제공된다.
+
+### Milestone 2. 시작 노드 source metadata preview
+
+목표:
+
+- 실행 전 시작 노드 설정 완료 후 실제 source metadata를 보여준다.
+- 사용자가 워크플로우 입력 데이터가 무엇인지 실행 전에 확인할 수 있게 한다.
+
+범위:
+
+- Spring preview endpoint shell 추가
+- FastAPI source preview endpoint 추가
+- Google Drive, Canvas LMS, Gmail source metadata preview
+- source 목록은 `limit`을 적용하고 `truncated`를 응답한다.
+- 기본값은 metadata-only이며 파일 본문은 가져오지 않는다.
+
+제외:
+
+- 중간 노드 처리 결과 preview
+- LLM 호출
+- output no-write preview
+
+완료 기준:
+
+- 시작 노드에서 Google Drive 폴더/Canvas 과목/Gmail label의 예상 입력 목록이 보인다.
+- preview 결과가 execution history에 저장되지 않는다.
+
+### Milestone 3. 하나씩 처리 sample preview
+
+목표:
+
+- 목록형 source preview에서 첫 번째 item을 sample로 선택해 다음 노드의 입력 preview로 전달한다.
+
+범위:
+
+- `FILE_LIST -> SINGLE_FILE`
+- `EMAIL_LIST -> SINGLE_EMAIL`
+- `SCHEDULE_DATA -> SCHEDULE_DATA` with one item
+- `SPREADSHEET_DATA -> SPREADSHEET_DATA` with one row
+- preview meta에 `sampled`, `sampleIndex`, `sampleReason` 포함
+
+제외:
+
+- 전체 item 반복 처리
+- LLM 처리 결과 생성
+
+완료 기준:
+
+- 하나씩 처리 다음 노드의 들어오는 데이터가 첫 번째 sample 기준으로 표시된다.
+- 사용자에게 sample preview라는 사실이 명확히 보인다.
+
+### Milestone 4. preview-safe 중간 노드 dry-run
+
+목표:
+
+- side effect가 없는 중간 노드만 preview-safe whitelist로 dry-run한다.
+
+preview-safe whitelist:
+
+- `passthrough`
+- `data_filter`
+- `llm`
+- `if_else`
+
+주의:
+
+- `llm`은 실제 LLM 호출을 허용하되 사용자 명시 액션으로만 호출한다.
+- 향후 외부 write가 있는 중간 노드가 추가되면 whitelist에 넣지 않는다.
+
+제외:
+
+- output node
+- branch 전체 path 탐색
+- 여러 branch 결과 동시 preview
+
+완료 기준:
+
+- 저장된 workflow 기준으로 선택 중간 노드까지 preview 결과가 반환된다.
+- preview 실패는 execution failure와 별도 상태로 표시된다.
+
+### Milestone 5. 도착 노드 no-write preview
+
+목표:
+
+- 도착 노드가 실제 write를 하지 않고 전송/저장 예정 데이터만 보여준다.
+
+범위:
+
+- 기존 `OutputNodeStrategy.execute()` 호출 금지
+- `preview_output.py` 같은 별도 builder 사용
+- Google Drive: 업로드 예정 파일 목록과 대상 폴더 표시
+- Gmail: 수신자, 제목, 본문 preview, 첨부 표시
+- Slack/Notion/Sheets/Calendar: 전송 예정 payload 표시
+
+완료 기준:
+
+- preview 호출 중 upload/send/create API가 호출되지 않는다.
+- output preview payload가 `OUTPUT_PREVIEW` 타입으로 반환된다.
+
+### Milestone 6. draft workflow preview
+
+목표:
+
+- 저장 전 변경사항까지 preview에 반영한다.
+
+범위:
+
+- Frontend가 현재 editor nodes/edges를 request body로 전달
+- Spring이 저장된 workflow 대신 draft body를 FastAPI runtime model로 변환
+
+제외:
+
+- 1차 구현에서는 제외한다.
+
+완료 기준:
+
+- dirty 상태에서도 저장 없이 preview 가능하다.
+
+## 10. 1차 구현 권장 범위
+
+실제 첫 이슈는 너무 크게 잡지 않는다.
+
+권장 1차 범위:
+
+1. Milestone 1: 실행 후 canonical payload 표시 개선
+2. Milestone 2 중 일부: 시작 노드 source metadata preview API skeleton
+
+더 보수적인 1차 범위:
+
+1. Milestone 1만 먼저 구현
+2. 백엔드 preview API는 별도 이슈로 분리
+
+이유:
+
+- 현재 백엔드는 실행 후 canonical payload를 이미 제공한다.
+- 사용자가 즉시 체감하는 문제인 JSON 원문 노출을 프론트만으로 줄일 수 있다.
+- preview/dry-run은 source, LLM, output no-write가 얽히므로 별도 백엔드 이슈로 분리하는 편이 안전하다.
+
+## 11. 구현 단계
+
+### Step 1. Spring preview shell
+
+- `WorkflowPreviewController` 추가
+- `NodePreviewRequest/Response` DTO 추가
+- 권한, node existence, 설정 상태 검증
+- FastAPI 호출 없이 unavailable/skeleton 응답까지 테스트
+
+### Step 2. Spring FastAPI bridge
+
+- `FastApiClient.previewNode()` 추가
+- token 수집 로직 공용화
+- runtime model과 service token을 FastAPI에 전달
+
+### Step 3. FastAPI preview endpoint
+
+- `app/models/preview.py` 추가
+- `POST /api/v1/workflows/{workflowId}/nodes/{nodeId}/preview` 추가
+- `WorkflowPreviewExecutor` skeleton 추가
+
+### Step 4. source preview
+
+- Google Drive, Canvas LMS, Gmail source preview 구현
+- metadata 중심 응답
+- limit/truncated meta 반환
+
+### Step 5. middle node dry-run
+
+- LLM, data filter, passthrough dry-run 연결
+- preview failure 응답 정리
+- AI 호출 허용
+
+### Step 6. loop sample preview
+
+- 목록형 payload 첫 번째 item 변환
+- sampled meta 반환
+- 다음 노드 input preview 연결
+
+### Step 7. output no-write preview
+
+- output node 전용 preview builder 추가
+- 실제 write strategy 호출 금지 테스트 추가
+
+### Step 8. Frontend 연결
+
+- preview API 타입과 hook 추가
+- 노드 패널에 preview 버튼 추가
+- preview/execution/schema 표시 우선순위 적용
+- canonical type별 renderer 적용
+
+## 12. 테스트 계획
+
+### 12.1 Spring 테스트
+
+- 소유자가 preview 요청하면 FastAPI 호출
+- 공유 사용자는 preview 거부
+- nodeId가 없으면 오류
+- 설정 미완료 노드는 `status=unavailable`
+- OAuth token이 없으면 `status=unavailable`
+- FastAPI 오류는 `status=failed` 또는 기존 오류 정책에 맞게 변환
+
+### 12.2 FastAPI 테스트
+
+- source preview가 DB에 execution 기록을 만들지 않음
+- Google Drive folder preview가 `FILE_LIST` 반환
+- Canvas course preview가 `FILE_LIST` 반환
+- LLM preview가 `TEXT` 반환
+- `FILE_LIST -> loop -> LLM` preview에서 첫 번째 파일만 sample 처리
+- output preview에서 upload/send/create 메서드가 호출되지 않음
+
+### 12.3 Frontend 테스트
+
+- 실행 전 preview 버튼으로 preview data 표시
+- preview 실패가 실제 실행 실패처럼 보이지 않음
+- 최신 실행 데이터와 preview data 라벨이 분리됨
+- dirty 상태에서 저장 안내 표시
+- canonical type별 renderer가 JSON 원문보다 우선 표시됨
+
+## 13. 결정 사항
+
+- preview는 소유자만 가능하다.
+- preview 결과는 저장하지 않는다.
+- preview는 기존 execution flow와 분리한다.
+- 도착 노드는 write 금지다.
+- AI preview는 실제 LLM 호출을 허용한다.
+- 하나씩 처리 preview는 첫 번째 항목만 사용한다.
+- 1차 구현은 저장된 workflow 기준으로 한다.
+- 실제 구현은 milestone 단위로 나눈다.
+- 중간 노드는 preview-safe whitelist에 포함된 strategy만 dry-run한다.
+
+## 14. 남은 논의
+
+- source preview의 기본 `limit` 값
+- `includeContent=true` 지원 여부와 최대 본문 크기
+- branch preview를 v1에서 어디까지 지원할지
+- preview 응답 cache가 필요한지
+- AI preview 호출 비용 안내 문구

--- a/src/entities/workflow/api/index.ts
+++ b/src/entities/workflow/api/index.ts
@@ -15,6 +15,7 @@ import { getWorkflowListAPI } from "./get-workflow-list.api";
 import { getWorkflowNodeSchemaPreviewAPI } from "./get-workflow-node-schema-preview.api";
 import { getWorkflowSchemaPreviewAPI } from "./get-workflow-schema-preview.api";
 import { getWorkflowAPI } from "./get-workflow.api";
+import { previewWorkflowNodeAPI } from "./preview-workflow-node.api";
 import { previewWorkflowSchemaAPI } from "./preview-workflow-schema.api";
 import { selectWorkflowChoiceAPI } from "./select-workflow-choice.api";
 import { shareWorkflowAPI } from "./share-workflow.api";
@@ -44,6 +45,7 @@ export const workflowApi = {
   getChoices: getWorkflowChoicesAPI,
   selectChoice: selectWorkflowChoiceAPI,
   previewSchema: previewWorkflowSchemaAPI,
+  previewNode: previewWorkflowNodeAPI,
   share: shareWorkflowAPI,
   generate: generateWorkflowAPI,
 };

--- a/src/entities/workflow/api/preview-workflow-node.api.ts
+++ b/src/entities/workflow/api/preview-workflow-node.api.ts
@@ -1,0 +1,14 @@
+import { request } from "@/shared/api/core";
+
+import { type NodePreviewRequest, type NodePreviewResponse } from "./types";
+
+export const previewWorkflowNodeAPI = (
+  workflowId: string,
+  nodeId: string,
+  payload: NodePreviewRequest = {},
+): Promise<NodePreviewResponse> =>
+  request<NodePreviewResponse>({
+    url: `/workflows/${workflowId}/nodes/${nodeId}/preview`,
+    method: "POST",
+    data: payload,
+  });

--- a/src/entities/workflow/api/types.ts
+++ b/src/entities/workflow/api/types.ts
@@ -221,6 +221,29 @@ export interface NodeSchemaPreviewResponse {
   nodeStatus?: NodeStatusSummaryResponse | null;
 }
 
+export interface NodePreviewRequest {
+  limit?: number;
+  includeContent?: boolean;
+}
+
+export interface NodePreviewResponse {
+  workflowId: string;
+  nodeId: string;
+  status: "available" | "unavailable" | "failed" | string;
+  available: boolean;
+  reason: string | null;
+  inputData?: Record<string, unknown> | null;
+  outputData?: Record<string, unknown> | null;
+  previewData?: Record<string, unknown> | null;
+  missingFields?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface PreviewWorkflowNodeCommand extends NodePreviewRequest {
+  workflowId: string;
+  nodeId: string;
+}
+
 export interface CreateWorkflowRequest {
   name: string;
   description?: string;

--- a/src/entities/workflow/lib/index.ts
+++ b/src/entities/workflow/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./node-status";
 export * from "./workflow-node-adapter";
+export * from "./workflow-display";

--- a/src/entities/workflow/lib/node-status.ts
+++ b/src/entities/workflow/lib/node-status.ts
@@ -17,7 +17,7 @@ const NODE_STATUS_FIELD_LABELS: Record<string, string> = {
   recipient: "수신자",
   service: "서비스",
   sheet_name: "시트",
-  source_mode: "source mode",
+  source_mode: "가져오는 방식",
   spreadsheet_id: "스프레드시트",
   subject: "제목",
   target: "대상",

--- a/src/entities/workflow/lib/workflow-display.ts
+++ b/src/entities/workflow/lib/workflow-display.ts
@@ -1,0 +1,217 @@
+import { type DataType } from "@/entities/node";
+
+export const WORKFLOW_DATA_TYPE_LABELS: Record<string, string> = {
+  API_RESPONSE: "API 응답",
+  EMAIL_LIST: "이메일 목록",
+  FILE_LIST: "여러 파일",
+  SCHEDULE_DATA: "일정 데이터",
+  SINGLE_EMAIL: "이메일",
+  SINGLE_FILE: "파일",
+  SPREADSHEET_DATA: "스프레드시트",
+  TEXT: "텍스트",
+  "api-response": "API 응답",
+  "email-list": "이메일 목록",
+  "file-list": "여러 파일",
+  "schedule-data": "일정 데이터",
+  "single-email": "이메일",
+  "single-file": "파일",
+  spreadsheet: "스프레드시트",
+  text: "텍스트",
+};
+
+export const WORKFLOW_FRONTEND_DATA_TYPE_LABELS: Record<DataType, string> = {
+  "api-response": "API 응답",
+  "email-list": "이메일 목록",
+  "file-list": "여러 파일",
+  "schedule-data": "일정 데이터",
+  "single-email": "이메일",
+  "single-file": "파일",
+  spreadsheet: "스프레드시트",
+  text: "텍스트",
+};
+
+const TRIGGER_KIND_LABELS: Record<string, string> = {
+  manual: "직접 실행",
+  polling: "주기적으로 확인",
+  schedule: "예약 실행",
+  webhook: "외부 요청으로 실행",
+};
+
+const EXECUTION_STATUS_LABELS: Record<string, string> = {
+  canceled: "실행 취소",
+  completed: "최근 실행 완료",
+  failed: "실행 실패",
+  running: "실행 중",
+  skipped: "실행 건너뜀",
+  success: "최근 실행 완료",
+};
+
+const NODE_DATA_REASON_LABELS: Record<string, string> = {
+  DATA_EMPTY: "표시할 데이터가 없습니다.",
+  EXECUTION_RUNNING: "워크플로우를 실행하는 중입니다.",
+  NODE_FAILED: "이 단계 실행에 실패했습니다.",
+  NODE_NOT_EXECUTED: "이 단계는 아직 실행되지 않았습니다.",
+  NODE_SKIPPED: "이 단계는 실행 과정에서 건너뛰었습니다.",
+  NO_EXECUTION: "아직 실행 기록이 없습니다.",
+};
+
+const SCHEMA_TYPE_LABELS: Record<string, string> = {
+  API_RESPONSE: "API 응답",
+  EMAIL: "이메일",
+  EMAIL_LIST: "이메일 목록",
+  FILE: "파일",
+  FILE_LIST: "파일 목록",
+  IMAGE: "이미지",
+  OBJECT: "데이터 묶음",
+  SCHEDULE: "일정",
+  SPREADSHEET: "스프레드시트",
+  TEXT: "텍스트",
+  UNKNOWN: "데이터 구조 미정",
+};
+
+const SCHEMA_VALUE_TYPE_LABELS: Record<string, string> = {
+  array: "목록",
+  boolean: "참/거짓",
+  date: "날짜",
+  datetime: "날짜와 시간",
+  file: "파일",
+  number: "숫자",
+  object: "데이터 묶음",
+  string: "텍스트",
+  text: "텍스트",
+  url: "링크",
+};
+
+const METADATA_LABELS: Record<string, string> = {
+  courseCount: "과목 수",
+  lastEditedTime: "마지막 수정일",
+  memberCount: "멤버 수",
+  mimeType: "파일 형식",
+  modifiedTime: "수정일",
+  parentType: "상위 위치",
+  size: "크기",
+  term: "학기",
+};
+
+const normalizeKey = (value: string) => value.trim();
+
+const getCaseInsensitiveLabel = (
+  labels: Record<string, string>,
+  value: string | null | undefined,
+) => {
+  if (!value) {
+    return null;
+  }
+
+  const normalizedValue = normalizeKey(value);
+  if (normalizedValue.length === 0) {
+    return null;
+  }
+
+  return (
+    labels[normalizedValue] ??
+    labels[normalizedValue.toUpperCase()] ??
+    labels[normalizedValue.toLowerCase()] ??
+    null
+  );
+};
+
+export const getDataTypeDisplayLabel = (
+  value: string | null | undefined,
+): string | null => getCaseInsensitiveLabel(WORKFLOW_DATA_TYPE_LABELS, value);
+
+export const getCanonicalInputTypeLabel = (
+  value: string | null | undefined,
+): string | null => getDataTypeDisplayLabel(value);
+
+export const getTriggerKindLabel = (
+  value: string | null | undefined,
+): string | null => getCaseInsensitiveLabel(TRIGGER_KIND_LABELS, value);
+
+export const getExecutionStatusLabel = (
+  value: string | null | undefined,
+): string | null => getCaseInsensitiveLabel(EXECUTION_STATUS_LABELS, value);
+
+export const getNodeDataReasonLabel = (
+  value: string | null | undefined,
+): string | null => getCaseInsensitiveLabel(NODE_DATA_REASON_LABELS, value);
+
+export const getSchemaTypeLabel = (
+  value: string | null | undefined,
+): string | null => getCaseInsensitiveLabel(SCHEMA_TYPE_LABELS, value);
+
+export const getSchemaValueTypeLabel = (
+  value: string | null | undefined,
+): string | null => getCaseInsensitiveLabel(SCHEMA_VALUE_TYPE_LABELS, value);
+
+export const isSuccessfulExecutionStatus = (
+  value: string | null | undefined,
+) => {
+  const normalizedValue = value?.trim().toLowerCase();
+
+  return normalizedValue === "success" || normalizedValue === "completed";
+};
+
+const formatDateTime = (value: string) => {
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(parsedDate);
+};
+
+const formatFileSize = (value: string | number) => {
+  const numericValue =
+    typeof value === "number" ? value : Number.parseInt(value, 10);
+
+  if (!Number.isFinite(numericValue) || numericValue < 0) {
+    return String(value);
+  }
+
+  if (numericValue < 1024) {
+    return `${numericValue} B`;
+  }
+
+  if (numericValue < 1024 * 1024) {
+    return `${(numericValue / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(numericValue / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const formatMetadataValue = (key: string, value: unknown) => {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return null;
+  }
+
+  if (key === "size") {
+    return formatFileSize(value);
+  }
+
+  if (key === "modifiedTime" || key === "lastEditedTime") {
+    return formatDateTime(String(value));
+  }
+
+  return String(value);
+};
+
+export const getWorkflowMetadataSummary = (
+  metadata: Record<string, unknown> | undefined,
+) => {
+  if (!metadata) {
+    return "";
+  }
+
+  return Object.entries(METADATA_LABELS)
+    .map(([key, label]) => {
+      const value = formatMetadataValue(key, metadata[key]);
+
+      return value ? `${label}: ${value}` : null;
+    })
+    .filter((value): value is string => value !== null)
+    .join(" · ");
+};

--- a/src/entities/workflow/model/index.ts
+++ b/src/entities/workflow/model/index.ts
@@ -22,6 +22,7 @@ export * from "./useUpdateWorkflowNodeMutation";
 export * from "./useWorkflowChoicesQuery";
 export * from "./useWorkflowListQuery";
 export * from "./useWorkflowNodeSchemaPreviewQuery";
+export * from "./useWorkflowNodePreviewMutation";
 export * from "./useWorkflowQuery";
 export * from "./useWorkflowSchemaPreviewMutation";
 export * from "./useWorkflowSchemaPreviewQuery";

--- a/src/entities/workflow/model/useWorkflowNodePreviewMutation.ts
+++ b/src/entities/workflow/model/useWorkflowNodePreviewMutation.ts
@@ -1,0 +1,33 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { type MutationPolicyOptions, toMutationMeta } from "@/shared/api";
+
+import {
+  type NodePreviewResponse,
+  type PreviewWorkflowNodeCommand,
+  workflowApi,
+} from "../api";
+
+export const useWorkflowNodePreviewMutation = (
+  options?: MutationPolicyOptions<
+    NodePreviewResponse,
+    PreviewWorkflowNodeCommand
+  >,
+) =>
+  useMutation({
+    mutationFn: ({
+      workflowId,
+      nodeId,
+      limit,
+      includeContent,
+    }: PreviewWorkflowNodeCommand) =>
+      workflowApi.previewNode(workflowId, nodeId, { limit, includeContent }),
+    retry: options?.retry,
+    meta: toMutationMeta(options),
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      await options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await options?.onError?.(error, variables, onMutateResult, context);
+    },
+  });

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -38,6 +38,9 @@ import {
   type SourceModeResponse,
   type SourceServiceResponse,
   findAddedNodeId,
+  getCanonicalInputTypeLabel,
+  getDataTypeDisplayLabel,
+  getTriggerKindLabel,
   getVisualNodeTypeFromServiceKey,
   toBackendDataType,
   toFrontendDataType,
@@ -82,28 +85,6 @@ const CATALOG_SERVICE_ICON_MAP: Record<string, IconType> = {
   google_sheets: SiGooglesheets,
   notion: MdArticle,
   slack: SiSlack,
-};
-
-const CANONICAL_INPUT_TYPE_LABELS: Record<string, string> = {
-  API_RESPONSE: "구조화된 API 응답",
-  EMAIL_LIST: "이메일 목록",
-  FILE_LIST: "파일 목록",
-  SCHEDULE_DATA: "일정 데이터",
-  SINGLE_EMAIL: "단일 이메일",
-  SINGLE_FILE: "단일 파일",
-  SPREADSHEET_DATA: "스프레드시트 데이터",
-  TEXT: "텍스트",
-};
-
-const DATA_TYPE_LABELS: Record<DataType, string> = {
-  "api-response": "API 응답",
-  "email-list": "이메일 목록",
-  "file-list": "파일 목록",
-  "schedule-data": "일정 데이터",
-  "single-email": "단일 이메일",
-  "single-file": "단일 파일",
-  spreadsheet: "스프레드시트 데이터",
-  text: "텍스트",
 };
 
 const TARGET_SCHEMA_LABELS: Record<string, string> = {
@@ -406,10 +387,9 @@ const SourceModeList = ({
             {mode.label}
           </Text>
           <Text color="text.secondary" fontSize="sm">
-            {CANONICAL_INPUT_TYPE_LABELS[mode.canonical_input_type] ??
-              mode.canonical_input_type}
+            {getCanonicalInputTypeLabel(mode.canonical_input_type) ?? "데이터"}
             {" · "}
-            {mode.trigger_kind}
+            {getTriggerKindLabel(mode.trigger_kind) ?? "실행 방식"}
           </Text>
         </Box>
       ))}
@@ -544,7 +524,7 @@ const StartNodeConfirm = ({
       </Box>
       <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
-          source mode
+          가져오는 방식
         </Text>
         <Text fontSize="md" fontWeight="semibold">
           {mode.label}
@@ -552,17 +532,16 @@ const StartNodeConfirm = ({
       </Box>
       <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
-          canonical type
+          가져오는 데이터
         </Text>
         <Text fontSize="md" fontWeight="semibold">
-          {CANONICAL_INPUT_TYPE_LABELS[mode.canonical_input_type] ??
-            mode.canonical_input_type}
+          {getCanonicalInputTypeLabel(mode.canonical_input_type) ?? "데이터"}
         </Text>
       </Box>
       {targetValue ? (
         <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
           <Text color="text.secondary" fontSize="sm">
-            target
+            선택한 대상
           </Text>
           <Text fontSize="md" fontWeight="semibold">
             {targetValue}
@@ -613,7 +592,7 @@ const SinkNodeConfirm = ({
     <VStack align="stretch" gap={3}>
       <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
-          sink 서비스
+          보낼 서비스
         </Text>
         <Text fontSize="md" fontWeight="semibold">
           {service.label}
@@ -621,10 +600,10 @@ const SinkNodeConfirm = ({
       </Box>
       <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
-          현재 결과 타입
+          보낼 데이터
         </Text>
         <Text fontSize="md" fontWeight="semibold">
-          {inputType ? DATA_TYPE_LABELS[inputType] : "결과 타입 확인 필요"}
+          {getDataTypeDisplayLabel(inputType) ?? "데이터 확인 필요"}
         </Text>
       </Box>
     </VStack>
@@ -1225,7 +1204,7 @@ export const ServiceSelectionPanel = () => {
                   connectedServiceKeys={connectedServiceKeys}
                   emptyMessage={
                     sinkInputType
-                      ? "현재 결과 타입과 연결할 수 있는 sink 서비스가 없습니다."
+                      ? "현재 데이터와 연결할 수 있는 보낼 서비스가 없습니다."
                       : "먼저 결과를 만들 노드가 필요합니다."
                   }
                   isAuthStatusError={isOAuthTokensError}

--- a/src/features/add-node/ui/SourceTargetPicker.tsx
+++ b/src/features/add-node/ui/SourceTargetPicker.tsx
@@ -11,6 +11,7 @@ import { Box, Button, Input, Text } from "@chakra-ui/react";
 import {
   type SourceModeResponse,
   type SourceTargetOptionItemResponse,
+  getWorkflowMetadataSummary,
   useInfiniteSourceTargetOptionsQuery,
 } from "@/entities/workflow";
 import {
@@ -52,40 +53,8 @@ const getOptionIcon = (option: RemoteOptionPickerItem) =>
   TARGET_OPTION_ICON_MAP[option.type as keyof typeof TARGET_OPTION_ICON_MAP] ??
   MdFolder;
 
-const formatMetadataValue = (value: unknown) => {
-  if (typeof value === "string" || typeof value === "number") {
-    return String(value);
-  }
-
-  return null;
-};
-
-const getMetadataSummary = (
-  metadata: SourceTargetOptionItemResponse["metadata"] | undefined,
-) => {
-  if (!metadata) {
-    return "";
-  }
-
-  const summaryKeys = [
-    "term",
-    "courseCount",
-    "mimeType",
-    "modifiedTime",
-    "size",
-  ];
-
-  return summaryKeys
-    .map((key) => {
-      const value = formatMetadataValue(metadata[key]);
-      return value ? `${key}: ${value}` : null;
-    })
-    .filter((value): value is string => value !== null)
-    .join(" · ");
-};
-
 const renderOptionMetadata = (option: RemoteOptionPickerItem) => {
-  const metadataSummary = getMetadataSummary(option.metadata);
+  const metadataSummary = getWorkflowMetadataSummary(option.metadata);
 
   return metadataSummary ? (
     <Text color="text.secondary" fontSize="xs">

--- a/src/features/configure-node/ui/panels/GenericNodePanel.tsx
+++ b/src/features/configure-node/ui/panels/GenericNodePanel.tsx
@@ -20,24 +20,33 @@ export const GenericNodePanel = ({ nodeId, data }: NodePanelProps) => {
     <NodePanelShell
       eyebrow={presentation.roleLabel}
       title={presentation.title}
-      description="이 노드의 설정 패널을 여기에 연결할 수 있습니다."
+      description="선택한 설정으로 준비된 단계입니다."
     >
-      <Box
-        as="pre"
-        p={3}
-        borderRadius="lg"
-        bg="bg.overlay"
-        color="text.secondary"
-        fontSize="xs"
-        whiteSpace="pre-wrap"
-        overflowX="auto"
-      >
-        {JSON.stringify(data.config, null, 2)}
+      <Box bg="gray.50" borderRadius="xl" px={4} py={3}>
+        <Text fontSize="sm" fontWeight="semibold">
+          설정 정보
+        </Text>
+        <Text color="text.secondary" fontSize="sm" mt={1}>
+          이 단계는 선택한 설정을 기준으로 워크플로우에 연결됩니다.
+        </Text>
       </Box>
-      <Text fontSize="xs" color="text.secondary">
-        새 패널을 추가할 때는 configure-node registry에 컴포넌트를 등록하면
-        됩니다.
-      </Text>
+
+      <Box as="details" color="text.secondary" fontSize="xs">
+        <Box as="summary" cursor="pointer" px={1} py={1}>
+          상세 설정 보기
+        </Box>
+        <Box
+          as="pre"
+          p={3}
+          borderRadius="lg"
+          bg="bg.overlay"
+          color="text.secondary"
+          whiteSpace="pre-wrap"
+          overflowX="auto"
+        >
+          {JSON.stringify(data.config, null, 2)}
+        </Box>
+      </Box>
     </NodePanelShell>
   );
 };

--- a/src/features/configure-node/ui/panels/SinkNodePanel.tsx
+++ b/src/features/configure-node/ui/panels/SinkNodePanel.tsx
@@ -16,7 +16,10 @@ import {
   type SinkSchemaFieldResponse,
   type SinkTargetOptionItemResponse,
   type SourceTargetOptionItemResponse,
+  getDataTypeDisplayLabel,
   getNodeStatusMissingFieldLabel,
+  getSchemaValueTypeLabel,
+  getWorkflowMetadataSummary,
   toBackendDataType,
   toEdgeDefinition,
   toNodeDefinition,
@@ -251,39 +254,8 @@ const createSearchPickerState = (scope: string) => ({
   searchQuery: "",
 });
 
-const formatMetadataValue = (value: unknown) => {
-  if (typeof value === "string" || typeof value === "number") {
-    return String(value);
-  }
-
-  return null;
-};
-
-const getMetadataSummary = (metadata: Record<string, unknown> | undefined) => {
-  if (!metadata) {
-    return "";
-  }
-
-  const summaryKeys = [
-    "mimeType",
-    "modifiedTime",
-    "size",
-    "memberCount",
-    "lastEditedTime",
-    "parentType",
-  ];
-
-  return summaryKeys
-    .map((key) => {
-      const value = formatMetadataValue(metadata[key]);
-      return value ? `${key}: ${value}` : null;
-    })
-    .filter((value): value is string => value !== null)
-    .join(" · ");
-};
-
 const renderRemotePickerMetadata = (option: RemoteOptionPickerItem) => {
-  const metadataSummary = getMetadataSummary(option.metadata);
+  const metadataSummary = getWorkflowMetadataSummary(option.metadata);
 
   return metadataSummary ? (
     <Text color="text.secondary" fontSize="xs">
@@ -1017,6 +989,11 @@ export const SinkNodePanel = ({
 
     return `${nodeId}:${serviceKey}:${JSON.stringify(snapshot)}`;
   }, [nodeId, serviceKey, sinkConfig, sinkSchema]);
+  const shouldShowNodeStatus = Boolean(
+    nodeStatus && (!nodeStatus.configured || !nodeStatus.executable),
+  );
+  const inputTypeLabel =
+    getDataTypeDisplayLabel(sinkInputType) ?? "데이터 확인 필요";
 
   return (
     <NodePanelShell
@@ -1025,31 +1002,32 @@ export const SinkNodePanel = ({
       title={selectedSinkService?.label ?? "Destination"}
     >
       <Box display="flex" flexDirection="column" gap={6}>
-        {nodeStatus ? (
-          <Box bg="gray.50" borderRadius="2xl" px={4} py={4}>
-            <Text fontSize="sm" fontWeight="medium" mb={1}>
-              현재 상태
+        {shouldShowNodeStatus ? (
+          <Box
+            bg="orange.50"
+            border="1px solid"
+            borderColor="orange.100"
+            borderRadius="2xl"
+            px={4}
+            py={4}
+          >
+            <Text color="orange.600" fontSize="sm" fontWeight="semibold" mb={1}>
+              도착 노드 설정을 확인해 주세요.
             </Text>
             <Text color="text.secondary" fontSize="sm">
-              설정 완료: {nodeStatus.configured ? "예" : "아니오"}
+              {missingFields.length > 0
+                ? `확인 항목: ${missingFields.join(", ")}`
+                : "설정 값을 다시 확인해 주세요."}
             </Text>
-            <Text color="text.secondary" fontSize="sm">
-              실행 가능: {nodeStatus.executable ? "예" : "아니오"}
-            </Text>
-            {missingFields.length > 0 ? (
-              <Text color="text.secondary" fontSize="sm" mt={2}>
-                확인 항목: {missingFields.join(", ")}
-              </Text>
-            ) : null}
           </Box>
         ) : null}
 
         <Box display="flex" flexDirection="column" gap={2}>
           <Text fontSize="sm" fontWeight="medium">
-            현재 결과 타입
+            보낼 데이터
           </Text>
           <Text color="text.secondary" fontSize="sm">
-            {inputType ? sinkInputType : "결과 타입 확인 필요"}
+            {inputType ? inputTypeLabel : "데이터 확인 필요"}
           </Text>
         </Box>
 
@@ -1067,22 +1045,30 @@ export const SinkNodePanel = ({
             </Box>
           ) : schemaPreview ? (
             <Box display="flex" flexDirection="column" gap={2}>
-              {schemaPreview.fields.map((field) => (
-                <Box
-                  key={field.key}
-                  bg="gray.50"
-                  borderRadius="xl"
-                  px={4}
-                  py={3}
-                >
-                  <Text fontSize="sm" fontWeight="semibold">
-                    {field.label}
-                  </Text>
-                  <Text color="text.secondary" fontSize="xs">
-                    {field.key} · {field.value_type}
-                  </Text>
-                </Box>
-              ))}
+              {schemaPreview.fields.map((field) => {
+                const valueTypeLabel = getSchemaValueTypeLabel(
+                  field.value_type,
+                );
+
+                return (
+                  <Box
+                    key={field.key}
+                    bg="gray.50"
+                    borderRadius="xl"
+                    px={4}
+                    py={3}
+                  >
+                    <Text fontSize="sm" fontWeight="semibold">
+                      {field.label || "항목"}
+                    </Text>
+                    {valueTypeLabel ? (
+                      <Text color="text.secondary" fontSize="xs">
+                        {valueTypeLabel}
+                      </Text>
+                    ) : null}
+                  </Box>
+                );
+              })}
             </Box>
           ) : (
             <Text color="text.secondary" fontSize="sm">
@@ -1093,7 +1079,7 @@ export const SinkNodePanel = ({
 
         <Box display="flex" flexDirection="column" gap={3}>
           <Text fontSize="sm" fontWeight="medium">
-            sink 상세 설정
+            도착 상세 설정
           </Text>
 
           {selectedSinkService && sinkSchema ? (
@@ -1108,7 +1094,7 @@ export const SinkNodePanel = ({
             />
           ) : (
             <Text color="text.secondary" fontSize="sm">
-              sink 서비스를 먼저 선택하면 상세 설정을 채울 수 있습니다.
+              보낼 서비스를 먼저 선택하면 상세 설정을 채울 수 있습니다.
             </Text>
           )}
         </Box>

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -25,6 +25,7 @@ import {
   NodeExecutionStatusBlock,
   SchemaPreviewBlock,
   SourceSummaryBlock,
+  getNodeConfigStatusNotice,
   isEmptyPanelData,
   useNodeDataPanelModel,
 } from "@/widgets/node-data-panel";
@@ -72,6 +73,10 @@ export const InputPanel = () => {
     isMiddleNode && isMiddleWizardCompleted(activeNode);
   const activeNodeMissingFields = (activeNodeStatus?.missingFields ?? []).map(
     getNodeStatusMissingFieldLabel,
+  );
+  const nodeConfigNotice = getNodeConfigStatusNotice(
+    activeNodeStatus,
+    activeNodeMissingFields,
   );
   const activeNodeConfig =
     (activeNode?.data.config as unknown as Record<string, unknown>) ?? null;
@@ -269,23 +274,30 @@ export const InputPanel = () => {
               />
             ) : null}
 
-            {activeNodeStatus ? (
+            {nodeConfigNotice ? (
               <Box>
                 <Text fontSize="md" fontWeight="bold" mb={3}>
                   설정 상태
                 </Text>
-                <Box bg="gray.50" borderRadius="2xl" px={4} py={4}>
-                  <Text fontSize="sm" fontWeight="semibold" mb={1}>
-                    {activeNodeStatus.configured ? "설정 완료" : "설정 필요"}
+                <Box
+                  bg="orange.50"
+                  border="1px solid"
+                  borderColor="orange.100"
+                  borderRadius="2xl"
+                  px={4}
+                  py={4}
+                >
+                  <Text
+                    color="orange.600"
+                    fontSize="sm"
+                    fontWeight="semibold"
+                    mb={1}
+                  >
+                    {nodeConfigNotice.title}
                   </Text>
                   <Text color="text.secondary" fontSize="sm">
-                    실행 가능: {activeNodeStatus.executable ? "예" : "아니오"}
+                    {nodeConfigNotice.description}
                   </Text>
-                  {activeNodeMissingFields.length > 0 ? (
-                    <Text color="text.secondary" fontSize="sm" mt={2}>
-                      확인 항목: {activeNodeMissingFields.join(", ")}
-                    </Text>
-                  ) : null}
                 </Box>
               </Box>
             ) : null}

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { MdCancel } from "react-icons/md";
 
-import { Box, Icon, Text } from "@chakra-ui/react";
+import { Box, Button, Icon, Text } from "@chakra-ui/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
 import {
@@ -182,6 +182,28 @@ export const InputPanel = () => {
                   source={nodeDataPanel.schemaPreview?.source ?? null}
                 />
               ) : null}
+              <Box display="flex" flexDirection="column" gap={2}>
+                <Button
+                  alignSelf="flex-start"
+                  size="sm"
+                  variant="outline"
+                  loading={nodeDataPanel.isPreviewLoading}
+                  disabled={!nodeDataPanel.canRequestPreview}
+                  onClick={nodeDataPanel.requestPreview}
+                >
+                  실행 전 미리보기
+                </Button>
+                {isDirty ? (
+                  <Text fontSize="xs" color="orange.500">
+                    저장 후 미리보기를 확인할 수 있습니다.
+                  </Text>
+                ) : null}
+                {nodeDataPanel.previewErrorMessage ? (
+                  <Text fontSize="xs" color="red.500">
+                    {nodeDataPanel.previewErrorMessage}
+                  </Text>
+                ) : null}
+              </Box>
               <DataStateNotice
                 state={nodeDataPanel.state}
                 panelKind="input"
@@ -192,7 +214,11 @@ export const InputPanel = () => {
               />
               {hasPreviewData ? (
                 <DataPreviewBlock
-                  title="입력 데이터"
+                  title={
+                    nodeDataPanel.isPreviewDataDisplayed
+                      ? "미리보기 데이터"
+                      : "입력 데이터"
+                  }
                   data={nodeDataPanel.dataToDisplay}
                 />
               ) : null}

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -182,28 +182,30 @@ export const InputPanel = () => {
                   source={nodeDataPanel.schemaPreview?.source ?? null}
                 />
               ) : null}
-              <Box display="flex" flexDirection="column" gap={2}>
-                <Button
-                  alignSelf="flex-start"
-                  size="sm"
-                  variant="outline"
-                  loading={nodeDataPanel.isPreviewLoading}
-                  disabled={!nodeDataPanel.canRequestPreview}
-                  onClick={nodeDataPanel.requestPreview}
-                >
-                  실행 전 미리보기
-                </Button>
-                {isDirty ? (
-                  <Text fontSize="xs" color="orange.500">
-                    저장 후 미리보기를 확인할 수 있습니다.
-                  </Text>
-                ) : null}
-                {nodeDataPanel.previewErrorMessage ? (
-                  <Text fontSize="xs" color="red.500">
-                    {nodeDataPanel.previewErrorMessage}
-                  </Text>
-                ) : null}
-              </Box>
+              {nodeDataPanel.isPreviewSupported ? (
+                <Box display="flex" flexDirection="column" gap={2}>
+                  <Button
+                    alignSelf="flex-start"
+                    size="sm"
+                    variant="outline"
+                    loading={nodeDataPanel.isPreviewLoading}
+                    disabled={!nodeDataPanel.canRequestPreview}
+                    onClick={nodeDataPanel.requestPreview}
+                  >
+                    실행 전 미리보기
+                  </Button>
+                  {isDirty ? (
+                    <Text fontSize="xs" color="orange.500">
+                      저장 후 미리보기를 확인할 수 있습니다.
+                    </Text>
+                  ) : null}
+                  {nodeDataPanel.previewErrorMessage ? (
+                    <Text fontSize="xs" color="red.500">
+                      {nodeDataPanel.previewErrorMessage}
+                    </Text>
+                  ) : null}
+                </Box>
+              ) : null}
               <DataStateNotice
                 state={nodeDataPanel.state}
                 panelKind="input"

--- a/src/widgets/node-data-panel/model/index.ts
+++ b/src/widgets/node-data-panel/model/index.ts
@@ -1,3 +1,4 @@
+export * from "./node-data-panel-display";
 export * from "./node-data-panel-utils";
 export * from "./types";
 export * from "./useNodeDataPanelModel";

--- a/src/widgets/node-data-panel/model/node-data-panel-display.ts
+++ b/src/widgets/node-data-panel/model/node-data-panel-display.ts
@@ -1,0 +1,162 @@
+import {
+  type ExecutionNodeData,
+  type NodeStatusSummaryResponse,
+  type SourceConfigSummaryResponse,
+  getCanonicalInputTypeLabel,
+  getExecutionStatusLabel,
+  getNodeDataReasonLabel,
+  getTriggerKindLabel,
+  isSuccessfulExecutionStatus,
+} from "@/entities";
+
+type SourceSummaryInput = {
+  config: Record<string, unknown> | null;
+  source: SourceConfigSummaryResponse | null;
+};
+
+export type NodeDataSummaryRow = {
+  label: string;
+  value: string;
+};
+
+export type NodeDataNotice = {
+  title: string;
+  description?: string;
+  tone: "error" | "warning";
+};
+
+const getStringValue = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+export const getSourceSummaryRows = ({
+  config,
+  source,
+}: SourceSummaryInput): NodeDataSummaryRow[] => {
+  const serviceLabel =
+    source?.serviceLabel ??
+    source?.service ??
+    getStringValue(config?.service) ??
+    null;
+  const modeLabel =
+    source?.modeLabel ?? source?.mode ?? getStringValue(config?.source_mode);
+  const targetLabel =
+    source?.targetLabel ??
+    getStringValue(config?.target_label) ??
+    source?.target ??
+    getStringValue(config?.target);
+  const canonicalInputType =
+    getCanonicalInputTypeLabel(source?.canonicalInputType) ??
+    getCanonicalInputTypeLabel(getStringValue(config?.canonical_input_type));
+  const triggerKind =
+    getTriggerKindLabel(source?.triggerKind) ??
+    getTriggerKindLabel(getStringValue(config?.trigger_kind));
+
+  return [
+    serviceLabel ? { label: "서비스", value: serviceLabel } : null,
+    modeLabel ? { label: "가져오는 방식", value: modeLabel } : null,
+    targetLabel ? { label: "선택한 대상", value: targetLabel } : null,
+    canonicalInputType
+      ? { label: "가져오는 데이터", value: canonicalInputType }
+      : null,
+    triggerKind ? { label: "실행 방식", value: triggerKind } : null,
+  ].filter((row): row is NodeDataSummaryRow => row !== null);
+};
+
+export const getSourceSummaryDescription = ({
+  config,
+  source,
+}: SourceSummaryInput) => {
+  const serviceLabel =
+    source?.serviceLabel ??
+    source?.service ??
+    getStringValue(config?.service) ??
+    null;
+  const targetLabel =
+    source?.targetLabel ??
+    getStringValue(config?.target_label) ??
+    source?.target ??
+    getStringValue(config?.target);
+  const canonicalInputType =
+    getCanonicalInputTypeLabel(source?.canonicalInputType) ??
+    getCanonicalInputTypeLabel(getStringValue(config?.canonical_input_type));
+
+  if (serviceLabel && targetLabel && canonicalInputType) {
+    return `${serviceLabel}의 ${targetLabel}에서 ${canonicalInputType}을 가져옵니다.`;
+  }
+
+  if (serviceLabel && canonicalInputType) {
+    return `${serviceLabel}에서 ${canonicalInputType}을 가져옵니다.`;
+  }
+
+  return "시작 노드 설정을 기준으로 워크플로우에 들어올 데이터를 요약합니다.";
+};
+
+export const getExecutionStatusNotice = (
+  executionData: ExecutionNodeData | null,
+): NodeDataNotice | null => {
+  if (!executionData) {
+    return null;
+  }
+
+  if (
+    executionData.available &&
+    isSuccessfulExecutionStatus(executionData.status)
+  ) {
+    return null;
+  }
+
+  const reasonLabel = getNodeDataReasonLabel(executionData.reason);
+  const statusLabel = getExecutionStatusLabel(executionData.status);
+  const errorMessage = executionData.error?.message ?? null;
+
+  if (executionData.error || executionData.reason === "NODE_FAILED") {
+    return {
+      title: "실행 실패",
+      description:
+        errorMessage ?? reasonLabel ?? "이 단계 실행 중 문제가 발생했습니다.",
+      tone: "error",
+    };
+  }
+
+  if (reasonLabel || statusLabel) {
+    return {
+      title: statusLabel ?? reasonLabel ?? "확인 필요",
+      description: reasonLabel ?? undefined,
+      tone: "warning",
+    };
+  }
+
+  return null;
+};
+
+export const getNodeConfigStatusNotice = (
+  status: NodeStatusSummaryResponse | null | undefined,
+  missingFields: string[],
+): NodeDataNotice | null => {
+  if (!status) {
+    return null;
+  }
+
+  if (status.configured && status.executable) {
+    return null;
+  }
+
+  const description =
+    missingFields.length > 0
+      ? `확인할 항목: ${missingFields.join(", ")}`
+      : "설정 값을 다시 확인해 주세요.";
+
+  if (!status.configured) {
+    return {
+      title: "필수 설정이 필요합니다.",
+      description,
+      tone: "warning",
+    };
+  }
+
+  return {
+    title: "실행 전 확인이 필요합니다.",
+    description,
+    tone: "warning",
+  };
+};

--- a/src/widgets/node-data-panel/model/node-data-panel-utils.ts
+++ b/src/widgets/node-data-panel/model/node-data-panel-utils.ts
@@ -1,4 +1,4 @@
-import { type ExecutionNodeData } from "@/entities";
+import { type ExecutionNodeData, type NodePreviewResponse } from "@/entities";
 
 import { type NodeDataPanelKind, type NodeDataPanelState } from "./types";
 
@@ -50,6 +50,24 @@ export const getPanelData = (
   }
 
   return executionData.outputData ?? null;
+};
+
+export const getPreviewPanelData = (
+  panelKind: NodeDataPanelKind,
+  previewData: NodePreviewResponse | null,
+  isStartNode: boolean,
+) => {
+  if (!previewData?.available) {
+    return null;
+  }
+
+  if (panelKind === "input") {
+    return isStartNode
+      ? (previewData.outputData ?? previewData.previewData ?? null)
+      : (previewData.inputData ?? null);
+  }
+
+  return previewData.outputData ?? previewData.previewData ?? null;
 };
 
 export const resolveNodeDataPanelState = ({

--- a/src/widgets/node-data-panel/model/types.ts
+++ b/src/widgets/node-data-panel/model/types.ts
@@ -2,6 +2,7 @@ import { type Node } from "@xyflow/react";
 
 import {
   type ExecutionNodeData,
+  type NodePreviewResponse,
   type NodeSchemaPreviewResponse,
   type SchemaPreviewResponse,
 } from "@/entities";
@@ -30,6 +31,7 @@ export type NodeDataPanelModel = {
   staticInputLabel: string | null;
   staticOutputLabel: string | null;
   executionData: ExecutionNodeData | null;
+  nodePreviewData: NodePreviewResponse | null;
   schemaPreview: NodeSchemaPreviewResponse | null;
   state: NodeDataPanelState;
   dataToDisplay: unknown;
@@ -37,6 +39,11 @@ export type NodeDataPanelModel = {
   schemaPreviewLabel: string | null;
   canViewExecutionData: boolean;
   isExecutionDataLoading: boolean;
+  isPreviewLoading: boolean;
   isSchemaPreviewLoading: boolean;
   isStaleAgainstCurrentEditor: boolean;
+  isPreviewDataDisplayed: boolean;
+  canRequestPreview: boolean;
+  previewErrorMessage: string | null;
+  requestPreview: () => void;
 };

--- a/src/widgets/node-data-panel/model/types.ts
+++ b/src/widgets/node-data-panel/model/types.ts
@@ -43,6 +43,7 @@ export type NodeDataPanelModel = {
   isSchemaPreviewLoading: boolean;
   isStaleAgainstCurrentEditor: boolean;
   isPreviewDataDisplayed: boolean;
+  isPreviewSupported: boolean;
   canRequestPreview: boolean;
   previewErrorMessage: string | null;
   requestPreview: () => void;

--- a/src/widgets/node-data-panel/model/useNodeDataPanelModel.ts
+++ b/src/widgets/node-data-panel/model/useNodeDataPanelModel.ts
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 
 import {
+  getDataTypeDisplayLabel,
   useLatestExecutionNodeDataQuery,
   useWorkflowNodeSchemaPreviewQuery,
 } from "@/entities";
 import { type FlowNodeData } from "@/entities/node";
-import { OUTPUT_DATA_LABELS } from "@/features/choice-panel";
 import { useWorkflowStore } from "@/features/workflow-editor";
 
 import {
@@ -23,7 +23,7 @@ type UseNodeDataPanelModelParameters = {
 };
 
 const getDataTypeLabel = (dataType: FlowNodeData["outputTypes"][number]) =>
-  OUTPUT_DATA_LABELS[dataType] ?? dataType;
+  getDataTypeDisplayLabel(dataType) ?? "데이터";
 
 export const useNodeDataPanelModel = ({
   panelKind,

--- a/src/widgets/node-data-panel/model/useNodeDataPanelModel.ts
+++ b/src/widgets/node-data-panel/model/useNodeDataPanelModel.ts
@@ -59,6 +59,7 @@ export const useNodeDataPanelModel = ({
 
   const isStartNode = Boolean(nodeId && nodeId === startNodeId);
   const isEndNode = Boolean(nodeId && nodeId === endNodeId);
+  const isPreviewSupported = isStartNode;
   const executionDataQuery = useLatestExecutionNodeDataQuery(
     workflowId,
     nodeId ?? undefined,
@@ -120,6 +121,7 @@ export const useNodeDataPanelModel = ({
       : null;
   const isPreviewDataDisplayed = !isEmptyPanelData(previewDataToDisplay);
   const canRequestPreview = Boolean(
+    isPreviewSupported &&
     workflowId &&
     nodeId &&
     activeNode &&
@@ -174,6 +176,7 @@ export const useNodeDataPanelModel = ({
     isSchemaPreviewLoading: schemaPreviewQuery.isLoading,
     isStaleAgainstCurrentEditor: isWorkflowDirty,
     isPreviewDataDisplayed,
+    isPreviewSupported,
     canRequestPreview,
     previewErrorMessage,
     requestPreview,

--- a/src/widgets/node-data-panel/model/useNodeDataPanelModel.ts
+++ b/src/widgets/node-data-panel/model/useNodeDataPanelModel.ts
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import {
   getDataTypeDisplayLabel,
   useLatestExecutionNodeDataQuery,
+  useWorkflowNodePreviewMutation,
   useWorkflowNodeSchemaPreviewQuery,
 } from "@/entities";
 import { type FlowNodeData } from "@/entities/node";
@@ -10,6 +11,8 @@ import { useWorkflowStore } from "@/features/workflow-editor";
 
 import {
   getPanelData,
+  getPreviewPanelData,
+  isEmptyPanelData,
   resolveNodeDataPanelState,
 } from "./node-data-panel-utils";
 import { type NodeDataPanelKind, type NodeDataPanelModel } from "./types";
@@ -72,9 +75,33 @@ export const useNodeDataPanelModel = ({
       showErrorToast: false,
     },
   );
+  const {
+    data: nodePreviewData = null,
+    error: nodePreviewError,
+    isPending: isPreviewLoading,
+    mutate: previewNode,
+    reset: resetNodePreview,
+  } = useWorkflowNodePreviewMutation({
+    showErrorToast: false,
+  });
+
+  useEffect(() => {
+    resetNodePreview();
+  }, [nodeId, panelKind, resetNodePreview, workflowId]);
+
   const executionData = executionDataQuery.data ?? null;
   const schemaPreview = schemaPreviewQuery.data ?? null;
-  const dataToDisplay = getPanelData(panelKind, executionData, isStartNode);
+  const previewDataToDisplay = getPreviewPanelData(
+    panelKind,
+    nodePreviewData,
+    isStartNode,
+  );
+  const executionDataToDisplay = getPanelData(
+    panelKind,
+    executionData,
+    isStartNode,
+  );
+  const dataToDisplay = previewDataToDisplay ?? executionDataToDisplay;
   const schemaToDisplay =
     panelKind === "input"
       ? (schemaPreview?.input?.schema ?? null)
@@ -91,14 +118,41 @@ export const useNodeDataPanelModel = ({
     activeNode?.data.outputTypes[0] !== undefined
       ? getDataTypeLabel(activeNode.data.outputTypes[0])
       : null;
-  const state = resolveNodeDataPanelState({
-    hasActiveNode: Boolean(activeNode),
-    canViewExecutionData,
-    isExecutionDataLoading: executionDataQuery.isLoading,
-    isExecutionDataError: executionDataQuery.isError,
-    executionData,
-    dataToDisplay,
-  });
+  const isPreviewDataDisplayed = !isEmptyPanelData(previewDataToDisplay);
+  const canRequestPreview = Boolean(
+    workflowId &&
+    nodeId &&
+    activeNode &&
+    canViewExecutionData &&
+    !isWorkflowDirty,
+  );
+  const requestPreview = useCallback(() => {
+    if (!workflowId || !nodeId || !canRequestPreview) {
+      return;
+    }
+
+    previewNode({
+      workflowId,
+      nodeId,
+      limit: 5,
+      includeContent: false,
+    });
+  }, [canRequestPreview, nodeId, previewNode, workflowId]);
+  const state = isPreviewDataDisplayed
+    ? "data-ready"
+    : resolveNodeDataPanelState({
+        hasActiveNode: Boolean(activeNode),
+        canViewExecutionData,
+        isExecutionDataLoading:
+          executionDataQuery.isLoading || isPreviewLoading,
+        isExecutionDataError: executionDataQuery.isError,
+        executionData,
+        dataToDisplay,
+      });
+  const previewErrorMessage =
+    nodePreviewData && !nodePreviewData.available
+      ? (nodePreviewData.reason ?? "PREVIEW_UNAVAILABLE")
+      : (nodePreviewError?.message ?? null);
 
   return {
     activeNode,
@@ -108,6 +162,7 @@ export const useNodeDataPanelModel = ({
     staticInputLabel,
     staticOutputLabel,
     executionData,
+    nodePreviewData,
     schemaPreview,
     state,
     dataToDisplay,
@@ -115,7 +170,12 @@ export const useNodeDataPanelModel = ({
     schemaPreviewLabel,
     canViewExecutionData,
     isExecutionDataLoading: executionDataQuery.isLoading,
+    isPreviewLoading,
     isSchemaPreviewLoading: schemaPreviewQuery.isLoading,
     isStaleAgainstCurrentEditor: isWorkflowDirty,
+    isPreviewDataDisplayed,
+    canRequestPreview,
+    previewErrorMessage,
+    requestPreview,
   };
 };

--- a/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
+++ b/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
@@ -1,14 +1,75 @@
-import { Box, Text } from "@chakra-ui/react";
+import { type ReactNode } from "react";
+
+import { Box, Link, Text } from "@chakra-ui/react";
+
+import { getDataTypeDisplayLabel } from "@/entities";
 
 type Props = {
   title?: string;
   data: unknown;
 };
 
-const getRecordEntries = (data: unknown) =>
-  data && typeof data === "object" && !Array.isArray(data)
-    ? Object.entries(data as Record<string, unknown>)
-    : [];
+type DataRecord = Record<string, unknown>;
+
+const MAX_TEXT_PREVIEW_LENGTH = 1400;
+const MAX_LIST_PREVIEW_COUNT = 12;
+const MAX_TABLE_ROW_COUNT = 12;
+
+const isRecord = (value: unknown): value is DataRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : "";
+
+const getNumber = (value: unknown) =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const getRecordItems = (value: unknown) =>
+  Array.isArray(value) ? value.filter(isRecord) : [];
+
+const getPayloadType = (data: unknown) =>
+  isRecord(data) ? getString(data.type).toUpperCase() : "";
+
+const truncateText = (value: string, maxLength = MAX_TEXT_PREVIEW_LENGTH) =>
+  value.length > maxLength
+    ? `${value.slice(0, maxLength).trimEnd()}...`
+    : value;
+
+const formatDateTime = (value: unknown) => {
+  const rawValue = getString(value);
+  if (!rawValue) {
+    return "";
+  }
+
+  const date = new Date(rawValue);
+  if (Number.isNaN(date.getTime())) {
+    return rawValue;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+};
+
+const formatFileSize = (value: unknown) => {
+  const numericValue =
+    getNumber(value) ?? (getString(value) ? Number(getString(value)) : null);
+
+  if (numericValue === null || !Number.isFinite(numericValue)) {
+    return "";
+  }
+
+  if (numericValue < 1024) {
+    return `${numericValue} B`;
+  }
+
+  if (numericValue < 1024 * 1024) {
+    return `${(numericValue / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(numericValue / (1024 * 1024)).toFixed(1)} MB`;
+};
 
 const formatPreviewData = (data: unknown) => {
   try {
@@ -18,63 +79,519 @@ const formatPreviewData = (data: unknown) => {
   }
 };
 
-const getPreviewSummary = (data: unknown) => {
+const getDisplayTypeLabel = (type: string) =>
+  getDataTypeDisplayLabel(type) ?? "데이터";
+
+const FieldText = ({ label, value }: { label: string; value: unknown }) => {
+  const displayValue =
+    typeof value === "number" ? String(value) : getString(value);
+
+  if (!displayValue) {
+    return null;
+  }
+
+  return (
+    <Text fontSize="xs" color="text.secondary">
+      {label}: {displayValue}
+    </Text>
+  );
+};
+
+const ExternalLink = ({ href }: { href: unknown }) => {
+  const value = getString(href);
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={value}
+      target="_blank"
+      rel="noreferrer"
+      color="blue.500"
+      fontSize="xs"
+      fontWeight="medium"
+    >
+      원본 열기
+    </Link>
+  );
+};
+
+const SummaryCard = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}) => (
+  <Box
+    px={4}
+    py={3}
+    borderRadius="xl"
+    bg="gray.50"
+    border="1px solid"
+    borderColor="gray.100"
+  >
+    <Text fontSize="sm" fontWeight="semibold">
+      {title}
+    </Text>
+    {description ? (
+      <Text color="text.secondary" fontSize="sm" mt={1} whiteSpace="pre-wrap">
+        {description}
+      </Text>
+    ) : null}
+    {children ? (
+      <Box display="flex" flexDirection="column" gap={1} mt={3}>
+        {children}
+      </Box>
+    ) : null}
+  </Box>
+);
+
+const FileItemCard = ({ item, index }: { item: DataRecord; index: number }) => {
+  const filename = getString(item.filename) || `파일 ${index + 1}`;
+  const mimeType = getString(item.mime_type) || getString(item.mimeType);
+  const size = formatFileSize(item.size);
+
+  return (
+    <Box
+      px={4}
+      py={3}
+      borderRadius="xl"
+      bg="white"
+      border="1px solid"
+      borderColor="gray.100"
+    >
+      <Text fontSize="sm" fontWeight="semibold" wordBreak="break-word">
+        {filename}
+      </Text>
+      <Box mt={1} display="flex" flexDirection="column" gap={1}>
+        <FieldText label="형식" value={mimeType} />
+        <FieldText label="크기" value={size} />
+        <FieldText
+          label="수정일"
+          value={formatDateTime(item.modified_time ?? item.modifiedTime)}
+        />
+        <ExternalLink href={item.url} />
+      </Box>
+    </Box>
+  );
+};
+
+const FileListPreview = ({ data }: { data: DataRecord }) => {
+  const items = getRecordItems(data.items);
+  const previewItems = items.slice(0, MAX_LIST_PREVIEW_COUNT);
+  const omittedCount = items.length - previewItems.length;
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <SummaryCard
+        title={`${items.length}개 파일`}
+        description={
+          items.length > 0
+            ? "다음 단계로 전달된 파일 목록입니다."
+            : "전달된 파일이 없습니다."
+        }
+      />
+      {previewItems.map((item, index) => (
+        <FileItemCard
+          key={`${getString(item.filename)}-${index}`}
+          item={item}
+          index={index}
+        />
+      ))}
+      {omittedCount > 0 ? (
+        <Text fontSize="xs" color="text.secondary">
+          외 {omittedCount}개 파일은 상세 데이터에서 확인할 수 있습니다.
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
+
+const SingleFilePreview = ({ data }: { data: DataRecord }) => {
+  const filename = getString(data.filename) || "파일";
+  const content = getString(data.content);
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <SummaryCard
+        title={filename}
+        description="다음 단계로 전달된 단일 파일입니다."
+      >
+        <FieldText label="형식" value={data.mime_type ?? data.mimeType} />
+        <FieldText label="크기" value={formatFileSize(data.size)} />
+        <FieldText
+          label="생성일"
+          value={formatDateTime(data.created_time ?? data.createdTime)}
+        />
+        <FieldText
+          label="수정일"
+          value={formatDateTime(data.modified_time ?? data.modifiedTime)}
+        />
+        <ExternalLink href={data.url} />
+      </SummaryCard>
+      {content ? (
+        <SummaryCard
+          title="본문 미리보기"
+          description={truncateText(content)}
+        />
+      ) : null}
+    </Box>
+  );
+};
+
+const TextPreview = ({ data }: { data: DataRecord }) => {
+  const content = getString(data.content);
+
+  return (
+    <SummaryCard
+      title="텍스트"
+      description={
+        content ? truncateText(content) : "표시할 텍스트가 없습니다."
+      }
+    />
+  );
+};
+
+const EmailItemCard = ({
+  item,
+  index,
+}: {
+  item: DataRecord;
+  index: number;
+}) => {
+  const subject = getString(item.subject) || `메일 ${index + 1}`;
+  const body = getString(item.body);
+
+  return (
+    <Box
+      px={4}
+      py={3}
+      borderRadius="xl"
+      bg="white"
+      border="1px solid"
+      borderColor="gray.100"
+    >
+      <Text fontSize="sm" fontWeight="semibold" wordBreak="break-word">
+        {subject}
+      </Text>
+      <Box mt={1} display="flex" flexDirection="column" gap={1}>
+        <FieldText label="보낸 사람" value={item.from} />
+        <FieldText label="날짜" value={formatDateTime(item.date)} />
+        {body ? (
+          <Text fontSize="xs" color="text.secondary" whiteSpace="pre-wrap">
+            {truncateText(body, 240)}
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+  );
+};
+
+const EmailListPreview = ({ data }: { data: DataRecord }) => {
+  const items = getRecordItems(data.items);
+  const previewItems = items.slice(0, MAX_LIST_PREVIEW_COUNT);
+  const omittedCount = items.length - previewItems.length;
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <SummaryCard
+        title={`${items.length}개 메일`}
+        description={
+          items.length > 0
+            ? "다음 단계로 전달된 메일 목록입니다."
+            : "전달된 메일이 없습니다."
+        }
+      />
+      {previewItems.map((item, index) => (
+        <EmailItemCard
+          key={`${getString(item.subject)}-${index}`}
+          item={item}
+          index={index}
+        />
+      ))}
+      {omittedCount > 0 ? (
+        <Text fontSize="xs" color="text.secondary">
+          외 {omittedCount}개 메일은 상세 데이터에서 확인할 수 있습니다.
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
+
+const SingleEmailPreview = ({ data }: { data: DataRecord }) => {
+  const attachments = getRecordItems(data.attachments);
+  const body = getString(data.body);
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <SummaryCard title={getString(data.subject) || "메일"}>
+        <FieldText label="보낸 사람" value={data.from} />
+        <FieldText label="날짜" value={formatDateTime(data.date)} />
+        <FieldText
+          label="첨부"
+          value={attachments.length ? `${attachments.length}개` : ""}
+        />
+      </SummaryCard>
+      {body ? (
+        <SummaryCard title="본문" description={truncateText(body)} />
+      ) : null}
+      {attachments.length > 0 ? (
+        <Box display="flex" flexDirection="column" gap={2}>
+          {attachments.slice(0, MAX_LIST_PREVIEW_COUNT).map((item, index) => (
+            <FileItemCard
+              key={`${getString(item.filename)}-${index}`}
+              item={item}
+              index={index}
+            />
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+const SpreadsheetPreview = ({ data }: { data: DataRecord }) => {
+  const headers = Array.isArray(data.headers)
+    ? data.headers.map((header) => String(header))
+    : [];
+  const rows = Array.isArray(data.rows)
+    ? data.rows
+        .filter(Array.isArray)
+        .map((row) => row.map((cell) => String(cell ?? "")))
+    : [];
+  const previewRows = rows.slice(0, MAX_TABLE_ROW_COUNT);
+  const columnCount = Math.max(
+    headers.length,
+    ...previewRows.map((row) => row.length),
+    1,
+  );
+  const displayHeaders =
+    headers.length > 0
+      ? headers
+      : Array.from({ length: columnCount }, (_, index) => `열 ${index + 1}`);
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <SummaryCard
+        title={`${rows.length}개 행`}
+        description={
+          getString(data.sheet_name)
+            ? `시트: ${getString(data.sheet_name)}`
+            : "표 데이터입니다."
+        }
+      />
+      <Box
+        overflowX="auto"
+        border="1px solid"
+        borderColor="gray.100"
+        borderRadius="xl"
+      >
+        <Box as="table" width="100%" minW="420px" borderCollapse="collapse">
+          <Box as="thead" bg="gray.50">
+            <Box as="tr">
+              {displayHeaders.map((header, index) => (
+                <Box
+                  as="th"
+                  key={`${header}-${index}`}
+                  px={3}
+                  py={2}
+                  textAlign="left"
+                  fontSize="xs"
+                  fontWeight="semibold"
+                  color="gray.600"
+                  borderBottom="1px solid"
+                  borderColor="gray.100"
+                >
+                  {header}
+                </Box>
+              ))}
+            </Box>
+          </Box>
+          <Box as="tbody">
+            {previewRows.map((row, rowIndex) => (
+              <Box as="tr" key={`row-${rowIndex}`}>
+                {displayHeaders.map((_, cellIndex) => (
+                  <Box
+                    as="td"
+                    key={`cell-${rowIndex}-${cellIndex}`}
+                    px={3}
+                    py={2}
+                    fontSize="xs"
+                    color="gray.700"
+                    borderTop={rowIndex === 0 ? "none" : "1px solid"}
+                    borderColor="gray.100"
+                  >
+                    {row[cellIndex] ?? ""}
+                  </Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </Box>
+      {rows.length > previewRows.length ? (
+        <Text fontSize="xs" color="text.secondary">
+          외 {rows.length - previewRows.length}개 행은 상세 데이터에서 확인할 수
+          있습니다.
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
+
+const SchedulePreview = ({ data }: { data: DataRecord }) => {
+  const items = getRecordItems(data.items);
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <SummaryCard
+        title={`${items.length}개 일정`}
+        description="다음 단계로 전달된 일정입니다."
+      />
+      {items.slice(0, MAX_LIST_PREVIEW_COUNT).map((item, index) => (
+        <Box
+          key={`${getString(item.title)}-${index}`}
+          px={4}
+          py={3}
+          borderRadius="xl"
+          bg="white"
+          border="1px solid"
+          borderColor="gray.100"
+        >
+          <Text fontSize="sm" fontWeight="semibold">
+            {getString(item.title) || `일정 ${index + 1}`}
+          </Text>
+          <Box mt={1} display="flex" flexDirection="column" gap={1}>
+            <FieldText label="시작" value={formatDateTime(item.start_time)} />
+            <FieldText label="종료" value={formatDateTime(item.end_time)} />
+            <FieldText label="장소" value={item.location} />
+            <FieldText label="설명" value={item.description} />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+const ApiResponsePreview = ({ data }: { data: DataRecord }) => {
+  const responseData = data.data;
+  const itemCount =
+    isRecord(responseData) && Array.isArray(responseData.items)
+      ? responseData.items.length
+      : null;
+
+  return (
+    <SummaryCard
+      title="API 응답"
+      description={
+        itemCount !== null
+          ? `${itemCount}개 항목이 포함된 응답입니다.`
+          : "외부 서비스에서 받은 응답 데이터입니다."
+      }
+    >
+      <FieldText label="출처" value={data.source} />
+    </SummaryCard>
+  );
+};
+
+const OutputPreview = ({ data }: { data: DataRecord }) => (
+  <SummaryCard
+    title="전송 예정 데이터"
+    description="미리보기용 결과이며 실제 전송은 수행되지 않았습니다."
+  >
+    <FieldText label="서비스" value={data.service} />
+    <FieldText label="작업" value={data.action} />
+  </SummaryCard>
+);
+
+const GenericPreview = ({ data }: { data: unknown }) => {
   if (typeof data === "string") {
-    return {
-      title: "텍스트 데이터",
-      description: data,
-    };
+    return <SummaryCard title="텍스트" description={truncateText(data)} />;
   }
 
   if (Array.isArray(data)) {
-    return {
-      title: `${data.length}개 항목`,
-      description: "목록 형태의 데이터입니다.",
-    };
+    return (
+      <SummaryCard
+        title={`${data.length}개 항목`}
+        description="목록 형태의 데이터입니다."
+      />
+    );
   }
 
-  const entries = getRecordEntries(data);
-  if (entries.length > 0) {
-    return {
-      title: "데이터 묶음",
-      description: `${entries.length}개 항목으로 구성된 데이터입니다.`,
-    };
+  if (isRecord(data)) {
+    const entries = Object.entries(data);
+
+    return (
+      <SummaryCard
+        title="데이터 묶음"
+        description={`${entries.length}개 항목으로 구성된 데이터입니다.`}
+      />
+    );
   }
 
-  return {
-    title: "데이터",
-    description: "표시할 수 있는 데이터가 있습니다.",
-  };
+  return (
+    <SummaryCard
+      title="데이터"
+      description="표시할 수 있는 데이터가 있습니다."
+    />
+  );
+};
+
+const CanonicalPreview = ({ data }: { data: unknown }) => {
+  if (!isRecord(data)) {
+    return <GenericPreview data={data} />;
+  }
+
+  switch (getPayloadType(data)) {
+    case "FILE_LIST":
+      return <FileListPreview data={data} />;
+    case "SINGLE_FILE":
+      return <SingleFilePreview data={data} />;
+    case "TEXT":
+      return <TextPreview data={data} />;
+    case "EMAIL_LIST":
+      return <EmailListPreview data={data} />;
+    case "SINGLE_EMAIL":
+      return <SingleEmailPreview data={data} />;
+    case "SPREADSHEET_DATA":
+      return <SpreadsheetPreview data={data} />;
+    case "SCHEDULE_DATA":
+      return <SchedulePreview data={data} />;
+    case "API_RESPONSE":
+      return <ApiResponsePreview data={data} />;
+    case "OUTPUT_PREVIEW":
+      return <OutputPreview data={data} />;
+    default:
+      return <GenericPreview data={data} />;
+  }
 };
 
 export const DataPreviewBlock = ({
   title = "데이터 미리보기",
   data,
 }: Props) => {
-  const previewSummary = getPreviewSummary(data);
   const previewText = formatPreviewData(data);
+  const payloadType = getPayloadType(data);
+  const payloadLabel = payloadType ? getDisplayTypeLabel(payloadType) : null;
 
   return (
-    <Box display="flex" flexDirection="column" gap={2}>
-      <Text fontSize="md" fontWeight="bold">
-        {title}
-      </Text>
-
-      <Box
-        px={4}
-        py={3}
-        borderRadius="xl"
-        bg="gray.50"
-        border="1px solid"
-        borderColor="gray.100"
-      >
-        <Text fontSize="sm" fontWeight="semibold">
-          {previewSummary.title}
+    <Box display="flex" flexDirection="column" gap={3}>
+      <Box>
+        <Text fontSize="md" fontWeight="bold">
+          {title}
         </Text>
-        <Text color="text.secondary" fontSize="sm" mt={1} whiteSpace="pre-wrap">
-          {previewSummary.description}
-        </Text>
+        {payloadLabel ? (
+          <Text mt={1} fontSize="xs" color="text.secondary">
+            {payloadLabel}
+          </Text>
+        ) : null}
       </Box>
+
+      <CanonicalPreview data={data} />
 
       <Box as="details" color="text.secondary" fontSize="xs">
         <Box as="summary" cursor="pointer" px={1} py={1}>

--- a/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
+++ b/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
@@ -5,11 +5,12 @@ type Props = {
   data: unknown;
 };
 
-const formatPreviewData = (data: unknown) => {
-  if (typeof data === "string") {
-    return data;
-  }
+const getRecordEntries = (data: unknown) =>
+  data && typeof data === "object" && !Array.isArray(data)
+    ? Object.entries(data as Record<string, unknown>)
+    : [];
 
+const formatPreviewData = (data: unknown) => {
   try {
     return JSON.stringify(data, null, 2);
   } catch {
@@ -17,10 +18,40 @@ const formatPreviewData = (data: unknown) => {
   }
 };
 
+const getPreviewSummary = (data: unknown) => {
+  if (typeof data === "string") {
+    return {
+      title: "텍스트 데이터",
+      description: data,
+    };
+  }
+
+  if (Array.isArray(data)) {
+    return {
+      title: `${data.length}개 항목`,
+      description: "목록 형태의 데이터입니다.",
+    };
+  }
+
+  const entries = getRecordEntries(data);
+  if (entries.length > 0) {
+    return {
+      title: "데이터 묶음",
+      description: `${entries.length}개 항목으로 구성된 데이터입니다.`,
+    };
+  }
+
+  return {
+    title: "데이터",
+    description: "표시할 수 있는 데이터가 있습니다.",
+  };
+};
+
 export const DataPreviewBlock = ({
   title = "데이터 미리보기",
   data,
 }: Props) => {
+  const previewSummary = getPreviewSummary(data);
   const previewText = formatPreviewData(data);
 
   return (
@@ -28,23 +59,44 @@ export const DataPreviewBlock = ({
       <Text fontSize="md" fontWeight="bold">
         {title}
       </Text>
+
       <Box
-        as="pre"
-        maxH="260px"
-        overflow="auto"
         px={4}
         py={3}
         borderRadius="xl"
         bg="gray.50"
         border="1px solid"
         borderColor="gray.100"
-        color="gray.700"
-        fontSize="xs"
-        lineHeight="1.6"
-        whiteSpace="pre-wrap"
-        wordBreak="break-word"
       >
-        {previewText}
+        <Text fontSize="sm" fontWeight="semibold">
+          {previewSummary.title}
+        </Text>
+        <Text color="text.secondary" fontSize="sm" mt={1} whiteSpace="pre-wrap">
+          {previewSummary.description}
+        </Text>
+      </Box>
+
+      <Box as="details" color="text.secondary" fontSize="xs">
+        <Box as="summary" cursor="pointer" px={1} py={1}>
+          상세 데이터 보기
+        </Box>
+        <Box
+          as="pre"
+          maxH="260px"
+          overflow="auto"
+          px={4}
+          py={3}
+          borderRadius="xl"
+          bg="gray.50"
+          border="1px solid"
+          borderColor="gray.100"
+          color="gray.700"
+          lineHeight="1.6"
+          whiteSpace="pre-wrap"
+          wordBreak="break-word"
+        >
+          {previewText}
+        </Box>
       </Box>
     </Box>
   );

--- a/src/widgets/node-data-panel/ui/NodeExecutionStatusBlock.tsx
+++ b/src/widgets/node-data-panel/ui/NodeExecutionStatusBlock.tsx
@@ -2,27 +2,44 @@ import { Box, Text } from "@chakra-ui/react";
 
 import { type ExecutionNodeData } from "@/entities";
 
+import { getExecutionStatusNotice } from "../model";
+
 type Props = {
   executionData: ExecutionNodeData | null;
 };
 
 export const NodeExecutionStatusBlock = ({ executionData }: Props) => {
-  if (!executionData) {
+  const notice = getExecutionStatusNotice(executionData);
+
+  if (!notice) {
     return null;
   }
+
+  const isError = notice.tone === "error";
 
   return (
     <Box display="flex" flexDirection="column" gap={1}>
       <Text fontSize="md" fontWeight="bold">
-        노드 상태
+        실행 상태
       </Text>
-      <Box px={4} py={3} borderRadius="xl" bg="gray.50">
-        <Text fontSize="sm" fontWeight="semibold">
-          {executionData.status ?? executionData.reason ?? "상태 없음"}
+      <Box
+        px={4}
+        py={3}
+        borderRadius="xl"
+        bg={isError ? "red.50" : "orange.50"}
+        border="1px solid"
+        borderColor={isError ? "red.100" : "orange.100"}
+      >
+        <Text
+          fontSize="sm"
+          fontWeight="semibold"
+          color={isError ? "red.500" : "orange.600"}
+        >
+          {notice.title}
         </Text>
-        {executionData.reason ? (
+        {notice.description ? (
           <Text mt={1} fontSize="xs" color="text.secondary">
-            {executionData.reason}
+            {notice.description}
           </Text>
         ) : null}
       </Box>

--- a/src/widgets/node-data-panel/ui/SchemaPreviewBlock.tsx
+++ b/src/widgets/node-data-panel/ui/SchemaPreviewBlock.tsx
@@ -1,6 +1,10 @@
 import { Box, Text } from "@chakra-ui/react";
 
-import { type SchemaPreviewResponse } from "@/entities";
+import {
+  type SchemaPreviewResponse,
+  getSchemaTypeLabel,
+  getSchemaValueTypeLabel,
+} from "@/entities";
 
 type Props = {
   title?: string;
@@ -8,11 +12,14 @@ type Props = {
 };
 
 const getSchemaTitle = (schema: SchemaPreviewResponse | null) => {
-  if (!schema || schema.schema_type === "UNKNOWN") {
-    return "스키마 미정";
+  if (!schema) {
+    return "데이터 구조 미정";
   }
 
-  return schema.schema_type;
+  const schemaTitle = getSchemaTypeLabel(schema.schema_type) ?? "데이터 구조";
+  const listLabel = schema.is_list ? "목록" : null;
+
+  return [schemaTitle, listLabel].filter(Boolean).join(" · ");
 };
 
 export const SchemaPreviewBlock = ({
@@ -29,42 +36,48 @@ export const SchemaPreviewBlock = ({
         </Text>
         <Text mt={1} fontSize="sm" color="text.secondary">
           {getSchemaTitle(schema)}
-          {schema?.is_list ? " · 목록" : ""}
         </Text>
       </Box>
 
       {fields.length > 0 ? (
         <Box display="flex" flexDirection="column" gap={2}>
-          {fields.map((field) => (
-            <Box
-              key={field.key}
-              display="flex"
-              justifyContent="space-between"
-              gap={3}
-              px={4}
-              py={3}
-              borderRadius="xl"
-              bg="gray.50"
-            >
-              <Box minW={0}>
-                <Text fontSize="sm" fontWeight="semibold">
-                  {field.label || field.key}
-                </Text>
-                <Text fontSize="xs" color="text.secondary">
-                  {field.key}
-                </Text>
+          {fields.map((field) => {
+            const valueTypeLabel = getSchemaValueTypeLabel(field.value_type);
+
+            return (
+              <Box
+                key={field.key}
+                display="flex"
+                justifyContent="space-between"
+                gap={3}
+                px={4}
+                py={3}
+                borderRadius="xl"
+                bg="gray.50"
+              >
+                <Box minW={0}>
+                  <Text fontSize="sm" fontWeight="semibold">
+                    {field.label || "항목"}
+                  </Text>
+                  {valueTypeLabel ? (
+                    <Text fontSize="xs" color="text.secondary" mt={1}>
+                      {valueTypeLabel}
+                    </Text>
+                  ) : null}
+                </Box>
+                {field.required ? (
+                  <Text flexShrink={0} fontSize="xs" color="text.secondary">
+                    필수
+                  </Text>
+                ) : null}
               </Box>
-              <Text flexShrink={0} fontSize="xs" color="text.secondary">
-                {field.value_type}
-                {field.required ? " · 필수" : ""}
-              </Text>
-            </Box>
-          ))}
+            );
+          })}
         </Box>
       ) : (
         <Box px={4} py={3} borderRadius="xl" bg="gray.50">
           <Text fontSize="sm" color="text.secondary">
-            표시할 필드 정보가 없습니다.
+            표시할 수 있는 항목 정보가 없습니다.
           </Text>
         </Box>
       )}

--- a/src/widgets/node-data-panel/ui/SourceSummaryBlock.tsx
+++ b/src/widgets/node-data-panel/ui/SourceSummaryBlock.tsx
@@ -2,13 +2,12 @@ import { Box, Text } from "@chakra-ui/react";
 
 import { type SourceConfigSummaryResponse } from "@/entities";
 
+import { getSourceSummaryDescription, getSourceSummaryRows } from "../model";
+
 type Props = {
   config: Record<string, unknown> | null;
   source: SourceConfigSummaryResponse | null;
 };
-
-const getStringValue = (value: unknown) =>
-  typeof value === "string" && value.trim().length > 0 ? value : null;
 
 const SummaryRow = ({ label, value }: { label: string; value: string }) => (
   <Box bg="gray.50" borderRadius="xl" px={4} py={3}>
@@ -22,31 +21,8 @@ const SummaryRow = ({ label, value }: { label: string; value: string }) => (
 );
 
 export const SourceSummaryBlock = ({ config, source }: Props) => {
-  const serviceLabel =
-    source?.serviceLabel ??
-    source?.service ??
-    getStringValue(config?.service) ??
-    null;
-  const modeLabel =
-    source?.modeLabel ?? source?.mode ?? getStringValue(config?.source_mode);
-  const targetLabel =
-    source?.targetLabel ??
-    getStringValue(config?.target_label) ??
-    source?.target ??
-    getStringValue(config?.target);
-  const canonicalInputType =
-    source?.canonicalInputType ?? getStringValue(config?.canonical_input_type);
-  const triggerKind =
-    source?.triggerKind ?? getStringValue(config?.trigger_kind);
-  const rows = [
-    serviceLabel ? { label: "서비스", value: serviceLabel } : null,
-    modeLabel ? { label: "가져오는 방식", value: modeLabel } : null,
-    targetLabel ? { label: "선택한 대상", value: targetLabel } : null,
-    canonicalInputType
-      ? { label: "입력 데이터 타입", value: canonicalInputType }
-      : null,
-    triggerKind ? { label: "트리거", value: triggerKind } : null,
-  ].filter((row): row is { label: string; value: string } => row !== null);
+  const rows = getSourceSummaryRows({ config, source });
+  const description = getSourceSummaryDescription({ config, source });
 
   if (rows.length === 0) {
     return null;
@@ -59,7 +35,7 @@ export const SourceSummaryBlock = ({ config, source }: Props) => {
           가져오는 데이터
         </Text>
         <Text color="text.secondary" fontSize="sm" mt={1}>
-          시작 노드 설정을 기준으로 예상되는 입력 출처입니다.
+          {description}
         </Text>
       </Box>
 

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { MdCancel } from "react-icons/md";
 
-import { Box, Icon, Spinner, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Icon, Spinner, Text, VStack } from "@chakra-ui/react";
 
 import { NODE_REGISTRY } from "@/entities/node";
 import {
@@ -343,9 +343,35 @@ export const OutputPanel = ({ wizardController }: Props) => {
                 nodeDataPanel.isStaleAgainstCurrentEditor
               }
             />
+            <Box display="flex" flexDirection="column" gap={2}>
+              <Button
+                alignSelf="flex-start"
+                size="sm"
+                variant="outline"
+                loading={nodeDataPanel.isPreviewLoading}
+                disabled={!nodeDataPanel.canRequestPreview}
+                onClick={nodeDataPanel.requestPreview}
+              >
+                실행 전 미리보기
+              </Button>
+              {isDirty ? (
+                <Text fontSize="xs" color="orange.500">
+                  저장 후 미리보기를 확인할 수 있습니다.
+                </Text>
+              ) : null}
+              {nodeDataPanel.previewErrorMessage ? (
+                <Text fontSize="xs" color="red.500">
+                  {nodeDataPanel.previewErrorMessage}
+                </Text>
+              ) : null}
+            </Box>
             {hasPreviewData ? (
               <DataPreviewBlock
-                title="출력 데이터"
+                title={
+                  nodeDataPanel.isPreviewDataDisplayed
+                    ? "미리보기 데이터"
+                    : "출력 데이터"
+                }
                 data={nodeDataPanel.dataToDisplay}
               />
             ) : null}

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -343,28 +343,30 @@ export const OutputPanel = ({ wizardController }: Props) => {
                 nodeDataPanel.isStaleAgainstCurrentEditor
               }
             />
-            <Box display="flex" flexDirection="column" gap={2}>
-              <Button
-                alignSelf="flex-start"
-                size="sm"
-                variant="outline"
-                loading={nodeDataPanel.isPreviewLoading}
-                disabled={!nodeDataPanel.canRequestPreview}
-                onClick={nodeDataPanel.requestPreview}
-              >
-                실행 전 미리보기
-              </Button>
-              {isDirty ? (
-                <Text fontSize="xs" color="orange.500">
-                  저장 후 미리보기를 확인할 수 있습니다.
-                </Text>
-              ) : null}
-              {nodeDataPanel.previewErrorMessage ? (
-                <Text fontSize="xs" color="red.500">
-                  {nodeDataPanel.previewErrorMessage}
-                </Text>
-              ) : null}
-            </Box>
+            {nodeDataPanel.isPreviewSupported ? (
+              <Box display="flex" flexDirection="column" gap={2}>
+                <Button
+                  alignSelf="flex-start"
+                  size="sm"
+                  variant="outline"
+                  loading={nodeDataPanel.isPreviewLoading}
+                  disabled={!nodeDataPanel.canRequestPreview}
+                  onClick={nodeDataPanel.requestPreview}
+                >
+                  실행 전 미리보기
+                </Button>
+                {isDirty ? (
+                  <Text fontSize="xs" color="orange.500">
+                    저장 후 미리보기를 확인할 수 있습니다.
+                  </Text>
+                ) : null}
+                {nodeDataPanel.previewErrorMessage ? (
+                  <Text fontSize="xs" color="red.500">
+                    {nodeDataPanel.previewErrorMessage}
+                  </Text>
+                ) : null}
+              </Box>
+            ) : null}
             {hasPreviewData ? (
               <DataPreviewBlock
                 title={


### PR DESCRIPTION
## 요약 (Summary)

실행 전 노드 데이터 미리보기 범위를 시작 노드 중심으로 정리했습니다.  
현재 지원 가능한 소스 노드 preview만 노출하고, 중간/도착 노드 dry-run preview는 후속 범위로 분리했습니다.

## 주요 변경 사항 (Key Changes)

- 시작 노드에서 실행 전 소스 데이터 미리보기 요청 연결
- 중간/도착 노드에서는 미지원 preview CTA 숨김 처리
- 노드 데이터 패널에 preview 가능 여부 상태 추가
- Spring/FastAPI preview 계약에 맞춰 설계 문서 보정

## 상세 구현 내용 (Implementation Details)

- `useNodeDataPanelModel`
  - `isPreviewSupported` 추가
  - 현재는 `startNodeId` 기준으로 시작 노드만 preview 지원
  - 저장되지 않은 변경이 있으면 preview 요청 비활성화

- `InputPanel`, `OutputPanel`
  - preview 지원 노드에서만 미리보기 버튼, 저장 필요 안내, preview 오류 표시
  - 미지원 노드에서는 기존 실행 결과/스키마 표시 흐름 유지

- 설계 문서
  - 1차 범위를 source/start preview로 제한
  - middle/output dry-run preview는 후속 작업으로 명시
  - Spring/FastAPI 응답 계약과 토큰 수집 범위 반영

## 트러블 슈팅 (Trouble Shooting)

- 중간/도착 노드 preview까지 한 번에 열 경우 OAuth, 토큰 수집, dry-run 실행 범위가 과도하게 커지는 문제가 있었습니다.
- 따라서 현재 구현은 시작 노드 preview만 먼저 안정화하고, 처리 노드 dry-run은 별도 이슈로 분리했습니다.

## 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- preview `metadata` key가 Spring 직접 응답과 FastAPI 응답에서 일부 다릅니다.
  - Spring: `includeContent`, `previewScope`
  - FastAPI: `include_content`, `preview_scope`
  - 현재 프론트는 해당 metadata에 의존하지 않아 기능 영향은 없습니다.
- 중간 처리 노드의 “설정에 따른 나가는 데이터” preview는 후속 dry-run 작업에서 처리합니다.

## 스크린샷 (Screenshots)

> 필요 시 PR 본문에 첨부

## 관련 이슈 (Related Issues)

- #140 
