### PR TITLE
Feat#163 more menu

### DIFF
--- a/src/entities/node/ui/BaseNode.tsx
+++ b/src/entities/node/ui/BaseNode.tsx
@@ -169,7 +169,15 @@ export const BaseNode = ({ id, data, selected, children }: BaseNodeProps) => {
       ) : null}
 
       {shouldShowNodeMenu ? (
-        <Box position="absolute" top={1} right={1} zIndex={1}>
+        <Box
+          className="nodrag nopan"
+          position="absolute"
+          top={1}
+          right={1}
+          zIndex={1}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
           <NodeMoreMenuButton
             open={isMenuOpen}
             onOpenChange={setIsMenuOpen}

--- a/src/entities/node/ui/BaseNode.tsx
+++ b/src/entities/node/ui/BaseNode.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { type MouseEvent, type ReactNode } from "react";
-import { MdCancel } from "react-icons/md";
+import { type ReactNode } from "react";
 
-import { Box, IconButton, Text } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import { Handle, Position } from "@xyflow/react";
 
 import { getNodeStatusSummaryLabel } from "@/entities/workflow";
@@ -12,6 +11,7 @@ import { getNodePresentation } from "../model";
 import { type FlowNodeData } from "../model/types";
 
 import { useNodeEditorContext } from "./NodeEditorContext";
+import { NodeMoreMenuButton } from "./NodeMoreMenuButton";
 
 interface BaseNodeProps {
   id: string;
@@ -59,7 +59,7 @@ const getNodeSourceMode = (data: FlowNodeData) => {
   return typeof config.source_mode === "string" ? config.source_mode : null;
 };
 
-export const BaseNode = ({ id, data, children }: BaseNodeProps) => {
+export const BaseNode = ({ id, data, selected, children }: BaseNodeProps) => {
   const {
     canEditNodes,
     endNodeIds,
@@ -69,7 +69,9 @@ export const BaseNode = ({ id, data, children }: BaseNodeProps) => {
     startNodeId,
   } = useNodeEditorContext();
   const [isHovered, setIsHovered] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const nodeStatus = getNodeStatus(id);
+  const isSelected = Boolean(selected);
 
   const presentation = getNodePresentation(data, {
     nodeId: id,
@@ -87,6 +89,8 @@ export const BaseNode = ({ id, data, children }: BaseNodeProps) => {
   const showNodeIcon = nodeStatus?.configured ?? data.config.isConfigured;
   const serviceKey = getNodeServiceKey(data);
   const sourceMode = getNodeSourceMode(data);
+  const shouldShowNodeMenu =
+    canEditNodes && (isHovered || isSelected || isMenuOpen);
 
   const renderNodeIcon = () => {
     if (!showNodeIcon) {
@@ -108,8 +112,8 @@ export const BaseNode = ({ id, data, children }: BaseNodeProps) => {
     onOpenPanel(id);
   };
 
-  const handleRemoveNode = (event: MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
+  const handleRemoveNode = () => {
+    setIsMenuOpen(false);
     onRemoveNode(id);
   };
 
@@ -164,18 +168,14 @@ export const BaseNode = ({ id, data, children }: BaseNodeProps) => {
         </Box>
       ) : null}
 
-      {isHovered && canEditNodes ? (
-        <IconButton
-          aria-label="노드 삭제"
-          size="xs"
-          position="absolute"
-          top={1}
-          right={1}
-          variant="ghost"
-          onClick={handleRemoveNode}
-        >
-          <MdCancel />
-        </IconButton>
+      {shouldShowNodeMenu ? (
+        <Box position="absolute" top={1} right={1} zIndex={1}>
+          <NodeMoreMenuButton
+            open={isMenuOpen}
+            onOpenChange={setIsMenuOpen}
+            onDelete={handleRemoveNode}
+          />
+        </Box>
       ) : null}
 
       <Handle

--- a/src/entities/node/ui/NodeMoreMenuButton.tsx
+++ b/src/entities/node/ui/NodeMoreMenuButton.tsx
@@ -1,0 +1,79 @@
+import { MdDeleteOutline, MdMoreHoriz } from "react-icons/md";
+
+import { Button, Icon, Menu, Portal, Text } from "@chakra-ui/react";
+
+type NodeMoreMenuButtonProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+};
+
+export const NodeMoreMenuButton = ({
+  open,
+  onOpenChange,
+  onDelete,
+}: NodeMoreMenuButtonProps) => (
+  <Menu.Root
+    lazyMount
+    unmountOnExit
+    open={open}
+    positioning={{ placement: "bottom-end" }}
+    onOpenChange={(details) => onOpenChange(details.open)}
+  >
+    <Menu.Trigger asChild>
+      <Button
+        type="button"
+        aria-label="노드 메뉴 열기"
+        title="노드 메뉴"
+        className="nodrag nopan"
+        height="26px"
+        minW="26px"
+        px={0}
+        bg="bg.surface"
+        color="text.primary"
+        border="1px solid"
+        borderColor="border.default"
+        borderRadius="lg"
+        flexShrink={0}
+        _hover={{ bg: "bg.overlay", borderColor: "border.strong" }}
+        _active={{ bg: "neutral.200" }}
+        _expanded={{ bg: "bg.overlay", borderColor: "border.strong" }}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Icon as={MdMoreHoriz} boxSize={4} />
+      </Button>
+    </Menu.Trigger>
+
+    <Portal>
+      <Menu.Positioner zIndex={30}>
+        <Menu.Content
+          className="nodrag nopan"
+          minW="128px"
+          p={1.5}
+          bg="bg.surface"
+          border="1px solid"
+          borderRadius="xl"
+          borderColor="border.default"
+          boxShadow="lg"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Menu.Item
+            value="delete"
+            color="status.error"
+            onSelect={() => {
+              onOpenChange(false);
+              onDelete();
+            }}
+          >
+            <Icon as={MdDeleteOutline} boxSize={4} />
+            <Text as="span" fontSize="sm">
+              삭제
+            </Text>
+          </Menu.Item>
+        </Menu.Content>
+      </Menu.Positioner>
+    </Portal>
+  </Menu.Root>
+);

--- a/src/pages/workflows/ui/WorkflowRow.tsx
+++ b/src/pages/workflows/ui/WorkflowRow.tsx
@@ -4,9 +4,9 @@ import {
   type SyntheticEvent,
 } from "react";
 import {
+  MdDeleteOutline,
   MdErrorOutline,
   MdMoreHoriz,
-  MdOpenInNew,
   MdPlayArrow,
   MdStop,
 } from "react-icons/md";
@@ -47,9 +47,12 @@ type Props = {
   executionActionKind: "run" | "stop";
   executionActionLabel: string;
   isExecutionActionPending: boolean;
+  canDelete: boolean;
+  isDeletePending: boolean;
   onOpen: () => void;
   onAutoRunToggle: () => void;
   onExecutionAction: () => void;
+  onDelete: () => void;
 };
 
 const AUTO_RUN_BUTTON_STYLES: Record<
@@ -90,9 +93,12 @@ export const WorkflowRow = ({
   executionActionKind,
   executionActionLabel,
   isExecutionActionPending,
+  canDelete,
+  isDeletePending,
   onOpen,
   onAutoRunToggle,
   onExecutionAction,
+  onDelete,
 }: Props) => {
   const { startNode, endNode } = getEndpointNodes(workflow);
   const startBadgeKey = getServiceBadgeKey(startNode);
@@ -102,6 +108,8 @@ export const WorkflowRow = ({
   const warningMessages = getWorkflowWarningMessages(workflow);
   const autoRunButtonStyle = AUTO_RUN_BUTTON_STYLES[autoRunKind];
   const shouldShowAutoRunButton = autoRunKind !== "manual";
+  const isAutoRunActionDisabled = isDeletePending || isAutoRunPending;
+  const isExecutionButtonDisabled = isDeletePending || isExecutionActionPending;
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter" || event.key === " ") {
@@ -190,12 +198,15 @@ export const WorkflowRow = ({
               color={autoRunButtonStyle.color}
               border={autoRunButtonStyle.border}
               opacity={isAutoRunToggleable || isAutoRunPending ? 1 : 0.72}
+              disabled={isAutoRunActionDisabled}
               cursor={
-                isAutoRunToggleable && !isAutoRunPending ? "pointer" : "default"
+                isAutoRunToggleable && !isAutoRunActionDisabled
+                  ? "pointer"
+                  : "default"
               }
               _hover={{
                 bg:
-                  isAutoRunToggleable && !isAutoRunPending
+                  isAutoRunToggleable && !isAutoRunActionDisabled
                     ? autoRunButtonStyle.hoverBg
                     : autoRunButtonStyle.bg,
               }}
@@ -212,7 +223,7 @@ export const WorkflowRow = ({
             aria-label={executionActionLabel}
             variant="ghost"
             size="sm"
-            disabled={isExecutionActionPending}
+            disabled={isExecutionButtonDisabled}
             onClick={(event) => handleInnerAction(event, onExecutionAction)}
           >
             {isExecutionActionPending ? (
@@ -257,10 +268,15 @@ export const WorkflowRow = ({
                   onClick={handleMenuEvent}
                   onKeyDown={handleMenuEvent}
                 >
-                  <Menu.Item value="open" onSelect={onOpen}>
-                    <Icon as={MdOpenInNew} boxSize={4} />
+                  <Menu.Item
+                    value="delete"
+                    color="status.error"
+                    disabled={!canDelete || isDeletePending}
+                    onSelect={onDelete}
+                  >
+                    <Icon as={MdDeleteOutline} boxSize={4} />
                     <Text as="span" fontSize="sm">
-                      워크플로우 열기
+                      {isDeletePending ? "삭제 중..." : "삭제"}
                     </Text>
                   </Menu.Item>
                 </Menu.Content>

--- a/src/pages/workflows/ui/WorkflowRow.tsx
+++ b/src/pages/workflows/ui/WorkflowRow.tsx
@@ -1,7 +1,12 @@
-import { type KeyboardEvent, type MouseEvent } from "react";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  type SyntheticEvent,
+} from "react";
 import {
   MdErrorOutline,
   MdMoreHoriz,
+  MdOpenInNew,
   MdPlayArrow,
   MdStop,
 } from "react-icons/md";
@@ -13,6 +18,8 @@ import {
   HStack,
   Icon,
   IconButton,
+  Menu,
+  Portal,
   Spinner,
   Text,
   VStack,
@@ -109,6 +116,10 @@ export const WorkflowRow = ({
   ) => {
     event.stopPropagation();
     action();
+  };
+
+  const handleMenuEvent = (event: SyntheticEvent<HTMLElement>) => {
+    event.stopPropagation();
   };
 
   return (
@@ -212,14 +223,50 @@ export const WorkflowRow = ({
               <MdPlayArrow />
             )}
           </IconButton>
-          <IconButton
-            aria-label="워크플로우 상세 보기"
-            variant="ghost"
-            size="sm"
-            onClick={(event) => handleInnerAction(event, onOpen)}
+          <Menu.Root
+            lazyMount
+            unmountOnExit
+            positioning={{ placement: "bottom-end" }}
           >
-            <MdMoreHoriz />
-          </IconButton>
+            <Menu.Trigger asChild>
+              <IconButton
+                type="button"
+                aria-label="워크플로우 메뉴 열기"
+                title="워크플로우 메뉴"
+                variant="ghost"
+                size="sm"
+                onPointerDown={handleMenuEvent}
+                onClick={handleMenuEvent}
+                onKeyDown={handleMenuEvent}
+              >
+                <MdMoreHoriz />
+              </IconButton>
+            </Menu.Trigger>
+
+            <Portal>
+              <Menu.Positioner zIndex={20}>
+                <Menu.Content
+                  minW="148px"
+                  p={1.5}
+                  bg="bg.surface"
+                  border="1px solid"
+                  borderRadius="xl"
+                  borderColor="border.default"
+                  boxShadow="lg"
+                  onPointerDown={handleMenuEvent}
+                  onClick={handleMenuEvent}
+                  onKeyDown={handleMenuEvent}
+                >
+                  <Menu.Item value="open" onSelect={onOpen}>
+                    <Icon as={MdOpenInNew} boxSize={4} />
+                    <Text as="span" fontSize="sm">
+                      워크플로우 열기
+                    </Text>
+                  </Menu.Item>
+                </Menu.Content>
+              </Menu.Positioner>
+            </Portal>
+          </Menu.Root>
         </HStack>
       </Flex>
 

--- a/src/pages/workflows/ui/WorkflowRowItem.tsx
+++ b/src/pages/workflows/ui/WorkflowRowItem.tsx
@@ -1,5 +1,10 @@
-import { type WorkflowResponse } from "@/entities/workflow";
+import {
+  type WorkflowResponse,
+  useDeleteWorkflowMutation,
+} from "@/entities/workflow";
 import { useWorkflowExecutionAction } from "@/features/workflow-execution";
+import { getAuthUser } from "@/shared";
+import { getApiErrorMessage, toaster } from "@/shared/utils";
 
 import { useWorkflowListAutoRunAction } from "../model";
 
@@ -11,8 +16,16 @@ type Props = {
 };
 
 export const WorkflowRowItem = ({ workflow, onOpen }: Props) => {
+  const viewerUserId = getAuthUser()?.id ?? null;
+  const canDeleteWorkflow = Boolean(
+    viewerUserId && workflow.userId === viewerUserId,
+  );
   const { actionKind, actionLabel, isActionPending, handleAction } =
     useWorkflowExecutionAction(workflow.id);
+  const { mutateAsync: deleteWorkflow, isPending: isDeletePending } =
+    useDeleteWorkflowMutation({
+      showErrorToast: false,
+    });
   const {
     autoRunKind,
     autoRunLabel,
@@ -20,6 +33,27 @@ export const WorkflowRowItem = ({ workflow, onOpen }: Props) => {
     isAutoRunPending,
     handleToggleAutoRun,
   } = useWorkflowListAutoRunAction(workflow);
+
+  const handleDeleteWorkflow = async () => {
+    if (!canDeleteWorkflow || isDeletePending) {
+      return;
+    }
+
+    try {
+      await deleteWorkflow(workflow.id);
+      toaster.create({
+        type: "success",
+        title: "워크플로우 삭제 완료",
+        description: "워크플로우가 목록에서 제거되었습니다.",
+      });
+    } catch (error) {
+      toaster.create({
+        type: "error",
+        title: "워크플로우 삭제 실패",
+        description: getApiErrorMessage(error),
+      });
+    }
+  };
 
   return (
     <WorkflowRow
@@ -31,9 +65,12 @@ export const WorkflowRowItem = ({ workflow, onOpen }: Props) => {
       executionActionKind={actionKind}
       executionActionLabel={actionLabel}
       isExecutionActionPending={isActionPending}
+      canDelete={canDeleteWorkflow}
+      isDeletePending={isDeletePending}
       onOpen={onOpen}
       onAutoRunToggle={() => void handleToggleAutoRun()}
       onExecutionAction={() => void handleAction()}
+      onDelete={() => void handleDeleteWorkflow()}
     />
   );
 };


### PR DESCRIPTION
## 📝 요약 (Summary)

워크플로우 편집 화면의 노드 삭제 액션을 기존 직접 삭제 버튼에서 `... -> 삭제` 메뉴 흐름으로 변경했습니다.  
추가로 워크플로우 목록 row의 `...` 버튼도 편집 화면 이동이 아니라 `삭제` 메뉴를 열도록 수정해, 사용자가 명시적으로 삭제 액션을 선택할 수 있게 했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 노드 우측 상단 삭제 액션을 `NodeMoreMenuButton` 기반 `... -> 삭제` 메뉴로 변경
- 워크플로우 목록 row의 `...` 버튼 클릭 시 `삭제` 메뉴가 열리도록 수정
- 기존 노드/워크플로우 삭제 API, 캐시 갱신, toast 흐름은 그대로 유지
- 메뉴 클릭이 노드 패널 열기, row 이동, React Flow drag/pan으로 전파되지 않도록 이벤트 차단 처리
- 삭제 중인 워크플로우 row에서는 실행/자동 실행 토글 등 충돌 가능 액션을 비활성화

## 💻 상세 구현 내용 (Implementation Details)

### 노드 삭제 메뉴

- `src/entities/node/ui/NodeMoreMenuButton.tsx` 신규 추가
- Chakra `Menu.Root`, `Menu.Trigger asChild`, `Portal`, `Menu.Positioner`, `Menu.Content`, `Menu.Item` 구조 사용
- `MdMoreHoriz`, `MdDeleteOutline` 아이콘 사용
- trigger/content에 `nodrag nopan` 적용
- `onPointerDown`, `onClick`에서 `stopPropagation()` 처리

### BaseNode 연결

- `src/entities/node/ui/BaseNode.tsx`에서 기존 직접 삭제 `IconButton` 제거
- `isMenuOpen` 상태 추가
- 메뉴 노출 조건 추가

```ts
const shouldShowNodeMenu =
  canEditNodes && (isHovered || isSelected || isMenuOpen);
