### PR TITLE
feat: support document content runtime preview contract

### DIFF
--- a/docs/DOCUMENT_CONTENT_RUNTIME_FRONTEND_IMPLEMENTATION_DESIGN.md
+++ b/docs/DOCUMENT_CONTENT_RUNTIME_FRONTEND_IMPLEMENTATION_DESIGN.md
@@ -1,0 +1,442 @@
+# 문서 본문 런타임 FE 반영 설계
+
+> 작성일: 2026-05-14  
+> 브랜치: `feat#172-document_content_runtime`  
+> 기준 문서:
+> - `docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS_ANALYSIS.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_FASTAPI.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md`
+
+---
+
+## 1. 목적
+
+문서 본문 런타임 계약이 도입되면 FE는 파일 본문을 직접 읽지 않고, Spring/FastAPI가 내려주는 canonical payload의 content 상태를 정확히 표시해야 한다.
+
+이번 FE 설계의 목적은 다음과 같다.
+
+- `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment의 `content_status`, `content_error`, `content_metadata`를 타입/표시 계층에서 수용한다.
+- source preview, AI/content preview, 실제 실행 결과를 사용자가 구분할 수 있게 만든다.
+- 본문이 필요한 자동화에서 “파일은 받았지만 본문을 못 읽은 상태”가 빈 요약 성공처럼 보이지 않게 한다.
+- Spring/FastAPI가 full content를 sanitize/truncate해서 내려주는 정책을 FE가 표시할 수 있게 한다.
+
+---
+
+## 2. 현재 FE 코드 기준 분석
+
+### 2.1 Preview API 타입
+
+대상:
+
+- `src/entities/workflow/api/types.ts`
+- `src/entities/workflow/api/preview-workflow-node.api.ts`
+- `src/entities/workflow/model/useWorkflowNodePreviewMutation.ts`
+
+현재 `NodePreviewRequest`는 이미 `includeContent?: boolean`을 가진다. `NodePreviewResponse.metadata`는 `Record<string, unknown>`이라 `previewScope`, `contentPolicy`, `contentIncluded`, `contentStatusScope` 같은 신규 metadata를 타입 확장 없이도 받을 수 있다.
+
+다만 FE에서 metadata 의미를 읽는 helper가 없고, preview 요청은 항상 `includeContent: false`로 고정되어 있다.
+
+### 2.2 Node data panel
+
+대상:
+
+- `src/widgets/node-data-panel/model/useNodeDataPanelModel.ts`
+- `src/widgets/node-data-panel/model/node-data-panel-utils.ts`
+- `src/widgets/input-panel/ui/InputPanel.tsx`
+- `src/widgets/output-panel/ui/OutputPanel.tsx`
+
+현재 preview는 `isStartNode`일 때만 지원한다.
+
+```ts
+const isPreviewSupported = isStartNode;
+```
+
+따라서 source preview는 가능하지만 AI 노드 preview는 현재 UX 범위 밖이다. 요구사항에는 “LLM 노드 preview 요청 시 includeContent true”가 있지만, Spring 문서도 AI 노드 preview는 별도 구현 전까지 source-only로 둘 수 있다고 정리했다.
+
+1차 FE는 source preview 버튼을 유지하되, content metadata를 표시하고, Spring이 AI preview를 열면 같은 구조로 확장할 수 있게 설계한다.
+
+### 2.3 DataPreviewBlock
+
+대상:
+
+- `src/widgets/node-data-panel/ui/DataPreviewBlock.tsx`
+
+현재 `SINGLE_FILE`은 `content`가 있으면 본문 미리보기를 보여준다. `FILE_LIST`와 Gmail attachment는 filename/mime/size/url 중심이다.
+
+빠진 것:
+
+- `content_status` 표시
+- `content_error` 표시
+- `content_metadata.truncated`, `char_count`, `original_char_count`, `extraction_method`, `content_kind` 표시
+- `extracted_text` legacy fallback 표시
+- Gmail attachment content 상태 표시
+- preview metadata의 `contentPolicy` 표시
+
+### 2.4 실행 에러 문구
+
+대상:
+
+- `src/entities/execution/model/nodeRuntimeIssue.ts`
+- `src/widgets/node-data-panel/model/node-data-panel-display.ts`
+- `src/widgets/node-data-panel/ui/DataStateNotice.tsx`
+- `src/widgets/node-data-panel/ui/NodeExecutionStatusBlock.tsx`
+
+현재 실행 실패 문구는 OAuth, column, not found, empty, rate limit, external service 정도로 분류한다. 신규 `DOCUMENT_CONTENT_*` error code에 대한 사용자 문구는 없다.
+
+---
+
+## 3. FE 반영 범위
+
+### 3.1 1차 범위
+
+1차 FE 구현은 backend contract가 내려오는 것을 전제로 표시/요청/문구를 정리한다.
+
+- content 상태 타입과 helper 추가
+- `DataPreviewBlock`에서 파일/첨부 content 상태 표시
+- preview metadata 표시
+- source preview의 `includeContent` 정책 정리
+- `DOCUMENT_CONTENT_*` 실행 오류 문구 매핑
+- 관련 unit test 추가
+
+### 3.2 1차 제외
+
+- FE에서 파일 본문 직접 다운로드 또는 파싱
+- FE에서 OCR/문서 변환
+- AI 노드 preview API가 backend에 없는데 FE 단독으로 노출
+- full content를 FE가 임의로 복원하거나 별도 저장
+
+---
+
+## 4. 타입 및 helper 설계
+
+### 4.1 신규 모델 파일
+
+신규 파일 후보:
+
+- `src/widgets/node-data-panel/model/document-content.ts`
+
+역할:
+
+- content status 정규화
+- camelCase/snake_case metadata 동시 지원
+- 사용자 표시 문구 생성
+- file item, email attachment 공용 처리
+
+권장 타입:
+
+```ts
+export type DocumentContentStatus =
+  | "available"
+  | "empty"
+  | "unsupported"
+  | "too_large"
+  | "failed"
+  | "not_requested";
+
+export type DocumentContentKind =
+  | "plain_text"
+  | "table_text"
+  | "slide_text"
+  | "ocr_text"
+  | "image_description"
+  | "mixed"
+  | "none";
+
+export type DocumentContentMetadata = {
+  extractionMethod: string | null;
+  contentKind: DocumentContentKind | string | null;
+  truncated: boolean;
+  charCount: number | null;
+  originalCharCount: number | null;
+  storedContentTruncated: boolean;
+  storedCharCount: number | null;
+  limits: {
+    maxDownloadBytes: number | null;
+    maxExtractedChars: number | null;
+    maxLlmInputChars: number | null;
+  };
+};
+```
+
+helper:
+
+- `getDocumentContentStatus(record)`
+- `getDocumentContentError(record)`
+- `getDocumentContentMetadata(record)`
+- `getDocumentContentText(record)`
+- `getDocumentContentStatusLabel(status)`
+- `getDocumentContentStatusDescription(status, metadata)`
+- `isDocumentContentProblem(status)`
+- `isDocumentContentUnavailableForSummary(status)`
+
+helper는 Spring public API와 FastAPI raw response를 모두 수용하기 위해 snake_case와 camelCase를 함께 읽는다.
+
+- `content_status`, `contentStatus`
+- `content_error`, `contentError`
+- `content_metadata`, `contentMetadata`
+- `extraction_method`, `extractionMethod`
+- `content_kind`, `contentKind`
+- `original_char_count`, `originalCharCount`
+- `stored_content_truncated`, `storedContentTruncated`
+- `stored_char_count`, `storedCharCount`
+- `limits.max_download_bytes`, `limits.maxDownloadBytes`
+- `limits.max_extracted_chars`, `limits.maxExtractedChars`
+- `limits.max_llm_input_chars`, `limits.maxLlmInputChars`
+
+`getDocumentContentText`는 하위 호환을 위해 아래 순서로 읽는다.
+
+1. `content`
+2. `extracted_text`
+3. `extractedText`
+
+본문이 표시되더라도 `content_metadata.truncated=true` 또는 `stored_content_truncated=true`이면 전체 본문이 아니라 잘린 preview일 수 있음을 함께 표시한다.
+
+### 4.2 Preview metadata helper
+
+같은 파일 또는 별도 파일:
+
+- `src/widgets/node-data-panel/model/preview-content-policy.ts`
+
+읽을 필드:
+
+- `metadata.contentPolicy`
+- `metadata.content_policy`
+- `metadata.previewScope`
+- `metadata.preview_scope`
+- `metadata.contentIncluded`
+- `metadata.content_included`
+- `metadata.contentStatusScope`
+- `metadata.content_status_scope`
+
+표시 문구:
+
+| contentPolicy | 표시 |
+|---------------|------|
+| `metadata_only` | 본문 미포함 미리보기 |
+| `content_included` | 본문 포함 미리보기 |
+| `content_status_only` | 본문 상태만 포함 |
+| `required_by_downstream` | 다음 단계에서 본문 필요 |
+| `content_required_but_unavailable` | 본문 필요하지만 미포함 |
+
+백엔드 문서상 Spring은 `required_by_downstream`, FastAPI는 `content_required_but_unavailable`을 언급한다. FE는 1차에서 두 값을 모두 수용하되, 표시 문구는 아래처럼 구분한다.
+
+- `required_by_downstream`: 다음 단계에서 본문 필요
+- `content_required_but_unavailable`: 본문이 필요한 단계지만 현재 미리보기에는 본문이 포함되지 않음
+
+---
+
+## 5. UI 표시 설계
+
+### 5.1 파일 카드 상태 표시
+
+대상:
+
+- `FileItemCard`
+- `SingleFilePreview`
+- Gmail attachment 렌더링 경로
+
+현재 파일 카드는 filename, mime, size, modified date, link만 보여준다. 여기에 content 상태 행을 추가한다.
+
+표시 규칙:
+
+| status | tone | 문구 |
+|--------|------|------|
+| `available` | normal | 본문 읽기 완료 |
+| `empty` | warning | 읽을 수 있는 본문 없음 |
+| `unsupported` | warning | 지원하지 않는 파일 형식 |
+| `too_large` | warning | 파일 크기 제한 초과 |
+| `failed` | error | 본문 읽기 실패 |
+| `not_requested` | muted | 본문 미포함 |
+
+`content_error`가 있으면 상태 문구 아래에 짧게 표시한다. `content_metadata.truncated=true`이면 “본문 일부만 표시됨”을 함께 표시한다.
+
+`content_metadata.limits`가 있으면 상세 줄에는 제한값을 그대로 나열하지 않고, `too_large`나 truncate 상태일 때만 보조 문구에 사용한다.
+
+예:
+
+- `현재 처리 가능한 크기를 초과했습니다.`
+- `본문 일부만 표시됩니다.`
+- `실행 로그에는 일부 본문만 저장되었습니다.`
+
+### 5.2 본문 미리보기 표시
+
+`SingleFilePreview`는 `content`뿐 아니라 legacy `extracted_text`도 fallback으로 사용한다.
+
+본문 카드 조건:
+
+- status가 `available`이고 text가 있으면 `본문 미리보기` 표시
+- text가 있고 status가 없으면 기존 호환을 위해 표시
+- status가 `not_requested`이면 본문 카드를 만들지 않고 상태만 표시
+- status가 `unsupported|too_large|failed|empty`이면 본문 카드 대신 상태/오류 표시
+
+### 5.3 FILE_LIST 표시
+
+`FileListPreview`는 목록 요약 카드에 content 상태 집계를 추가한다.
+
+예:
+
+- `본문 읽기 완료 3개`
+- `본문 미포함 5개`
+- `읽기 실패 1개`
+
+개별 `FileItemCard`에서도 상태를 보여준다. 목록이 많을 경우 기존 `MAX_LIST_PREVIEW_COUNT` 제한은 유지한다.
+
+### 5.4 Gmail attachment 표시
+
+`SingleEmailPreview`는 attachments를 `FileItemCard`로 렌더링하고 있으므로, `FileItemCard`가 content status를 처리하면 Gmail attachment도 자동으로 상태 표시가 가능하다.
+
+추가로 attachment에 `content`가 있고 status가 `available`이면 카드 안에서 짧은 본문 preview를 240자 수준으로 표시한다. 메일 본문과 첨부 본문을 혼동하지 않도록 label은 `첨부 본문`으로 둔다.
+
+### 5.5 Preview metadata 표시
+
+`DataPreviewBlock`은 현재 payload 데이터만 받는다. preview metadata를 표시하려면 props 확장이 필요하다.
+
+권장 변경:
+
+```ts
+type Props = {
+  title?: string;
+  data: unknown;
+  previewMetadata?: Record<string, unknown> | null;
+};
+```
+
+`InputPanel`과 `OutputPanel`에서 `nodeDataPanel.nodePreviewData?.metadata`를 넘긴다.
+
+표시 위치:
+
+- payload type label 아래
+- 작은 보조 텍스트 또는 notice
+
+예:
+
+- `본문 미포함 미리보기`
+- `본문 포함 미리보기`
+- `본문 상태만 포함된 미리보기`
+
+---
+
+## 6. Preview 요청 정책
+
+### 6.1 현재 1차 정책
+
+현재 backend preview는 source preview 중심이다. 따라서 FE 1차는 기존 버튼을 유지하고 `includeContent=false`를 기본으로 둔다.
+
+이유:
+
+- source preview가 자동으로 full content를 요청하면 문서 다운로드/추출 비용이 커진다.
+- backend 문서에서 metadata-only preview와 content-included preview를 분리했다.
+- AI 노드 preview는 backend 범위가 확정된 뒤 노출하는 편이 안전하다.
+
+### 6.2 사용자 액션 확장안
+
+source preview 버튼을 두 단계로 확장할 수 있다.
+
+1. `실행 전 미리보기`: `includeContent=false`
+2. `본문 포함 미리보기`: `includeContent=true`
+
+1차 구현에서는 버튼을 바로 추가하지 않고, 설계만 열어둔다. backend가 `includeContent=true`의 비용/권한/error 정책을 안정화하면 추가한다.
+
+### 6.3 AI 노드 preview 확장 조건
+
+아래 조건이 모두 만족되면 중간/AI 노드 preview를 열 수 있다.
+
+- Spring preview endpoint가 start node 외 target node dry-run을 지원한다.
+- `NodePreviewResponse.metadata.contentPolicy`가 내려온다.
+- 실패 시 `DOCUMENT_CONTENT_*` error가 사용자 문구로 매핑된다.
+- FE가 `canRequestPreview`를 start node 한정에서 backend capability 기반으로 바꾼다.
+
+---
+
+## 7. Error UX 설계
+
+### 7.1 실행 오류 문구 매핑
+
+대상:
+
+- `src/entities/execution/model/nodeRuntimeIssue.ts`
+
+추가 매핑:
+
+| code | 사용자 문구 |
+|------|-------------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | 이 파일 형식은 아직 본문 읽기를 지원하지 않습니다. |
+| `DOCUMENT_CONTENT_TOO_LARGE` | 파일이 너무 커서 본문을 읽을 수 없습니다. |
+| `DOCUMENT_CONTENT_EMPTY` | 파일에서 읽을 수 있는 본문이 없습니다. |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 파일 본문을 읽는 중 오류가 발생했습니다. |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 본문이 필요한 작업이지만 본문 미리보기/추출이 요청되지 않았습니다. |
+
+`OAUTH_SCOPE_INSUFFICIENT`, `OAUTH_TOKEN_MISSING`, `OAUTH_TOKEN_INVALID`는 기존 OAuth 문구 흐름을 재사용하되 Gmail/Drive 권한 부족 메시지를 유지한다.
+
+### 7.2 Node data panel notice
+
+`DataStateNotice`는 execution error message를 그대로 보여준다. Spring이 user-friendly message를 내려주면 그대로 표시하고, raw code만 내려오는 경우에는 FE helper로 보정한다.
+
+현재 `DataStateNotice`는 `executionData.error.message`를 직접 표시한다. 구현 시 `getUserFriendlyExecutionErrorMessage` 또는 신규 error helper를 `getExecutionStatusNotice`와 `DataStateNotice` 양쪽에서 재사용하도록 정리한다.
+
+권장 순서:
+
+1. Spring이 내려준 사용자 문구가 있으면 우선 표시한다.
+2. `error.code`가 `DOCUMENT_CONTENT_*`이면 FE 매핑 문구를 사용한다.
+3. 기존 OAuth/column/not found/rate limit 매핑을 적용한다.
+4. 그래도 없으면 기본 실행 실패 문구를 표시한다.
+
+---
+
+## 8. 테스트 계획
+
+### 8.1 Unit tests
+
+추가 후보:
+
+- `src/widgets/node-data-panel/model/document-content.test.ts`
+- `src/widgets/node-data-panel/ui/DataPreviewBlock.test.tsx`
+- `src/entities/execution/model/nodeRuntimeIssue.test.ts`
+
+필수 케이스:
+
+- snake_case `content_status`, `content_metadata` 읽기
+- camelCase `contentStatus`, `contentMetadata` 읽기
+- `available + truncated` 표시
+- `not_requested`는 본문 카드 없이 상태 표시
+- `unsupported|too_large|failed|empty` 상태 문구 표시
+- legacy `extracted_text` fallback 표시
+- `FILE_LIST.items[]` 상태 집계
+- Gmail attachment content status 표시
+- `DOCUMENT_CONTENT_*` error code 문구 매핑
+
+### 8.2 Manual QA
+
+1. Google Drive source preview metadata-only
+2. Google Drive source preview content included (2차 또는 `본문 포함 미리보기` 버튼 도입 후)
+3. `SINGLE_FILE` 실행 결과 content available
+4. `SINGLE_FILE` 실행 결과 unsupported
+5. `FILE_LIST`에 mixed content status 포함
+6. Gmail attachment metadata-only unsupported/not_requested
+7. 실행 실패 코드 `DOCUMENT_CONTENT_TOO_LARGE`
+
+---
+
+## 9. 구현 순서
+
+1. `document-content.ts` helper와 test 추가
+2. `nodeRuntimeIssue`에 `DOCUMENT_CONTENT_*` 문구 매핑 추가
+3. `DataPreviewBlock` props에 `previewMetadata` 추가
+4. `FileItemCard`, `SingleFilePreview`, `FileListPreview`, `SingleEmailPreview`에 content 상태 표시
+5. `InputPanel`, `OutputPanel`에서 preview metadata 전달
+6. preview 버튼/정책은 backend capability 확정 후 2차로 확장
+7. 문서/테스트 업데이트 후 `pnpm test`, `pnpm tsc` 확인
+
+---
+
+## 10. 미해결 결정
+
+- source preview에 `본문 포함 미리보기` 버튼을 1차에 추가할지 여부
+- AI 노드 preview를 backend source-only 제약이 풀리기 전에 UI에 노출할지 여부
+- full content가 sanitize되어 내려올 때 FE가 “전체 본문 보기” 같은 UX를 제공할지 여부
+- `content_error`를 그대로 노출할지, FE 문구 매핑을 항상 우선할지 여부
+
+1차 권장은 보수적이다. FE는 상태와 제한을 정확히 보여주고, 본문 포함 preview/AI preview는 backend capability가 확정된 뒤 열어야 한다.
+
+따라서 `Google Drive source preview content included` QA는 1차 필수 검증이 아니라, `includeContent=true`를 호출하는 UI가 추가되거나 backend 안정화 후 진행하는 확장 검증으로 둔다.

--- a/docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md
+++ b/docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md
@@ -1,0 +1,494 @@
+# 문서 본문 읽기/요약 자동화 문제 분석 및 해결 요구사항
+
+> 작성일: 2026-05-13  
+> 대상: Google Drive/Gmail 파일 입력 -> LLM 요약/분석 -> Slack/Gmail/Sheets/Drive 등 후속 자동화  
+> 관련 문서:
+> - `docs/FOLDER_DOCUMENT_SUMMARY_TEMPLATE_DESIGN.md`
+> - `docs/WORKFLOW_NODE_PREVIEW_DRY_RUN_DESIGN.md`
+> - `docs/WORKFLOW_FILE_TYPE_BRANCH_FRONTEND_DESIGN.md`
+> - `docs/GMAIL_NODE_OPTION_C_IMPLEMENTATION_PLAN.md`
+> - `docs/backend/FASTAPI_RUNTIME_CONTRACT_REQUEST.md`
+
+---
+
+## 1. 문제 요약
+
+현재 사용자가 문서 요약, 문서 내부 읽기, 문서 내용을 기반으로 한 자동화를 구성하면 LLM 또는 후속 노드가 문서 본문을 제대로 사용하지 못하는 것으로 보인다.
+
+가장 유력한 원인은 파일이 워크플로우로 전달되더라도 canonical payload 안에 실제 문서 본문 또는 추출 텍스트가 포함되지 않거나, 본문 포함 여부가 런타임 계약에서 명확하지 않은 것이다.
+
+---
+
+## 2. 분석 방법
+
+분석은 아래 순서로 진행한다.
+
+1. 사용자 시나리오를 데이터 흐름으로 분해한다.
+   - Google Drive 폴더/파일 source
+   - Gmail 첨부파일 source
+   - `FILE_LIST -> LOOP -> SINGLE_FILE -> LLM`
+   - `SINGLE_FILE -> LLM`
+   - `SINGLE_EMAIL -> LLM`
+2. FE가 저장하는 노드 config와 edge 계약을 확인한다.
+   - source node의 `source_mode`, `target`, `canonical_input_type`
+   - choice wizard의 `choiceActionId`, `choiceNodeType`, `choiceSelections`
+   - loop/branch edge label과 sourceHandle
+3. Spring이 FE config를 FastAPI runtime payload로 변환할 때 본문 추출 요구가 보존되는지 확인한다.
+   - `runtime_source`
+   - `runtime_config`
+   - `dataType`, `outputDataType`
+4. FastAPI source/loop/LLM 전략이 canonical payload의 어떤 필드를 읽는지 확인한다.
+   - `FILE_LIST.items[]`
+   - `SINGLE_FILE.content`
+   - `SINGLE_EMAIL.body`
+   - Gmail attachment metadata/content
+5. preview와 실제 실행 결과를 비교한다.
+   - preview `includeContent=false/true`
+   - 최신 실행 node data의 `inputData`, `outputData`
+   - LLM 노드 input에 본문 필드가 존재하는지
+
+---
+
+## 3. 현재 FE 기준 관찰
+
+### 3.1 FE는 파일 본문을 직접 읽지 않는다
+
+FE의 source 설정은 파일/폴더/라벨 같은 target을 저장하고, 실제 외부 파일 다운로드나 본문 추출은 Spring/FastAPI 런타임에 위임하는 구조다.
+
+따라서 FE만으로 문서 내부를 읽는 문제를 해결할 수 없고, 런타임 canonical payload 계약이 필요하다.
+
+### 3.2 choice wizard는 LLM 의도를 저장하지만 본문 포함 정책은 저장하지 않는다
+
+문서 요약 액션을 선택하면 AI 노드에는 주로 아래 값이 저장된다.
+
+```json
+{
+  "choiceActionId": "summarize",
+  "choiceNodeType": "AI",
+  "choiceSelections": {
+    "summarize": "brief"
+  },
+  "isConfigured": true
+}
+```
+
+이 config는 “요약하라”는 의미는 담지만, “Google Drive 파일을 다운로드하고 본문을 추출해서 LLM input으로 넣어라”는 실행 정책은 담지 않는다.
+
+### 3.3 preview API에는 `includeContent`가 있지만 기본값은 metadata 중심이다
+
+기존 dry-run 설계는 preview request에 `includeContent`를 두고, 1차 구현 기본값을 `false`로 정의했다.
+
+```json
+{
+  "limit": 50,
+  "includeContent": false
+}
+```
+
+따라서 preview에서 파일 카드만 보이고 본문이 비어 있는 것은 설계상 가능한 상태다. 다만 실제 실행에서도 동일하게 본문이 누락되면 LLM 요약은 정상 동작할 수 없다.
+
+### 3.4 기존 Gmail 계획에서는 attachment content 전달이 제외되어 있다
+
+Gmail 선택지 C 계획에서 `attachment content download/전달`은 명시적으로 1차 제외 범위다. 그러므로 Gmail 첨부 문서 요약은 현재 계약만으로는 동작 보장이 어렵다.
+
+---
+
+## 4. 원인 가설
+
+### 4.1 1순위: source payload가 본문 없는 metadata-only 형태로 전달됨
+
+`FILE_LIST` 또는 `SINGLE_FILE` payload가 아래처럼 파일 식별자와 메타데이터만 포함하면 LLM은 문서 내용을 알 수 없다.
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "file_id": "file_1",
+  "filename": "report.pdf",
+  "mime_type": "application/pdf",
+  "url": "https://drive.google.com/file/d/file_1"
+}
+```
+
+LLM 요약 가능 payload는 최소한 아래처럼 추출 텍스트가 있어야 한다.
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "file_id": "file_1",
+  "filename": "report.pdf",
+  "mime_type": "application/pdf",
+  "content": "문서에서 추출된 텍스트...",
+  "content_status": "available"
+}
+```
+
+### 4.2 2순위: `FILE_LIST -> LOOP` 변환에서 item content가 보존되지 않음
+
+폴더 기반 자동화는 대개 `FILE_LIST`를 받은 뒤 loop가 한 파일씩 `SINGLE_FILE`로 넘긴다. 이때 source가 content를 포함했더라도 loop가 item metadata만 복사하면 LLM input에서 본문이 사라진다.
+
+### 4.3 3순위: LLM strategy가 파일 payload의 본문 필드를 읽지 않음
+
+LLM strategy가 `TEXT.content`나 `SINGLE_EMAIL.body`만 읽고 `SINGLE_FILE.content`, `text`, `extracted_text` 같은 필드를 읽지 않으면, source가 본문을 내려도 요약에 사용되지 않는다.
+
+### 4.4 4순위: 파일 타입별 추출 전략이 미정
+
+파일 종류마다 본문 추출 방식이 다르다.
+
+- Google Docs: export text/plain 또는 Docs API
+- PDF: PDF text extraction 또는 OCR fallback
+- CSV/TSV: 인코딩 감지 후 text/table 형태로 파싱
+- PowerPoint: slide text, speaker note, alt text 추출
+- Word: paragraph/table/header/footer text 추출
+- HWPX: XML 기반 본문 텍스트 추출
+- TXT/Markdown: 인코딩 감지 후 원문 text 사용
+- 이미지: OCR 또는 vision 모델
+- 기타 바이너리: unsupported 처리
+
+파일 타입별 지원 범위와 실패 응답이 없으면 “파일은 받았지만 읽지 못함” 상태가 사용자에게 설명되지 않는다.
+
+### 4.5 5순위: Gmail 첨부파일은 content download 범위 밖
+
+Gmail `attachment_email` 또는 첨부파일 기반 source가 attachment metadata만 반환하면, Drive 파일과 달리 원본 다운로드 경로가 없어 LLM이 문서를 읽을 수 없다.
+
+---
+
+## 5. 해결 요구사항
+
+### 5.1 Canonical payload에 문서 본문 필드를 표준화한다
+
+`SINGLE_FILE`은 아래 필드를 표준으로 가진다.
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "file_id": "string",
+  "filename": "string",
+  "mime_type": "string",
+  "size": "number|string|null",
+  "url": "string|null",
+  "content": "string|null",
+  "content_status": "available|empty|unsupported|too_large|failed|not_requested",
+  "content_error": "string|null",
+  "content_metadata": {
+    "extraction_method": "google_export|pdf_text|csv_parse|pptx_text|word_text|hwpx_xml|plain_text|ocr|vision|gmail_attachment|none",
+    "content_kind": "plain_text|table_text|slide_text|ocr_text|image_description|mixed|none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0
+  }
+}
+```
+
+`FILE_LIST.items[]`는 `SINGLE_FILE`과 같은 item shape를 사용한다. 목록 preview에서는 content를 생략할 수 있지만, 실제 실행에서 LLM 또는 content-dependent action으로 연결될 때는 본문 추출이 수행되어야 한다.
+
+### 5.1.1 1차 지원 대상 파일 타입
+
+문서 요약/본문 읽기 자동화는 최소 아래 파일군을 호환 대상으로 둔다.
+
+| 파일군 | 대표 확장자 | 대표 MIME type | 추출 방식 | 1차 등급 | 1차 기대 |
+|--------|-------------|----------------|-----------|-----------|----------|
+| PDF text layer | `.pdf` | `application/pdf` | text layer 추출 | 필수 지원 | 텍스트 PDF는 `content_status=available` |
+| PDF scan | `.pdf` | `application/pdf` | OCR fallback | 조건부 지원 | OCR 미구현이면 `unsupported`, 구현 시 `ocr` 기록 |
+| CSV/TSV | `.csv`, `.tsv` | `text/csv`, `text/tab-separated-values` | delimiter/encoding 감지 후 text 또는 table summary input 생성 | 필수 지원 | UTF-8, UTF-8 BOM, CP949 대응 |
+| PowerPoint modern | `.pptx` | `application/vnd.openxmlformats-officedocument.presentationml.presentation` | slide text/note/alt text 추출 | 필수 지원 | slide 순서 유지 |
+| PowerPoint legacy | `.ppt` | `application/vnd.ms-powerpoint` | 변환 가능 시 추출 | 조건부 지원 | 미구현이면 `unsupported` |
+| HWPX | `.hwpx` | `application/hwp+zip`, `application/x-hwpx` | zip 내부 XML 파싱 후 본문 추출 | 필수 지원 | `.hwpx` 본문 text 추출 |
+| Word modern | `.docx` | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | paragraph/table/header/footer text 추출 | 필수 지원 | paragraph와 table text 포함 |
+| Word legacy | `.doc` | `application/msword` | 변환 가능 시 추출 | 조건부 지원 | 미구현이면 `unsupported` |
+| Plain text | `.txt`, `.md`, `.log` | `text/plain`, `text/markdown` | encoding 감지 후 원문 사용 | 필수 지원 | UTF-8, UTF-8 BOM, CP949 대응 |
+| Image common | `.png`, `.jpg`, `.jpeg`, `.webp`, `.bmp`, `.tif`, `.tiff` | `image/*` | OCR 또는 vision 모델 기반 text/description 추출 | 조건부 지원 | OCR/vision 미구현이면 `unsupported` |
+| Image animated/HEIC | `.gif`, `.heic` | `image/gif`, `image/heic` | 대표 frame 추출 또는 변환 후 OCR/vision | 조건부 지원 | 미구현이면 `unsupported` |
+| Google Workspace | Google Docs/Slides/Sheets | Google Drive export MIME | text/plain, csv, pptx 등으로 export 후 추출 | 필수 지원 | export 가능한 파일 우선 지원 |
+
+지원하지 못하는 확장자 또는 MIME type은 `content_status=unsupported`로 응답하고, 사용자에게 표시 가능한 `content_error`를 함께 내려야 한다.
+
+1차 등급 의미:
+
+- 필수 지원: 1차 완료 기준에 포함한다. 성공 또는 명확한 파일별 실패 사유가 필요하다.
+- 조건부 지원: 1차에서 extractor를 구현하지 않아도 되지만, 지원 여부와 실패 상태를 명확히 반환해야 한다.
+
+### 5.1.2 파일 타입 판별 기준
+
+런타임은 확장자만으로 파일 타입을 확정하지 않는다. 아래 순서로 판별한다.
+
+1. Google Drive/Gmail이 제공하는 MIME type
+2. 파일 확장자
+3. 파일 signature 또는 archive 내부 구조
+4. 추출기 실행 결과
+
+MIME type과 확장자가 충돌하면 MIME type을 우선하되, 추출 실패 시 확장자 기반 fallback을 시도한다.
+
+### 5.1.3 추출 결과 정규화
+
+파일 타입별 원본 구조가 달라도 LLM input에는 일관된 text representation을 전달한다.
+
+- PDF/Word/HWPX/TXT: 본문 문단 순서를 유지한다.
+- CSV/TSV: header와 주요 row를 읽을 수 있는 text/table 형태로 변환한다.
+- PPTX: slide 번호, slide title, body, speaker note를 구분 가능한 text로 변환한다.
+- 이미지: OCR 텍스트와 image description을 구분한다.
+- Google Sheets export CSV는 row/column 구조가 사라지지 않도록 header를 포함한다.
+
+추출된 본문이 너무 길면 truncate하되, `content_metadata.truncated=true`, `char_count`, `original_char_count`를 내려야 한다.
+
+`content_kind` 의미:
+
+- `plain_text`: 일반 문서 본문
+- `table_text`: CSV/TSV/Sheets처럼 표 구조에서 만든 text representation
+- `slide_text`: PPTX/Slides처럼 slide 단위로 만든 text representation
+- `ocr_text`: 이미지 또는 스캔 문서에서 OCR로 추출한 텍스트
+- `image_description`: vision 모델이 생성한 이미지 설명
+- `mixed`: OCR 텍스트와 image description 등 여러 결과를 합친 입력
+- `none`: 본문이 없거나 추출하지 않은 상태
+
+### 5.2 Runtime은 content-dependent action을 판별해야 한다
+
+아래 action은 본문이 필요한 작업으로 본다.
+
+- `summarize`
+- `extract_info`
+- `translate`
+- `classify_by_content`
+- `describe_image`
+- `ocr`
+- `ai_summarize`
+- `ai_analyze`
+
+책임 분리는 아래처럼 둔다.
+
+- Spring은 `choiceActionId`, `choiceNodeType`, `dataType`, `outputDataType`를 바탕으로 `runtime_config.requires_content`를 생성한다.
+- FastAPI는 `runtime_config.requires_content=true`인 노드 실행 또는 preview에서 source/loop/LLM 직전 본문 추출을 수행한다.
+- FastAPI는 `requires_content=true`인데 본문을 만들 수 없으면 빈 요약을 생성하지 않고 `content_status`와 실행/preview error를 명확히 반환한다.
+
+### 5.3 `FILE_LIST -> LOOP -> SINGLE_FILE`에서 content 보존을 보장한다
+
+Loop strategy는 `FILE_LIST.items[]`의 각 item을 `SINGLE_FILE`로 전달할 때 아래 필드를 유지해야 한다.
+
+- `file_id`
+- `filename`
+- `mime_type`
+- `url`
+- `content`
+- `content_status`
+- `content_error`
+- `content_metadata`
+
+만약 list 단계에서 content가 없고 다음 노드가 content-dependent action이면 loop 또는 다음 LLM 단계에서 lazy extraction을 수행해야 한다.
+
+### 5.4 LLM strategy는 파일/메일 canonical input을 명시적으로 지원한다
+
+LLM strategy는 입력 타입별 본문 필드를 아래 우선순위로 읽는다.
+
+- `TEXT`: `content`
+- `SINGLE_FILE`: `content`
+- `SINGLE_EMAIL`: `body`, `bodyPreview`, `body_preview`, `snippet`
+- `EMAIL_LIST`: 각 item의 `body`, `bodyPreview`, `body_preview`, `snippet`
+- `FILE_LIST`: 각 item의 `content`, 없으면 filename/mime/url metadata만 보조 정보로 사용
+
+본문이 필요한 action인데 `content_status`가 `unsupported`, `failed`, `too_large`, `not_requested`이면 성공처럼 빈 요약을 만들지 않고 명시적 실패 또는 부분 성공으로 응답해야 한다.
+
+### 5.5 Preview와 실행의 content 정책을 분리하되 표시를 명확히 한다
+
+preview 기본값은 metadata-only로 유지할 수 있다. 다만 사용자가 문서 요약 노드를 preview할 때는 다음 중 하나를 만족해야 한다.
+
+- FE가 LLM 노드 preview 요청 시 `includeContent: true`를 보낸다.
+- Spring/FastAPI가 content-dependent node preview에서는 자동으로 content extraction을 수행한다.
+- 본문 추출을 하지 않는 경우 `reason` 또는 `metadata.preview_scope`로 “본문 미포함 preview”임을 명시한다.
+
+### 5.6 Gmail 첨부파일 content 지원 범위를 별도 계약으로 추가한다
+
+Gmail 첨부 문서 요약을 지원하려면 Gmail source payload에 아래 필드가 필요하다.
+
+```json
+{
+  "type": "SINGLE_EMAIL",
+  "email": {
+    "subject": "string",
+    "body": "string|null",
+    "attachments": [
+      {
+        "attachment_id": "string",
+        "filename": "string",
+        "mime_type": "string",
+        "size": "number|string|null",
+        "content": "string|null",
+        "content_status": "available|unsupported|too_large|failed|not_requested",
+        "content_error": "string|null",
+        "content_metadata": {
+          "extraction_method": "gmail_attachment|pdf_text|csv_parse|pptx_text|word_text|hwpx_xml|plain_text|ocr|vision|none",
+          "content_kind": "plain_text|table_text|slide_text|ocr_text|image_description|mixed|none",
+          "truncated": false,
+          "char_count": 0,
+          "original_char_count": 0
+        }
+      }
+    ]
+  }
+}
+```
+
+1차에서 Gmail attachment content를 지원하지 않는다면, Gmail 첨부 문서 요약 템플릿 또는 선택지는 “첨부파일 이름/메타데이터만 사용 가능”으로 제한해야 한다.
+
+### 5.7 파일 크기와 보안 제한을 정의한다
+
+본문 추출은 외부 파일 데이터를 다루므로 제한이 필요하다.
+
+- 최대 다운로드 크기
+- 최대 추출 문자 수
+- LLM input 최대 문자 수
+- 추출 결과 truncate 정책
+- OAuth scope 부족 시 error code
+- Google Drive 권한 없음/파일 삭제/바이러스 스캔 제한 파일 처리
+- 민감 파일 로깅 금지
+
+MVP에서는 구체 수치를 백엔드에서 정할 수 있으나, 적용된 제한값은 반드시 응답 metadata에 포함한다.
+
+```json
+{
+  "content_metadata": {
+    "limits": {
+      "max_download_bytes": 0,
+      "max_extracted_chars": 0,
+      "max_llm_input_chars": 0
+    }
+  }
+}
+```
+
+제한에 걸린 경우:
+
+- 다운로드 크기 초과: `content_status=too_large`
+- 추출 결과 truncate: `content_status=available`, `content_metadata.truncated=true`
+- LLM input truncate: LLM 결과 metadata에 truncate 여부를 남긴다.
+
+---
+
+## 6. 백엔드 요청사항
+
+### 6.1 Spring Boot
+
+- FE config의 `choiceActionId`, `choiceNodeType`, `choiceSelections`를 FastAPI `runtime_config`에 안정적으로 전달한다.
+- content-dependent action 판별 로직 위치를 FastAPI와 합의한다.
+- `runtime_config.requires_content`를 생성해 FastAPI에 전달한다.
+- preview 요청에서 target node가 content-dependent이면 `includeContent=true` 또는 이에 준하는 runtime flag를 전달한다.
+- source/LLM 실행 실패를 raw exception이 아니라 사용자 표시 가능한 error code로 변환한다.
+- 실행 node data에 `content_status`, `content_error`, `content_metadata`를 보존한다.
+
+### 6.2 FastAPI
+
+- Google Drive source에서 `SINGLE_FILE.content` 추출을 구현하거나 현재 지원 범위를 명확히 응답한다.
+- Google Drive `FILE_LIST.items[]`에 content 포함이 필요한 경우 lazy extraction 또는 eager extraction 정책을 제공한다.
+- Loop strategy에서 file item content 필드를 보존한다.
+- LLM strategy가 `SINGLE_FILE.content`와 `FILE_LIST.items[].content`를 읽도록 보장한다.
+- PDF, CSV, PPTX, HWPX, TXT, Word, image, Google Workspace, unsupported 파일별 `content_status`를 반환한다.
+- 파일 타입별 extractor를 모듈화하고, extractor 선택 결과를 `content_metadata.extraction_method`에 기록한다.
+- `content_metadata.content_kind`, `char_count`, `original_char_count`, `limits`를 반환한다.
+- CSV/TXT 계열은 UTF-8, UTF-8 BOM, CP949 같은 한국어 문서에서 자주 나오는 인코딩을 처리한다.
+- 이미지 계열은 OCR 가능 여부와 vision fallback 여부를 명확히 반환한다.
+- Gmail attachment content는 지원 여부를 명시하고, 미지원이면 `content_status=not_requested|unsupported`로 반환한다.
+
+---
+
+## 7. FE 후속 요구사항
+
+FE는 런타임 계약이 정리된 뒤 아래 항목을 반영한다.
+
+- LLM 노드 preview 요청 시 content-dependent action이면 `includeContent: true`를 전달한다.
+- `DataPreviewBlock`에서 `SINGLE_FILE.content_status`, `content_error`, `content_metadata.truncated`를 표시한다.
+- `FILE_LIST` preview에서 item별 content 상태를 표시한다.
+- Gmail 첨부파일 preview에서 attachment content 상태를 표시한다.
+- content 미지원 파일에 대해 “파일은 받았지만 본문을 읽을 수 없음” 상태를 사용자 문구로 표시한다.
+- 문서 요약 템플릿 설명에서 지원 파일 타입과 제한을 실제 런타임 기준으로 맞춘다.
+
+---
+
+## 8. 검증 시나리오
+
+### 8.1 Google Drive 단일 문서 요약
+
+1. Google Drive `single_file` source로 Google Docs 문서를 선택한다.
+2. 다음 노드로 AI `summarize`를 선택한다.
+3. AI 노드 preview 또는 실행 결과에서 inputData에 `SINGLE_FILE.content`가 있는지 확인한다.
+4. outputData가 문서 본문 기반 요약인지 확인한다.
+
+### 8.2 Google Drive 폴더 신규 파일 요약
+
+1. Google Drive `folder_new_file` 또는 `folder_all_files` source를 설정한다.
+2. `FILE_LIST -> LOOP -> AI summarize` 흐름을 만든다.
+3. Loop output이 `SINGLE_FILE.content` 또는 lazy extraction 가능한 file id를 유지하는지 확인한다.
+4. AI output이 파일명/메타데이터 요약이 아니라 본문 요약인지 확인한다.
+
+### 8.3 PDF 요약
+
+1. 텍스트가 포함된 PDF를 선택한다.
+2. AI `summarize`를 실행한다.
+3. `content_metadata.extraction_method=pdf_text`가 기록되는지 확인한다.
+4. 스캔 PDF라면 OCR 지원 여부에 따라 `available` 또는 `unsupported`가 명확히 내려오는지 확인한다.
+
+### 8.4 CSV 요약
+
+1. UTF-8 CSV와 CP949 CSV를 각각 선택한다.
+2. AI `summarize` 또는 `ai_analyze`를 실행한다.
+3. header와 row 내용이 LLM input에 포함되는지 확인한다.
+4. `content_metadata.extraction_method=csv_parse`가 기록되는지 확인한다.
+
+### 8.5 PPTX 요약
+
+1. `.pptx` 파일을 선택한다.
+2. AI `summarize`를 실행한다.
+3. slide title/body/note가 순서대로 추출되는지 확인한다.
+4. `.ppt` 파일은 지원 또는 미지원 상태가 명확히 표시되는지 확인한다.
+
+### 8.6 HWPX 요약
+
+1. `.hwpx` 파일을 선택한다.
+2. AI `summarize`를 실행한다.
+3. XML 기반 본문 텍스트가 추출되는지 확인한다.
+4. 암호화/손상 파일은 `content_status=failed|unsupported`로 응답하는지 확인한다.
+
+### 8.7 Word 요약
+
+1. `.docx` 파일을 선택한다.
+2. AI `summarize`를 실행한다.
+3. paragraph/table/header/footer 중 최소 본문 paragraph와 table text가 포함되는지 확인한다.
+4. `.doc` 파일은 변환 가능 여부에 따라 `available` 또는 `unsupported`가 명확히 표시되는지 확인한다.
+
+### 8.8 TXT/Markdown 요약
+
+1. UTF-8, UTF-8 BOM, CP949 텍스트 파일을 각각 선택한다.
+2. AI `summarize`를 실행한다.
+3. 글자가 깨지지 않고 `content_metadata.extraction_method=plain_text`가 기록되는지 확인한다.
+
+### 8.9 이미지 OCR/설명 생성
+
+1. `.png`, `.jpg`, `.jpeg`, `.webp`, `.tif` 파일을 선택한다.
+2. OCR 또는 image description action을 실행한다.
+3. OCR 가능 이미지는 추출 텍스트가 포함되는지 확인한다.
+4. OCR 불가 이미지는 vision description 또는 `unsupported` 상태가 명확히 표시되는지 확인한다.
+
+### 8.10 Gmail 첨부파일 요약
+
+1. 첨부파일이 있는 Gmail source를 설정한다.
+2. AI `summarize`를 연결한다.
+3. 현재 범위에서 attachment content가 미지원이면 사용자에게 제한이 표시되는지 확인한다.
+4. 지원 범위에 포함되면 `attachments[].content`가 LLM input으로 전달되는지 확인한다.
+
+### 8.11 Preview와 실제 실행 비교
+
+1. source node preview를 metadata-only로 확인한다.
+2. AI node preview를 content 포함 모드로 확인한다.
+3. 실제 workflow 실행 후 latest execution node data를 확인한다.
+4. preview와 실행이 같은 canonical payload 필드를 사용하고 있는지 비교한다.
+
+---
+
+## 9. 완료 기준
+
+- `SINGLE_FILE` canonical payload의 content 계약이 Spring/FastAPI/FE 문서에 반영되어 있다.
+- PDF, CSV, PPTX, HWPX, TXT, Word, image, Google Workspace 파일의 지원/미지원 기준이 문서화되어 있다.
+- 필수 지원 파일군은 1차 완료 기준에 포함되고, 조건부 지원 파일군은 `unsupported` 상태와 사용자 표시 가능한 사유가 반환된다.
+- Spring은 content-dependent action에 `runtime_config.requires_content=true`를 전달한다.
+- Google Drive 문서 요약에서 LLM input에 실제 본문이 들어간다.
+- `FILE_LIST -> LOOP -> AI` 경로에서 본문 또는 lazy extraction key가 손실되지 않는다.
+- content 추출 실패가 빈 요약 성공으로 처리되지 않는다.
+- preview와 실제 실행 모두에서 본문 포함/미포함 상태가 구분된다.
+- Gmail 첨부파일 요약은 지원 또는 미지원 범위가 명확히 표시된다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_FASTAPI.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_FASTAPI.md
@@ -1,0 +1,920 @@
+# 문서 본문 런타임 요구사항 분석 및 구현 계획
+
+> 작성일: 2026-05-14  
+> 기준 문서: `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`  
+> 대상 범위: FastAPI 런타임, Spring runtime contract, FE preview 표시 계약  
+> 핵심 시나리오: Google Drive/Gmail 파일 입력 -> LLM 요약/분석 -> Slack/Gmail/Sheets/Drive 후속 자동화
+
+---
+
+## 1. 결론 요약
+
+현재 Flowify FastAPI 런타임은 Google Drive 파일을 canonical payload로 전달하고, LLM 노드에서 Google Drive 단일 파일 본문을 lazy extraction으로 읽는 일부 경로를 이미 갖고 있다.
+
+그러나 요구사항 문서의 완료 기준을 만족하기에는 아래 간극이 남아 있다.
+
+1. `SINGLE_FILE` 본문 상태 계약이 표준화되어 있지 않다.
+   - 현재: `extracted_text`, `extraction_status=success|truncated|unsupported|failed|not_requested`
+   - 요구: `content`, `content_status=available|empty|unsupported|too_large|failed|not_requested`, `content_error`, `content_metadata`
+2. Google Drive extractor 지원 범위가 좁다.
+   - 현재: Google Docs/Sheets/Slides export, text mime, PDF text layer 중심
+   - 요구: PDF, CSV/TSV, PPTX, HWPX, DOCX, TXT/MD, Google Workspace 필수 지원 및 이미지/legacy 문서 명확한 미지원 처리
+3. `FILE_LIST` preview와 실행에서 item content 정책이 아직 metadata 중심이다.
+   - loop는 item 필드를 보존하지만, list 단계에서 content 표준 필드가 없으면 LLM은 lazy extraction 조건에 의존한다.
+4. LLM 노드는 `SINGLE_FILE.content`와 Google Drive lazy extraction을 지원하지만, `FILE_LIST.items[].content`는 현재 포맷에 포함하지 않는다.
+5. Gmail 첨부파일은 metadata만 전달되며 attachment content download/extraction 계약은 없다.
+6. preview는 `include_content`를 지원하지만 source node preview 중심이고, content-dependent AI preview 자동 판별은 아직 없다.
+
+따라서 1차 구현 목표는 "문서 본문 canonical contract 정규화 + Google Drive 필수 파일군 extractor + LLM/Loop/Preview 경로 보존"으로 잡는 것이 안전하다. Gmail 첨부 본문 읽기는 별도 2차 범위 또는 명시적 미지원 상태로 두는 것을 권장한다.
+
+---
+
+## 2. 현재 코드 기준 관찰
+
+### 2.1 Workflow 모델
+
+`app/models/workflow.py`는 Spring이 전달하는 `runtime_source`, `runtime_config`, `runtime_action`을 수용한다.
+
+`RuntimeConfig`는 `extra="allow"`이므로 Spring이 `requires_content` 같은 신규 필드를 추가해도 FastAPI 모델에서 버려지지 않는다.
+
+```json
+{
+  "runtime_config": {
+    "node_type": "llm",
+    "action": "summarize",
+    "output_data_type": "TEXT",
+    "requires_content": true
+  }
+}
+```
+
+즉 모델 계층은 확장 가능하고, 병목은 실행 전략과 payload shape에 있다.
+
+### 2.1.1 Canonical 모델
+
+`app/models/canonical.py`에는 `SingleFilePayload`, `FileItem`, `FileListPayload`, `EmailAttachment` 모델이 있지만 현재 파일 본문 상태 필드는 없다.
+
+현재 모델:
+
+- `SingleFilePayload`: `filename`, `content`, `mime_type`, `url`
+- `FileItem`: `filename`, `mime_type`, `size`, `url`
+- `EmailAttachment`: `filename`, `mime_type`, `size`
+
+실제 런타임 코드는 대부분 dict payload를 직접 만들고 있어 당장 모델 validation에 막히지는 않는다. 다만 canonical contract 문서와 타입 모델이 계속 어긋나면 Spring/FE/API 문서가 서로 다른 payload를 상정하게 된다.
+
+따라서 구현 시 `app/models/canonical.py`도 아래 방향으로 확장한다.
+
+- `SingleFilePayload`에 `source_service`, `file_id`, `content_status`, `content_error`, `content_metadata` 추가
+- `FileItem`에도 같은 content 상태 필드 추가
+- `EmailAttachment`에 `attachment_id`, `message_id`, `content`, `content_status`, `content_error`, `content_metadata` 추가
+- 기존 필드명 `mimeType`, `messageId`, `attachmentId`처럼 camelCase로 들어오는 runtime payload는 dict 단계에서 유지하되, 모델에는 snake_case alias를 둔다.
+
+### 2.2 Google Drive source
+
+`app/core/nodes/input_node.py`의 Google Drive source는 단일 파일과 폴더 파일 목록을 생성한다.
+
+현재 단일 파일 payload:
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "source_service": "google_drive",
+  "file_id": "file_1",
+  "filename": "report.pdf",
+  "content": null,
+  "extracted_text": null,
+  "extraction_status": "not_requested",
+  "mime_type": "application/pdf",
+  "size": "1024",
+  "url": "https://drive.google.com/file/d/file_1"
+}
+```
+
+현재 `folder_all_files` payload는 `FILE_LIST.items[]`에 metadata만 담는다. 이 item은 `source_service`, `file_id`, `filename`, `mime_type`, `url`을 포함하므로 LLM lazy extraction의 최소 key는 유지된다.
+
+### 2.3 Google Drive extractor
+
+`app/services/integrations/google_drive.py`에는 `extract_file_text()`가 있다.
+
+현재 지원:
+
+- Google Docs: `text/plain` export
+- Google Sheets: `text/csv` export
+- Google Slides: `text/plain` export
+- `text/*`, `application/json`, `application/xml`: UTF-8 decode
+- PDF: `pypdf` text extraction
+- 기타: `unsupported`
+
+현재 한계:
+
+- CP949/BOM 인코딩 감지 없음
+- CSV/TSV table representation 없음
+- PPTX/DOCX/HWPX extractor 없음
+- 이미지 OCR/vision 없음
+- 다운로드 크기 제한 metadata 없음
+- `status=success|truncated`가 요구사항의 `content_status=available`과 다름
+- `content_metadata.extraction_method`, `content_kind`, `char_count`, `original_char_count`, `limits` 없음
+
+### 2.4 Loop
+
+`WorkflowExecutor._to_loop_item_payload()`는 `FILE_LIST -> SINGLE_FILE` 변환 시 `dict(item)`을 복사한 뒤 `type="SINGLE_FILE"`을 추가한다.
+
+따라서 item 안에 `content`, `content_status`, `content_error`, `content_metadata`가 있으면 보존된다. Loop 자체는 요구사항과 충돌하지 않는다.
+
+남은 일은 source/list/lazy extraction이 표준 필드를 채우도록 하는 것이다.
+
+### 2.5 LLM 노드
+
+`app/core/nodes/llm_node.py`는 `SINGLE_FILE` 입력에서 아래 순서로 본문을 찾는다.
+
+1. `extracted_text`
+2. `content`
+3. `source_service=google_drive`와 `file_id`가 있으면 `GoogleDriveService.extract_file_text()` lazy 호출
+4. 실패하면 filename/mime/url metadata 사용
+
+좋은 점:
+
+- 단일 Drive 파일 요약은 이미 metadata-only source 뒤에서도 lazy extraction 가능하다.
+- 테스트도 lazy extraction 경로를 검증한다.
+
+문제점:
+
+- extraction 실패를 LLM input의 문장으로 넣고 계속 요약할 수 있다. 요구사항은 content-dependent action에서 빈 요약 성공처럼 처리하지 말고 명시적 실패 또는 부분 성공으로 응답하라고 한다.
+- `FILE_LIST` 포맷터는 현재 filename/mime/size/url만 포함하고 item `content`를 넣지 않는다.
+- `SINGLE_EMAIL`은 `body`와 `bodyPreview`를 읽지만 attachment content는 읽지 않는다.
+
+### 2.6 Preview
+
+`app/core/engine/preview_executor.py`는 `include_content`를 받아 Google Drive 단일 파일 preview에서 `extract_file_text()`를 호출할 수 있다.
+
+현재 preview content 필드:
+
+- `content`: 항상 `None`
+- `extracted_text`: include_content=true일 때 추출 텍스트
+- `extraction_status`: `success|truncated|unsupported|failed|not_requested`
+
+문제점:
+
+- 요구사항의 `content_status/content_metadata`와 다르다.
+- `folder_all_files` preview에서 item별 include_content extraction이 없다.
+- AI 노드 preview는 아직 `PREVIEW_NOT_IMPLEMENTED`다.
+
+### 2.7 Gmail attachment
+
+`app/services/integrations/gmail.py`는 첨부파일 metadata를 재귀적으로 추출하지만 content download는 하지 않는다.
+
+현재 attachment item:
+
+```json
+{
+  "filename": "report.pdf",
+  "mime_type": "application/pdf",
+  "size": 12345,
+  "source": "gmail",
+  "messageId": "msg_1",
+  "attachmentId": "att_1",
+  "content": null,
+  "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg_1/attachments/att_1"
+}
+```
+
+따라서 Gmail 첨부 문서 요약은 현재 metadata 요약만 가능하다.
+
+---
+
+## 3. 표준 Canonical Contract
+
+### 3.1 `SINGLE_FILE`
+
+FastAPI 내부 canonical payload는 아래 shape를 표준으로 삼는다.
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "source_service": "google_drive|gmail|upload|url",
+  "file_id": "string",
+  "filename": "string",
+  "mime_type": "string",
+  "size": "number|string|null",
+  "url": "string|null",
+  "content": "string|null",
+  "content_status": "available|empty|unsupported|too_large|failed|not_requested",
+  "content_error": "string|null",
+  "content_metadata": {
+    "extraction_method": "google_export|pdf_text|csv_parse|pptx_text|word_text|hwpx_xml|plain_text|ocr|vision|gmail_attachment|none",
+    "content_kind": "plain_text|table_text|slide_text|ocr_text|image_description|mixed|none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0,
+    "limits": {
+      "max_download_bytes": 0,
+      "max_extracted_chars": 0,
+      "max_llm_input_chars": 0
+    }
+  }
+}
+```
+
+하위 호환을 위해 1차 구현 동안은 기존 필드를 병행 유지한다.
+
+- `extracted_text`: `content`와 같은 값
+- `extraction_status`: 기존 테스트 보호용 legacy status
+- `extraction_error`: `content_error` alias
+
+### 3.1.1 상태값 의미와 legacy mapping
+
+`content_status`는 사용자 표시와 실행 제어에 쓰는 표준 상태다.
+
+| `content_status` | 의미 | LLM content-dependent action 처리 |
+|------------------|------|-----------------------------------|
+| `available` | 본문 추출 성공. truncate 가능성은 metadata로 표시 | 실행 가능 |
+| `empty` | 파일은 읽었지만 추출 가능한 텍스트가 없음 | 기본 실패, 사용자가 허용한 경우만 부분 성공 |
+| `unsupported` | 파일 타입 또는 추출 방식 미지원 | 실패 |
+| `too_large` | 다운로드/추출/입력 제한 초과 | 실패 |
+| `failed` | 권한, 손상, parser exception 등 예기치 않은 실패 | 실패 |
+| `not_requested` | preview 또는 metadata-only 경로에서 아직 추출하지 않음 | lazy extraction 가능하면 재시도, 불가하면 실패 |
+
+기존 `extraction_status`와의 매핑:
+
+| legacy `extraction_status` | 표준 `content_status` |
+|----------------------------|-----------------------|
+| `success` | `available` |
+| `truncated` | `available` + `content_metadata.truncated=true` |
+| `unsupported` | `unsupported` |
+| `failed` | `failed` |
+| `not_requested` | `not_requested` |
+
+`content_status=available`이면서 `content=""`인 payload는 만들지 않는다. 텍스트가 비어 있으면 `empty`를 사용한다.
+
+### 3.2 `FILE_LIST`
+
+`FILE_LIST.items[]`는 `SINGLE_FILE`에서 `type`만 생략 가능한 같은 item shape를 사용한다.
+
+metadata-only preview에서는 아래처럼 content 미요청 상태를 명확히 둔다.
+
+```json
+{
+  "type": "FILE_LIST",
+  "items": [
+    {
+      "source_service": "google_drive",
+      "file_id": "file_1",
+      "filename": "report.pdf",
+      "mime_type": "application/pdf",
+      "content": null,
+      "content_status": "not_requested",
+      "content_error": null,
+      "content_metadata": {
+        "extraction_method": "none",
+        "content_kind": "none",
+        "truncated": false,
+        "char_count": 0,
+        "original_char_count": 0
+      }
+    }
+  ]
+}
+```
+
+### 3.3 Gmail attachments
+
+Gmail 첨부파일도 `FILE_LIST.items[]`로 전달될 수 있으므로 같은 file item shape를 사용한다.
+
+1차에서 attachment download/extraction을 구현하지 않을 경우:
+
+- metadata-only source/preview: `content_status="not_requested"`
+- content-dependent 실행에서 download/extraction 미구현: `content_status="unsupported"`
+- `content_error`: `"Gmail attachment content extraction is not supported yet."`
+- 사용자에게 "첨부파일 본문은 아직 읽지 않고 메타데이터만 사용한다"는 상태를 보여준다.
+
+---
+
+## 4. Content-Dependent Action 판별
+
+본문이 필요한 action:
+
+- `summarize`
+- `extract_info`
+- `extract`
+- `translate`
+- `classify_by_content`
+- `describe_image`
+- `ocr`
+- `ai_summarize`
+- `ai_analyze`
+
+권장 책임:
+
+- Spring: FE choice config를 해석해 `runtime_config.requires_content=true`를 전달한다.
+- FastAPI: `requires_content`가 없더라도 action 이름으로 보수적으로 재판별한다.
+- Preview API: target node가 content-dependent이면 `include_content=true`와 같은 효과를 적용하거나, metadata-only preview임을 `metadata.preview_scope`에 명확히 표시한다.
+
+FastAPI fallback 판별 예:
+
+```python
+CONTENT_DEPENDENT_ACTIONS = {
+    "summarize",
+    "extract",
+    "extract_info",
+    "translate",
+    "classify_by_content",
+    "describe_image",
+    "ocr",
+    "ai_summarize",
+    "ai_analyze",
+}
+```
+
+### 4.1 실행 시점별 책임
+
+본문 추출은 어느 한 레이어에만 몰아넣지 않고 아래 순서로 보장한다.
+
+| 시점 | 책임 | 비고 |
+|------|------|------|
+| Source 실행 | metadata와 lazy extraction key 보존 | `source_service`, `file_id`, `mime_type`, `url` 필수 |
+| Source preview | 기본 metadata-only, 요청 시 content 포함 | `include_content=false`면 `not_requested` |
+| Loop 변환 | item payload 필드 손실 금지 | `dict(item)` 복사 방식 유지 |
+| LLM 직전 | `requires_content=true` 또는 content-dependent action이면 lazy extraction | source가 metadata-only여도 여기서 마지막 보장 |
+| Output 실행 | 원본 파일 bytes가 필요한 sink는 기존 download 경로 사용 | 본문 추출용 text와 파일 전송용 bytes를 혼동하지 않음 |
+
+핵심 원칙:
+
+- source는 항상 "나중에 읽을 수 있는 key"를 남긴다.
+- LLM은 본문이 필요할 때 metadata만으로 성공하지 않는다.
+- preview는 빠른 metadata preview와 content 포함 preview를 명확히 구분한다.
+
+---
+
+## 5. 구현 계획
+
+### Phase 1. Canonical payload 정규화
+
+대상 파일:
+
+- `app/models/canonical.py`
+- `app/core/nodes/input_node.py`
+- `app/core/engine/preview_executor.py`
+- `app/services/integrations/google_drive.py`
+- `app/core/nodes/llm_node.py`
+
+작업:
+
+1. file content 기본값 builder를 추가한다.
+   - `content=None`
+   - `content_status="not_requested"`
+   - `content_error=None`
+   - `content_metadata.extraction_method="none"`
+   - `content_metadata.content_kind="none"`
+2. Google Drive source/preview의 `SINGLE_FILE`, `FILE_LIST.items[]`에 표준 필드를 추가한다.
+3. 기존 `extracted_text`, `extraction_status`는 compatibility field로 유지한다.
+4. Loop 테스트에 `content_status/content_metadata` 보존 케이스를 추가한다.
+5. `app/models/canonical.py`의 `SingleFilePayload`, `FileItem`, `EmailAttachment`를 표준 contract와 맞춘다.
+
+완료 기준:
+
+- metadata-only source payload만 봐도 "본문 미요청" 상태를 구분할 수 있다.
+- 기존 테스트는 깨지지 않는다.
+
+### Phase 2. Google Drive extraction result 표준화
+
+대상 파일:
+
+- `app/services/integrations/google_drive.py`
+- 신규 후보: `app/services/document_extractors/*`
+
+작업:
+
+1. `extract_file_text()` 반환값을 표준 shape로 확장한다.
+2. legacy 반환 필드도 당분간 유지한다.
+3. `success/truncated`를 `content_status=available`로 매핑한다.
+4. 빈 텍스트는 `empty`로 처리한다.
+5. `MAX_EXTRACTED_TEXT_CHARS` 기반 truncate 시 metadata에 `truncated=true`, `char_count`, `original_char_count`를 기록한다.
+6. `limits`를 metadata에 포함한다.
+
+권장 반환 예:
+
+```json
+{
+  "text": "문서 본문",
+  "status": "success",
+  "truncated": false,
+  "error": null,
+  "content": "문서 본문",
+  "content_status": "available",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "pdf_text",
+    "content_kind": "plain_text",
+    "truncated": false,
+    "char_count": 5,
+    "original_char_count": 5,
+    "limits": {
+      "max_download_bytes": 0,
+      "max_extracted_chars": 60000,
+      "max_llm_input_chars": 0
+    }
+  }
+}
+```
+
+완료 기준:
+
+- preview와 LLM lazy extraction이 같은 extraction result contract를 사용한다.
+- 추출 실패가 단순 metadata 요약 성공으로 숨겨지지 않는다.
+
+### Phase 2.1 Extractor registry 분리
+
+`GoogleDriveService.extract_file_text()`가 모든 parser를 직접 들고 있으면 Drive/Gmail/URL 업로드가 같은 extractor를 재사용하기 어렵다.
+
+권장 구조:
+
+```text
+app/services/document_extractors/
+  __init__.py
+  models.py
+  registry.py
+  text.py
+  csv.py
+  pdf.py
+  docx.py
+  pptx.py
+  hwpx.py
+```
+
+권장 인터페이스:
+
+```python
+class DocumentExtractionResult(TypedDict):
+    content: str | None
+    content_status: str
+    content_error: str | None
+    content_metadata: dict
+    text: str
+    status: str
+    truncated: bool
+    error: str | None
+```
+
+`registry.extract(raw, filename, mime_type, source_hint)`는 MIME type, 확장자, file signature 순서로 extractor를 고르고, 실패 시 fallback 가능성을 기록한다.
+
+Google Drive는 다운로드/export만 담당하고, 본문 해석은 registry에 위임한다. Gmail attachment를 2차로 구현할 때도 같은 registry를 사용한다.
+
+### Phase 3. 필수 파일군 extractor 추가
+
+필수 지원 우선순위:
+
+1. TXT/MD/LOG
+   - UTF-8, UTF-8 BOM, CP949 decode fallback
+   - `extraction_method=plain_text`
+2. CSV/TSV
+   - UTF-8, UTF-8 BOM, CP949 decode fallback
+   - delimiter 감지 또는 MIME/확장자 기반 분기
+   - header와 row를 LLM이 읽을 수 있는 table text로 변환
+   - `extraction_method=csv_parse`, `content_kind=table_text`
+3. PDF text layer
+   - 기존 `pypdf` 유지
+   - text가 비면 `empty` 또는 scan PDF `unsupported` 판단
+   - `extraction_method=pdf_text`
+4. DOCX
+   - `python-docx` 또는 zip/XML 직접 파싱
+   - paragraph/table 우선
+   - `extraction_method=word_text`
+5. PPTX
+   - `python-pptx` 또는 zip/XML 직접 파싱
+   - slide 번호/title/body/note 순서 유지
+   - `extraction_method=pptx_text`, `content_kind=slide_text`
+6. HWPX
+   - zip 내부 XML에서 body text 추출
+   - `extraction_method=hwpx_xml`
+7. Google Workspace
+   - 기존 export 유지
+   - Docs는 plain text, Sheets는 csv_parse, Slides는 가능하면 slide_text 또는 plain_text
+
+의존성 가이드:
+
+- PDF: 이미 사용 중인 `pypdf` 유지
+- DOCX/PPTX: 신규 dependency를 추가하기 전, zip/XML 직접 파싱으로 MVP 요구를 만족할 수 있는지 먼저 검토
+- CSV/TSV/TXT/HWPX: 표준 라이브러리로 구현 가능
+- OCR/vision: provider 결정 전까지 dependency 추가 금지
+
+조건부 지원:
+
+- `.ppt`, `.doc`: 변환기 없으면 `unsupported`
+- image: OCR/vision 미구현이면 `unsupported`
+- scan PDF: OCR 미구현이면 `unsupported` 또는 `empty`가 아니라 scan/OCR 미지원 사유를 `content_error`에 기록
+
+완료 기준:
+
+- 필수 파일군은 성공 또는 명확한 실패 사유를 반환한다.
+- 조건부 파일군은 미지원 상태가 사용자 표시 가능한 메시지를 갖는다.
+
+### Phase 4. LLM 입력 정책 강화
+
+대상 파일:
+
+- `app/core/nodes/llm_node.py`
+
+작업:
+
+1. `SINGLE_FILE`은 `content`를 우선하고, legacy `extracted_text`를 fallback으로 둔다.
+2. `FILE_LIST.items[]` 포맷터가 item content를 포함한다.
+3. `content_status in {"unsupported", "too_large", "failed"}`이고 action이 content-dependent이면 `FlowifyException`으로 실패 처리한다.
+4. `content_status="not_requested"`이고 lazy extraction key가 있으면 extraction을 시도한다.
+5. `content_status="empty"`이고 action이 요약/분석/추출처럼 본문 의미가 필요한 작업이면 실패 처리한다.
+6. metadata-only action 또는 파일 라우팅/분류처럼 본문 없이도 의미 있는 action은 `empty`를 부분 성공으로 허용할 수 있지만, 결과 metadata에 `content_status=empty`를 남긴다.
+7. lazy extraction 결과를 LLM input에만 쓰는 대신 가능하면 payload에도 표준 content 필드를 반영하는 helper를 둔다.
+8. Gmail attachment content는 1차 미지원이면 LLM input에 "첨부 본문 미지원" 상태를 명확히 포함하거나 content-dependent action에서 실패 처리한다.
+9. `SINGLE_EMAIL`의 attachment content가 지원되는 경우, 본문 입력은 `email.body` 다음에 attachment별 filename/content/status를 구분해 붙인다.
+
+완료 기준:
+
+- 본문이 필요한 요약/분석 action이 filename만 보고 성공 요약을 만들지 않는다.
+- 요약/분석/추출 action에서 `unsupported`, `too_large`, `failed`, `empty` 상태가 명시적 실패 또는 사용자 표시 가능한 부분 실패로 기록된다.
+- metadata-only action은 본문 실패를 숨기지 않고 payload metadata에 남긴다.
+- `FILE_LIST -> LOOP -> AI`와 `SINGLE_FILE -> AI`가 동일한 content contract를 사용한다.
+
+### Phase 5. Preview 정책 정리
+
+대상 파일:
+
+- `app/core/engine/preview_executor.py`
+- Spring preview request translator
+- FE `DataPreviewBlock`
+
+작업:
+
+1. source preview metadata에는 기존 호환 필드 `preview_scope="source_metadata"`를 유지한다.
+2. `include_content=true`일 때는 `content`, `content_status`, `content_metadata`를 채운다.
+3. folder preview에서 `include_content=true`인 경우 limit 범위 item별 extraction을 수행할지 결정한다.
+4. AI 노드 preview는 별도 구현 전까지 `PREVIEW_NOT_IMPLEMENTED` 대신 "source preview만 가능" 이유를 유지하되, content-dependent target preview 설계를 문서화한다.
+5. FE는 `content_status`, `content_error`, `truncated`를 표시한다.
+6. preview 응답 metadata에 신규 의미 필드 `content_policy`를 추가한다.
+   - `metadata_only`
+   - `content_included`
+   - `content_status_only`
+   - `content_required_but_unavailable`
+
+호환 필드와 신규 필드 병행 규칙:
+
+| 필드 | 형식 | 목적 | 유지 기간 |
+|------|------|------|-----------|
+| `metadata.preview_scope` | snake_case | 기존 FastAPI preview response 호환 | 기존 FE/Spring 전환 완료까지 유지 |
+| `metadata.previewScope` | camelCase 선택 | Spring public API가 camelCase로 재직렬화할 때 사용 가능 | Spring 응답 정책에 따름 |
+| `metadata.content_policy` | snake_case | FastAPI 내부/테스트 기준 신규 의미 필드 | 표준 필드 |
+| `metadata.contentPolicy` | camelCase 선택 | Spring public API/FE 표시용 신규 의미 필드 | Spring 응답 정책에 따름 |
+
+권장 preview metadata 예:
+
+```json
+{
+  "preview_scope": "source_metadata",
+  "content_policy": "metadata_only",
+  "include_content": false
+}
+```
+
+Spring이 public API에서 camelCase만 노출한다면 아래처럼 변환한다.
+
+```json
+{
+  "previewScope": "source_metadata",
+  "contentPolicy": "metadata_only",
+  "includeContent": false
+}
+```
+
+완료 기준:
+
+- preview에서 본문이 빠진 상태와 추출 실패 상태가 구분된다.
+
+### Phase 6. Gmail attachment 범위 결정
+
+선택지:
+
+- Option A: 1차 미지원으로 명시
+  - attachment item에 `content_status="unsupported"`
+  - FE 템플릿/preview에 제한 표시
+- Option B: Gmail attachment download + 공통 extractor 연결
+  - Gmail API `messages.attachments.get` 호출
+  - base64url decode
+  - Google Drive와 같은 extractor registry 사용
+
+권장:
+
+- 1차는 Option A로 명확히 막고, Google Drive 필수 파일군을 먼저 안정화한다.
+- 2차에서 Option B를 구현한다.
+
+### Phase 7. 보안, 로깅, 저장 정책
+
+본문 추출은 민감한 문서 내용을 다루므로 실행 로그와 callback payload 정책을 명확히 둔다.
+
+권장 정책:
+
+1. 노드 실행 중 in-memory payload는 다음 노드 실행에 필요한 full `content`를 가질 수 있다.
+2. FastAPI가 실행 로그를 저장하기 전 `_sanitize_for_log()`에서 긴 `content`를 제한 길이로 truncate한다.
+3. FastAPI가 Spring callback payload를 만들 때도 저장 로그와 같은 sanitized payload를 보낸다. full content를 callback으로 보내지 않는다.
+4. Spring은 callback 수신 후 다시 저장/조회용 sanitize를 적용할 수 있지만, 1차 책임 경계는 FastAPI 반환 전 sanitize다.
+5. truncate된 로그에는 `content_metadata.truncated_for_log=true` 또는 별도 `log_metadata`를 남긴다.
+6. 원본 파일 bytes는 저장하지 않는다.
+7. extractor exception에는 파일 본문 일부를 넣지 않는다.
+8. `content_error`는 사용자 표시 가능한 메시지로 제한하고, 상세 stack trace는 서버 로그에만 남긴다.
+9. OAuth scope/권한 문제는 `content_status=failed`, `content_error="파일을 읽을 권한이 없습니다."`처럼 사용자 행동이 가능한 메시지로 변환한다.
+
+경계 요약:
+
+| 경로 | full content 허용 여부 | 정책 |
+|------|------------------------|------|
+| 노드 실행 중 in-memory payload | 허용 | 다음 LLM/후속 노드 실행에 필요할 수 있음 |
+| MongoDB execution log | 비허용 | sanitize 후 preview 길이만 저장 |
+| FastAPI -> Spring callback | 비허용 | sanitize된 log payload만 전송 |
+| Spring public 조회 API | 비허용 | 저장된 sanitized payload를 그대로 또는 추가 마스킹 후 반환 |
+| 서버 debug log | 비허용 | content 본문 직접 출력 금지 |
+
+### Phase 8. 에러 코드와 관측성
+
+FastAPI error code 후보:
+
+- `DOCUMENT_CONTENT_UNSUPPORTED`
+- `DOCUMENT_CONTENT_TOO_LARGE`
+- `DOCUMENT_CONTENT_EXTRACTION_FAILED`
+- `DOCUMENT_CONTENT_NOT_REQUESTED`
+- `DOCUMENT_CONTENT_EMPTY`
+
+Spring public API 매핑 권장:
+
+| FastAPI error code | HTTP status | node status | 사용자 문구 예 | 비고 |
+|--------------------|-------------|-------------|----------------|------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | 422 | `failed` 또는 `partial_failed` | 이 파일 형식은 아직 본문 읽기를 지원하지 않습니다. | 조건부 지원 파일군/미지원 MIME |
+| `DOCUMENT_CONTENT_TOO_LARGE` | 413 | `failed` | 파일이 현재 처리 가능한 크기를 초과했습니다. | limit metadata 함께 표시 |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 502 또는 500 | `failed` | 파일 본문을 읽는 중 오류가 발생했습니다. | 외부 API 실패는 502, parser 내부 실패는 500 |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 409 | `failed` | 본문이 필요한 작업이지만 본문 추출이 요청되지 않았습니다. | translator/config 오류 가능성 |
+| `DOCUMENT_CONTENT_EMPTY` | 422 | `failed` 또는 `partial_failed` | 파일에서 읽을 수 있는 텍스트를 찾지 못했습니다. | 스캔 PDF/OCR 미지원과 구분 |
+| `OAUTH_TOKEN_INVALID` | 401 | `failed` | 파일을 읽기 위한 인증이 만료되었습니다. | 기존 OAuth error와 통합 |
+| `EXTERNAL_API_ERROR` | 502 | `failed` | 외부 파일 서비스에서 파일을 가져오지 못했습니다. | Drive/Gmail API 실패 |
+
+Spring은 raw exception message를 그대로 FE에 노출하지 않고, `error_code`, 사용자 문구, node id, content status 정도만 public response에 포함한다. 상세 stack trace와 extractor 내부 error는 서버 로그 또는 internal metadata로 제한한다.
+
+관측성 metadata:
+
+```json
+{
+  "content_metadata": {
+    "source": "google_drive",
+    "detected_mime_type": "application/pdf",
+    "declared_mime_type": "application/pdf",
+    "extension": ".pdf",
+    "extraction_method": "pdf_text",
+    "duration_ms": 123,
+    "attempts": ["mime:application/pdf", "extension:.pdf"]
+  }
+}
+```
+
+이 metadata는 디버깅용이지만 사용자에게 그대로 노출하지 않아도 된다. FE에는 `content_status`, `content_error`, `truncated`, `char_count` 정도만 표시한다.
+
+---
+
+## 6. 테스트 계획
+
+### Unit tests
+
+추가/수정 대상:
+
+- `app/models/canonical.py`
+- `tests/test_preview_executor.py`
+- `tests/test_llm_node.py`
+- `tests/test_executor.py`
+- `tests/test_integrations/test_google_drive.py`
+
+필수 케이스:
+
+1. Google Drive single_file metadata-only preview
+   - `content_status="not_requested"`
+   - `content_metadata.extraction_method="none"`
+2. Google Drive single_file include_content preview
+   - `content="문서 본문"`
+   - `content_status="available"`
+   - legacy `extracted_text`도 유지
+3. `FILE_LIST -> LOOP -> SINGLE_FILE`
+   - item의 `content_status/content_metadata` 보존
+4. LLM `SINGLE_FILE.content` 우선 사용
+5. LLM legacy `extracted_text` fallback 사용
+6. LLM Google Drive lazy extraction result의 표준 metadata 처리
+7. LLM `FILE_LIST.items[].content` 포함
+8. unsupported/failed file content-dependent action 실패 처리
+9. TXT UTF-8/UTF-8 BOM/CP949 extraction
+10. CSV UTF-8/CP949 table text extraction
+11. PDF text layer extraction
+12. DOCX paragraph/table text extraction
+    - paragraph 순서 유지
+    - table cell text 포함
+    - `extraction_method=word_text`
+13. PPTX slide text extraction
+    - slide 번호 순서 유지
+    - title/body/note 또는 추출 가능한 placeholder text 포함
+    - `content_kind=slide_text`
+14. HWPX XML body extraction
+    - zip 내부 XML body text 추출
+    - 손상/암호화 파일은 `failed|unsupported`
+    - `extraction_method=hwpx_xml`
+15. Gmail attachment metadata-only 미지원 상태
+16. `app/models/canonical.py` 모델이 표준 file content field를 수용하는지
+17. log sanitize가 긴 `content`를 제한하고 metadata를 보존하는지
+
+### Integration-like tests
+
+외부 API는 mock으로 둔다.
+
+1. `single_file -> llm summarize`
+   - source output은 metadata-only
+   - LLM에서 lazy extraction 호출
+   - LLM input에 본문 포함
+2. `folder_all_files -> loop -> llm summarize`
+   - item별 file_id/mime_type 유지
+   - body iteration에서 lazy extraction 호출
+3. `attachment_email -> llm summarize`
+   - 1차 미지원 선택 시 사용자 표시 가능한 failure 또는 partial failure
+
+### Contract tests
+
+Spring/FE와 맞출 계약 테스트를 별도로 둔다.
+
+1. Spring이 `runtime_config.requires_content=true`를 보낸 payload를 FastAPI가 수용한다.
+2. preview request의 `include_content=true`가 source preview 결과의 `content_status`를 `available|empty|unsupported|failed|too_large` 중 하나로 만든다.
+3. execution log callback payload에서 `content_status/content_error/content_metadata`가 보존된다.
+4. legacy field가 있는 payload와 신규 field가 있는 payload를 모두 LLM이 처리한다.
+5. callback payload의 긴 `content`가 truncate되어 Spring에 전달된다.
+6. FastAPI error code가 Spring public error shape로 매핑된다.
+
+---
+
+## 7. Spring/FE 요청사항
+
+### Spring
+
+1. `runtime_config.requires_content`를 생성한다.
+2. `choiceActionId`, `choiceNodeType`, `choiceSelections`를 FastAPI runtime payload에 유지한다.
+3. preview target이 content-dependent이면 `includeContent=true`를 전달하거나, FastAPI가 판단할 수 있는 target node context를 전달한다.
+4. 실행 로그의 `inputData/outputData`에서 `content_status`, `content_error`, `content_metadata`를 제거하지 않는다.
+
+#### Spring requiresContent 판별 보강
+
+Spring Boot 팀 책임으로 아래 우선순위에 따라 `runtime_config.requires_content`를 생성한다.
+
+1. 명시 필드 우선
+   - FE 또는 template이 이미 `requiresContent`/`requires_content`를 저장했다면 그 값을 우선한다.
+2. `choiceActionId`
+   - `summarize`, `ai_summarize`, `extract_info`, `translate`, `classify_by_content`, `describe_image`, `ocr`, `ai_analyze`는 true.
+3. `choiceSelections`
+   - `choiceSelections.summarize`, `choiceSelections.extract_info`, `choiceSelections.translate`처럼 action key가 있으면 true.
+   - `choiceSelections.follow_up`만 있고 action이 `filter_fields`, `filter_metadata`이면 false. 이는 필드 projection이지 본문 의미 분석이 아니다.
+4. node/action fallback
+   - `runtime_config.action`, `config.action`, `dataType`, `outputDataType`를 확인한다.
+   - LLM 계열 action이 content-dependent 목록에 있으면 true.
+5. prompt fallback
+   - template migration 데이터에서 action id가 누락된 경우에만 사용한다.
+   - prompt에 "요약", "summarize", "본문", "문서 내용", "extract", "translate", "OCR" 같은 강한 키워드가 있고 입력 타입이 `SINGLE_FILE|FILE_LIST|SINGLE_EMAIL`이면 true로 둘 수 있다.
+   - prompt fallback은 false positive 위험이 있으므로 `runtime_config.requires_content_inferred=true`, `requires_content_reason="prompt_keyword"` 같은 추론 metadata를 함께 남긴다.
+
+Spring pseudo-code:
+
+```java
+boolean requiresContent(Node node) {
+    if (node.hasExplicitRequiresContent()) return node.getRequiresContent();
+
+    String actionId = node.config("choiceActionId");
+    if (CONTENT_ACTIONS.contains(actionId)) return true;
+
+    Map<String, Object> selections = node.config("choiceSelections");
+    if (containsAnyKey(selections, CONTENT_ACTIONS)) return true;
+    if (isMetadataOnlyChoice(actionId, selections)) return false;
+
+    String action = firstNonBlank(
+        node.runtimeConfig("action"),
+        node.config("action")
+    );
+    if (CONTENT_ACTIONS.contains(action)) return true;
+
+    return inferFromPromptOnlyForLegacyTemplates(node);
+}
+```
+
+FastAPI도 방어적으로 action 기반 fallback을 갖되, Spring이 보낸 명시 `requires_content`를 가장 신뢰한다.
+
+#### Spring public error shape
+
+Spring public API는 FastAPI 내부 error를 아래 shape로 정규화한다.
+
+```json
+{
+  "errorCode": "DOCUMENT_CONTENT_UNSUPPORTED",
+  "message": "이 파일 형식은 아직 본문 읽기를 지원하지 않습니다.",
+  "nodeId": "node_ai_1",
+  "nodeStatus": "failed",
+  "contentStatus": "unsupported",
+  "retryable": false
+}
+```
+
+`retryable` 권장값:
+
+- `DOCUMENT_CONTENT_TOO_LARGE`: false
+- `DOCUMENT_CONTENT_UNSUPPORTED`: false
+- `DOCUMENT_CONTENT_EMPTY`: false
+- `DOCUMENT_CONTENT_EXTRACTION_FAILED`: true if external/transient, false if parser/file damage
+- `DOCUMENT_CONTENT_NOT_REQUESTED`: false, translator/config 수정 필요
+- `OAUTH_TOKEN_INVALID`: true after re-auth
+
+### FE
+
+1. source preview는 metadata-only일 수 있음을 표시한다.
+2. AI 요약/분석 preview는 content 포함 preview를 요청한다.
+3. `SINGLE_FILE`과 `FILE_LIST.items[]`에 대해 아래 상태를 표시한다.
+   - `available`: 본문 읽기 완료
+   - `empty`: 파일은 읽었지만 추출 가능한 텍스트 없음
+   - `not_requested`: 미리보기에서 본문 미포함
+   - `unsupported`: 지원하지 않는 파일
+   - `too_large`: 크기 제한 초과
+   - `failed`: 추출 실패
+4. 템플릿 설명에 Gmail 첨부 본문 지원 여부를 실제 런타임 기준으로 맞춘다.
+
+---
+
+## 8. 결정 필요사항
+
+아래 항목은 구현 전에 팀 결정이 필요하다.
+
+1. Gmail 첨부파일 본문 읽기를 1차에 포함할지
+   - 권장: 1차 미지원 명시, 2차 구현
+2. 이미지 OCR/vision을 1차에 포함할지
+   - 권장: 1차 미지원 명시, OCR/vision provider 확정 후 구현
+3. 최대 다운로드 크기
+   - 임시 권장: 20MB
+4. 최대 추출 문자 수
+   - 현재 코드: 60,000 chars
+   - 권장: 유지하되 `content_metadata.limits.max_extracted_chars=60000` 기록
+5. LLM input 최대 문자 수
+   - 권장: 모델별 제한과 별도 product limit 중 작은 값 적용
+6. 추출 실패 시 workflow 실패로 볼 action 범위
+   - 권장: `requires_content=true`이면 실패, metadata-only action이면 부분 성공 허용
+7. legacy field 제거 시점
+   - 권장: FE/Spring 반영 후 한 릴리즈 이상 병행 유지
+8. 로그에 본문을 얼마나 저장할지
+   - 권장: 실행 디버깅용으로 짧은 preview만 저장하고, 전체 content는 저장하지 않음
+9. DOCX/PPTX 구현 방식
+   - 권장: dependency 추가 전 zip/XML 직접 파싱 MVP 검토
+10. `content_status=empty` 처리
+   - 권장: 요약/분석에서는 실패, 파일 분류/라우팅에서는 부분 성공 허용 가능
+
+---
+
+## 9. 권장 구현 순서
+
+1. `content_status/content_metadata` helper 추가
+2. `app/models/canonical.py`를 표준 필드에 맞게 확장
+3. Google Drive source/preview payload에 표준 필드 추가
+4. Google Drive extractor 반환 shape 확장
+5. Extractor registry를 분리하고 TXT/CSV/PDF를 먼저 연결
+6. LLM node가 표준 field를 우선 사용하도록 수정
+7. `FILE_LIST` formatter에 item content 포함
+8. unsupported/failed/empty 상태에서 content-dependent action 실패 처리
+9. DOCX/PPTX/HWPX extractor 추가
+10. Gmail attachment는 미지원 상태 명시 또는 download 구현
+11. 로그 sanitize와 error code 정리
+12. FE/Spring contract 문서와 preview 표시 반영
+
+---
+
+## 10. 완료 기준 분리
+
+이 문서는 두 종류의 완료 기준을 명확히 구분한다.
+
+### 10.1 계약/경로 안정화 MVP
+
+이 기준은 런타임 경로와 canonical contract를 먼저 안정화하기 위한 중간 마일스톤이다. 원문 요구사항의 1차 완료와 동일하지 않다.
+
+계약/경로 안정화 MVP는 아래를 모두 만족하면 완료로 본다.
+
+- `SINGLE_FILE`과 `FILE_LIST.items[]`에 `content_status`, `content_error`, `content_metadata`가 항상 존재한다.
+- Google Drive 단일 문서 요약에서 LLM input에 실제 본문이 들어간다.
+- `FILE_LIST -> LOOP -> AI summarize` 경로에서 본문 또는 lazy extraction key가 손실되지 않는다.
+- TXT/CSV/PDF/Google Workspace는 본문 추출 성공 또는 명확한 실패 사유를 반환한다.
+- DOCX/PPTX/HWPX가 아직 미구현이면 `unsupported`로 명확히 응답하고, 문서/릴리즈 노트에 "원문 1차 완료 미달"로 표시한다.
+- Gmail 첨부파일 요약은 지원 여부가 preview와 실행 결과에 명확히 표시된다.
+- 추출 실패가 빈 요약 성공으로 처리되지 않는다.
+- preview와 실제 실행 모두에서 본문 포함/미포함 상태가 구분된다.
+- 저장 로그와 Spring callback payload에는 full content가 남지 않는다.
+
+### 10.2 원문 요구사항 1차 완료
+
+원문 `.docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`의 1차 필수 지원군까지 완료하려면 계약/경로 안정화 MVP에 더해 아래가 모두 필요하다.
+
+- DOCX extractor가 paragraph와 table text를 추출한다.
+- PPTX extractor가 slide 순서를 유지하고 title/body/note 또는 추출 가능한 placeholder text를 추출한다.
+- HWPX extractor가 zip 내부 XML body text를 추출한다.
+- DOCX/PPTX/HWPX 손상/암호화/파싱 실패 파일이 `failed|unsupported`와 사용자 표시 가능한 `content_error`를 반환한다.
+- DOCX/PPTX/HWPX unit test와 integration-like test가 통과한다.
+- Spring public API가 FastAPI document content error code를 사용자 표시 가능한 error shape로 변환한다.
+- FE preview가 필수 지원 파일군의 `available|empty|unsupported|too_large|failed|not_requested` 상태를 모두 표시할 수 있다.
+
+DOCX/PPTX/HWPX를 뒤로 미루는 릴리즈는 "계약/경로 안정화 MVP"로만 부르고, "문서 본문 원문 요구사항 1차 완료" 또는 "필수 파일군 지원 완료"라고 표기하지 않는다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md
@@ -1,0 +1,278 @@
+# 문서 본문 런타임 분석 및 구현 계획
+
+> 작성일: 2026-05-14  
+> 기준 문서: `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`, `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS_ANALYSIS.md`  
+> 목적: 문서 본문 추출/요약 런타임을 Spring Boot와 FastAPI 책임으로 분리하고, MVP와 원문 1차 완료 범위를 혼동 없이 정의한다.
+
+---
+
+## 1. 범위 구분
+
+이 문서는 두 완료 기준을 분리한다.
+
+| 구분 | 목적 | 포함 범위 | 완료 의미 |
+|------|------|-----------|-----------|
+| 계약/경로 안정화 MVP | payload 계약, `requires_content`, preview/error/log 경계를 먼저 고정 | TXT/Markdown, CSV/TSV, PDF text layer, Google Workspace export, Gmail attachment metadata status | 본문 추출 경로가 동작하고 실패/미지원이 명확히 표시됨 |
+| 원문 요구사항 1차 완료 | 원문에 명시된 필수 파일군까지 실제 extractor 지원 | MVP + DOCX, PPTX, HWPX | 원문 `5.1.1 1차 지원 대상 파일 타입`의 필수 지원군이 구현/검증됨 |
+
+MVP는 원문 요구사항을 축소 완료했다는 뜻이 아니다. MVP는 FastAPI/Spring/FE 계약과 실행 경로를 먼저 안정화하기 위한 중간 마일스톤이다. 원문 요구사항의 1차 완료로 선언하려면 DOCX/PPTX/HWPX까지 필수 지원군 extractor와 테스트가 포함되어야 한다.
+
+---
+
+## 2. 책임 분리
+
+### 2.1 Spring Boot 책임
+
+- editor 모델을 FastAPI runtime 모델로 변환한다.
+- content-dependent 노드에 `runtime_config.requires_content=true`를 전달한다.
+- FastAPI error code를 Spring public API error/status로 변환한다.
+- preview 응답의 기존 호환 필드와 신규 content 정책 필드를 같이 보존한다.
+- FastAPI callback 또는 preview 응답을 저장하기 전에 저장 정책에 맞게 sanitize/truncate한다.
+
+Spring은 파일 다운로드와 본문 추출을 직접 수행하지 않는다.
+
+### 2.2 FastAPI 책임
+
+- Google Drive/Gmail source payload를 canonical payload로 정규화한다.
+- 파일 타입을 판별하고 본문을 추출한다.
+- `content_status`, `content_error`, `content_metadata`를 생성한다.
+- Loop에서 `FILE_LIST.items[]`의 content 관련 필드 또는 lazy extraction key를 보존한다.
+- LLM input builder가 canonical payload의 본문 필드를 일관되게 읽는다.
+- Spring으로 반환할 callback/preview payload는 저장 정책에 맞춰 full content 또는 truncated content를 구분한다.
+
+FastAPI는 원문 bytes/base64와 LLM용 추출 텍스트를 같은 필드에 섞지 않는다.
+
+---
+
+## 3. Runtime Contract
+
+### 3.1 `SINGLE_FILE.content` 의미
+
+`content`는 LLM/preview/UI가 읽을 수 있는 canonical text representation으로 고정한다.
+
+| 목적 | 권장 필드 |
+|------|-----------|
+| LLM 입력용 추출 텍스트 | `content` |
+| 추출 상태 | `content_status` |
+| 사용자 표시 가능한 실패 사유 | `content_error` |
+| 추출 방식/길이/제한값 | `content_metadata` |
+| 원본 파일 재전달 | `file_id`, `download_url`, `content_ref`, `raw_content_base64` 중 별도 계약 |
+
+Gmail/Google Drive sink가 원본 파일 업로드나 첨부를 수행해야 할 때는 `content`를 원본 bytes로 해석하지 않는다.
+
+### 3.2 Preview metadata 병행 정책
+
+기존 호환 필드는 유지하고, 신규 의미 필드를 추가한다.
+
+```json
+{
+  "metadata": {
+    "previewScope": "source_metadata",
+    "contentPolicy": "metadata_only",
+    "contentIncluded": false,
+    "contentStatusScope": "none",
+    "limit": 5
+  }
+}
+```
+
+권장 값:
+
+| 필드 | 값 | 설명 |
+|------|----|------|
+| `previewScope` | `source_metadata` | 기존 FE 호환 필드. source preview라는 API 범위를 뜻함 |
+| `contentPolicy` | `metadata_only` | 본문 미포함 |
+| `contentPolicy` | `content_included` | 본문 포함 |
+| `contentPolicy` | `content_status_only` | 본문 원문 없이 추출 가능/불가 상태만 포함 |
+| `contentPolicy` | `required_by_downstream` | 다음 노드가 본문을 요구함 |
+| `contentIncluded` | boolean | 실제 `content` 포함 여부 |
+| `contentStatusScope` | `none|item|attachment|node` | content status가 어느 단위에 붙었는지 |
+
+`previewScope=source_metadata`와 `contentPolicy=metadata_only`는 충돌하지 않는다. 전자는 preview API 범위, 후자는 본문 포함 정책이다.
+
+### 3.3 `content_status=empty` 정책
+
+| 상황 | 처리 |
+|------|------|
+| `requires_content=true`이고 action이 `summarize`, `extract_info`, `translate`, `ai_analyze` | 실패 또는 사용자 표시 가능한 partial failure. 빈 요약 성공 금지 |
+| `requires_content=true`이고 action이 `ocr`, `describe_image` | extractor 결과가 빈 경우 실패 또는 `empty` 명시 |
+| metadata-only action | 부분 성공 가능. 파일명/MIME/URL 기반 결과임을 metadata에 표시 |
+| source preview metadata-only | `not_requested` 또는 `empty`를 성공처럼 표시하지 않고 scope를 명시 |
+
+LLM은 `empty`, `unsupported`, `too_large`, `failed`, `not_requested`를 정상 본문으로 간주하면 안 된다.
+
+---
+
+## 4. Spring Implementation Plan
+
+### 4.1 `requires_content` 판별
+
+판별 우선순위:
+
+1. node config의 명시적 `requires_content` 또는 `requiresContent`.
+2. `choiceActionId` 또는 `choice_action_id`.
+3. `action`, 단 `process`는 choice prompt resolver의 기본 runtime action이므로 content action으로 보지 않는다.
+4. `choiceSelections` key 중 content-dependent action id와 정확히 일치하는 key.
+5. 파일/메일 계열 `dataType` + 생성형 `outputDataType` + AI/AI_FILTER 노드 조합.
+
+`choiceSelections` fallback은 마이그레이션 데이터 방어용이다. selection value는 style id일 수 있으므로 action id로 해석하지 않는다.
+
+### 4.2 Spring error mapping
+
+FastAPI error code는 Spring public API에서 사용자 표시 가능한 error/status로 변환한다.
+
+| FastAPI error_code | Spring ErrorCode 후보 | HTTP status | node/preview status | 사용자 문구 후보 |
+|--------------------|-----------------------|-------------|---------------------|------------------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | `PREFLIGHT_VALIDATION_FAILED` 또는 신규 `DOCUMENT_CONTENT_UNSUPPORTED` | 422 | `unavailable` | 이 파일 형식은 아직 본문 읽기를 지원하지 않습니다. |
+| `DOCUMENT_CONTENT_TOO_LARGE` | `PREFLIGHT_VALIDATION_FAILED` 또는 신규 `DOCUMENT_CONTENT_TOO_LARGE` | 413 또는 422 | `unavailable` | 파일이 너무 커서 본문을 읽을 수 없습니다. |
+| `DOCUMENT_CONTENT_EMPTY` | 신규 `DOCUMENT_CONTENT_EMPTY` 또는 `EXECUTION_FAILED` | 422 | `failed` | 파일에서 읽을 수 있는 본문이 없습니다. |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | `EXTERNAL_API_ERROR` 또는 신규 `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 502 | `failed` | 파일 본문 추출 중 오류가 발생했습니다. |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 에러 아님 | 200 | `available` | 본문 미포함 미리보기입니다. |
+| `OAUTH_SCOPE_INSUFFICIENT` | `OAUTH_SCOPE_INSUFFICIENT` | 403 | `unavailable` | 파일을 읽기 위한 권한이 부족합니다. |
+| `OAUTH_TOKEN_MISSING` | `OAUTH_NOT_CONNECTED` | 401 또는 403 | `unavailable` | 외부 서비스 연결이 필요합니다. |
+
+신규 Spring `ErrorCode`를 추가하지 않는 MVP에서는 기존 code로 매핑하되, `metadata.fastApiErrorCode` 또는 `reason`에 원본 error code를 보존한다. FE가 사용자 문구를 안정적으로 표시해야 한다면 신규 ErrorCode 추가가 더 낫다.
+
+### 4.3 저장/sanitize 경계
+
+실행 중 full content가 필요하더라도 저장/조회 payload는 별도 정책을 따른다.
+
+| 단계 | full content 허용 | sanitize 책임 | 정책 |
+|------|-------------------|---------------|------|
+| FastAPI 내부 실행 컨텍스트 | 허용 | FastAPI | LLM 입력 생성에 사용 |
+| FastAPI -> Spring callback | 기본적으로 truncated 권장 | FastAPI 우선 | `content`는 최대 저장 길이로 자르고 metadata에 표시 |
+| Spring 저장 전 | full content 수신 가능성 방어 | Spring | `content`, `raw_content_base64`, signed URL/token 제거 또는 truncate |
+| Spring public 조회 API | full content 비권장 | Spring | preview snippet/status/metadata 중심 |
+
+권장 metadata:
+
+```json
+{
+  "content_metadata": {
+    "truncated": true,
+    "char_count": 4000,
+    "original_char_count": 82000,
+    "stored_content_truncated": true,
+    "stored_char_count": 1000
+  }
+}
+```
+
+FastAPI가 반환 전 sanitize하는 것이 1차 방어선이고, Spring 저장 전 sanitize는 2차 방어선이다.
+
+---
+
+## 5. FastAPI Implementation Plan
+
+### 5.1 Extractor MVP
+
+계약/경로 안정화 MVP 대상:
+
+| 파일군 | 구현 |
+|--------|------|
+| TXT/Markdown | UTF-8, UTF-8 BOM, CP949 인코딩 처리 |
+| CSV/TSV | header와 row를 table text로 변환 |
+| PDF text layer | OCR 없이 text layer 추출 |
+| Google Docs | text/plain export |
+| Google Sheets | CSV export 후 table text |
+| Google Slides | text 또는 pptx export 가능 경로 우선 |
+| Gmail attachment | content 미지원이면 metadata + `content_status=unsupported|not_requested` |
+
+### 5.2 원문 1차 필수 extractor
+
+원문 요구사항 1차 완료에는 아래가 추가로 필요하다.
+
+| 파일군 | 필수 테스트 기준 |
+|--------|------------------|
+| DOCX | paragraph, table text, header/footer 중 최소 paragraph/table 추출 |
+| PPTX | slide 순서 유지, title/body/speaker note 구분 |
+| HWPX | zip 내부 XML body text 추출 |
+
+DOCX/PPTX/HWPX를 구현하지 않은 상태는 MVP일 수는 있지만 원문 1차 완료가 아니다.
+
+### 5.3 LLM input policy
+
+입력 우선순위:
+
+| payload | 본문 필드 우선순위 |
+|---------|-------------------|
+| `TEXT` | `content` |
+| `SINGLE_FILE` | `content` only |
+| `FILE_LIST` | `items[].content`; 없으면 metadata 보조 정보 |
+| `SINGLE_EMAIL` | `body`, `bodyPreview`, `body_preview`, `snippet` |
+| `EMAIL_LIST` | 각 item의 `body`, `bodyPreview`, `body_preview`, `snippet` |
+| Gmail attachment | `attachments[].content`가 있을 때만 본문 사용 |
+
+`requires_content=true`인데 status가 `empty|unsupported|too_large|failed|not_requested`이면 LLM 호출 전에 실패/partial failure로 중단한다.
+
+---
+
+## 6. Test Plan
+
+### 6.1 Spring unit tests
+
+- `choiceActionId=summarize` + `action=process`인 AI 노드는 `requires_content=true`.
+- `choiceSelections` key가 `summarize`인 legacy config는 `requires_content=true`.
+- `choiceSelections` value가 `brief` 같은 style id인 경우에는 action으로 오판하지 않음.
+- `PASSTHROUGH`는 `requires_content=false`.
+- 명시적 `requires_content=false`는 자동 추론보다 우선.
+- preview metadata는 `previewScope=source_metadata`와 `contentPolicy=metadata_only`를 함께 반환.
+- FastAPI `DOCUMENT_CONTENT_UNSUPPORTED` 응답은 Spring reason/public error로 보존.
+
+### 6.2 FastAPI unit tests
+
+MVP:
+
+- TXT UTF-8, UTF-8 BOM, CP949 추출.
+- CSV/TSV header와 row text 변환.
+- PDF text layer 추출.
+- Google Docs text/plain export 결과 정규화.
+- Google Sheets CSV export 결과 header 보존.
+- Gmail attachment metadata-only일 때 `content_status=unsupported|not_requested`.
+
+원문 1차 필수:
+
+- DOCX paragraph와 table text 추출.
+- PPTX slide order, slide title/body/note 추출.
+- HWPX zip XML body text 추출.
+
+공통:
+
+- unsupported MIME type은 `content_status=unsupported`와 사용자 표시 가능한 `content_error`.
+- too large 파일은 `content_status=too_large`.
+- 추출 결과 truncate 시 `available` + `content_metadata.truncated=true`.
+- LLM input builder는 `empty|unsupported|too_large|failed|not_requested`를 정상 본문으로 사용하지 않음.
+
+### 6.3 Integration scenarios
+
+- Google Drive single_file -> AI summarize -> Slack.
+- Google Drive folder_new_file -> Loop/lazy extraction -> AI summarize.
+- Google Drive folder_all_files -> FILE_LIST item content status 보존.
+- Gmail attachment_email -> AI summarize는 미지원이면 명확한 제한 상태를 반환.
+- Preview metadata-only와 실제 실행 content-included 결과가 구분됨.
+
+---
+
+## 7. Completion Criteria
+
+### 7.1 계약/경로 안정화 MVP 완료
+
+- Spring runtime model에 `requires_content`가 안정적으로 포함된다.
+- `choiceActionId` 기반 AI 노드는 `action=process`여도 content-dependent로 판별된다.
+- FastAPI payload에 `content_status`, `content_error`, `content_metadata`가 포함된다.
+- TXT/CSV/PDF text layer/Google Workspace 경로에서 본문 추출 또는 명확한 실패가 동작한다.
+- Preview는 `previewScope=source_metadata`를 유지하면서 `contentPolicy`로 본문 포함 정책을 구분한다.
+- FastAPI error code가 Spring public API에서 사용자 표시 가능한 reason/status로 보존된다.
+- Spring 저장/조회 payload에는 full content 저장 여부와 truncate/sanitize 정책이 적용된다.
+
+### 7.2 원문 요구사항 1차 완료
+
+MVP 완료 기준에 더해 아래가 모두 필요하다.
+
+- DOCX paragraph/table 추출이 구현되고 테스트된다.
+- PPTX slide 순서와 slide text/note 추출이 구현되고 테스트된다.
+- HWPX XML body 추출이 구현되고 테스트된다.
+- 필수 지원군 전체가 `content_status=available` 또는 명확한 파일별 실패 사유를 반환한다.
+- `FILE_LIST -> LOOP -> LLM` 경로에서 content 또는 lazy extraction key가 손실되지 않는다.
+- `content_status=empty` 정책이 요약/분석 실패 또는 partial failure로 일관되게 처리된다.
+- Gmail 첨부파일 요약은 지원 또는 미지원 범위가 FE에 명확히 표시된다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md
@@ -84,11 +84,19 @@ Gmail/Google Drive sink가 원본 파일 업로드나 첨부를 수행해야 할
 | `contentPolicy` | `metadata_only` | 본문 미포함 |
 | `contentPolicy` | `content_included` | 본문 포함 |
 | `contentPolicy` | `content_status_only` | 본문 원문 없이 추출 가능/불가 상태만 포함 |
-| `contentPolicy` | `required_by_downstream` | 다음 노드가 본문을 요구함 |
 | `contentIncluded` | boolean | 실제 `content` 포함 여부 |
 | `contentStatusScope` | `none|item|attachment|node` | content status가 어느 단위에 붙었는지 |
+| `contentRequired` | boolean | downstream 또는 runtime config가 본문을 요구하는지 |
+| `contentRequiredReason` | `downstream|user_request|runtime_config|null` | 본문 필요 사유 |
 
 `previewScope=source_metadata`와 `contentPolicy=metadata_only`는 충돌하지 않는다. 전자는 preview API 범위, 후자는 본문 포함 정책이다.
+
+FE 연동 관점에서는 `DOCUMENT_CONTENT_RUNTIME_FRONTEND_INTEGRATION_REVIEW.md`의 표시 계약을 따른다. 특히 downstream 때문에 본문이 필요한 상태는 `contentPolicy` 값으로 직접 섞지 않고 `contentRequired=true`, `contentRequiredReason=downstream`으로 분리한다.
+
+FastAPI raw response 또는 legacy FE 설계에서 `contentPolicy=required_by_downstream` 또는 `contentPolicy=content_required_but_unavailable`이 들어오더라도 Spring public API에서는 가능한 한 정규화한다.
+
+- `required_by_downstream` -> `contentPolicy=metadata_only|content_status_only`, `contentRequired=true`, `contentRequiredReason=downstream`
+- `content_required_but_unavailable` -> `contentPolicy=content_status_only`, `contentIncluded=false`, `contentRequired=true`, `contentRequiredReason=runtime_config`
 
 ### 3.3 `content_status=empty` 정책
 
@@ -127,11 +135,13 @@ FastAPI error code는 Spring public API에서 사용자 표시 가능한 error/s
 | `DOCUMENT_CONTENT_TOO_LARGE` | `PREFLIGHT_VALIDATION_FAILED` 또는 신규 `DOCUMENT_CONTENT_TOO_LARGE` | 413 또는 422 | `unavailable` | 파일이 너무 커서 본문을 읽을 수 없습니다. |
 | `DOCUMENT_CONTENT_EMPTY` | 신규 `DOCUMENT_CONTENT_EMPTY` 또는 `EXECUTION_FAILED` | 422 | `failed` | 파일에서 읽을 수 있는 본문이 없습니다. |
 | `DOCUMENT_CONTENT_EXTRACTION_FAILED` | `EXTERNAL_API_ERROR` 또는 신규 `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 502 | `failed` | 파일 본문 추출 중 오류가 발생했습니다. |
-| `DOCUMENT_CONTENT_NOT_REQUESTED` | 에러 아님 | 200 | `available` | 본문 미포함 미리보기입니다. |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 에러 아님. FastAPI가 error response로 보낸 경우 신규 `DOCUMENT_CONTENT_NOT_REQUESTED` | 200 또는 422 | `available` 또는 `failed` | 본문 미포함 미리보기입니다. 실행 실패라면 본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다. |
 | `OAUTH_SCOPE_INSUFFICIENT` | `OAUTH_SCOPE_INSUFFICIENT` | 403 | `unavailable` | 파일을 읽기 위한 권한이 부족합니다. |
 | `OAUTH_TOKEN_MISSING` | `OAUTH_NOT_CONNECTED` | 401 또는 403 | `unavailable` | 외부 서비스 연결이 필요합니다. |
 
 신규 Spring `ErrorCode`를 추가하지 않는 MVP에서는 기존 code로 매핑하되, `metadata.fastApiErrorCode` 또는 `reason`에 원본 error code를 보존한다. FE가 사용자 문구를 안정적으로 표시해야 한다면 신규 ErrorCode 추가가 더 낫다.
+
+FE 표시 정책상 `DOCUMENT_CONTENT_NOT_REQUESTED`는 기본적으로 실패가 아니라 info 성격의 content policy다. 단, FastAPI가 `requires_content=true`인 실행 경로에서 본문 추출이 수행되지 않아 error response로 내려준 경우에는 Spring public error code도 `DOCUMENT_CONTENT_NOT_REQUESTED`로 보존한다.
 
 ### 4.3 저장/sanitize 경계
 
@@ -153,12 +163,18 @@ FastAPI error code는 Spring public API에서 사용자 표시 가능한 error/s
     "char_count": 4000,
     "original_char_count": 82000,
     "stored_content_truncated": true,
-    "stored_char_count": 1000
+    "stored_char_count": 1000,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 80000,
+      "max_llm_input_chars": 20000
+    }
   }
 }
 ```
 
 FastAPI가 반환 전 sanitize하는 것이 1차 방어선이고, Spring 저장 전 sanitize는 2차 방어선이다.
+`limits`는 FE가 모든 값을 기본 노출하기 위한 필드가 아니라, `too_large` 또는 truncate 상태의 보조 설명과 디버깅에 사용할 수 있는 metadata다.
 
 ---
 

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_BACKEND_IMPLEMENTATION_HANDOFF.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_BACKEND_IMPLEMENTATION_HANDOFF.md
@@ -1,0 +1,362 @@
+# 문서 본문 런타임 Backend 구현 전달 문서
+
+> 작성일: 2026-05-14  
+> Backend 브랜치: `feat/26-runtime-document`  
+> 전달 대상: Frontend 팀  
+> 관련 문서:
+> - `.docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `.docs/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN.md`
+> - `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_FE_DESIGN_REVIEW.md`
+> - `.docs/DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md`
+> - `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`
+
+---
+
+## 1. 전달 요약
+
+문서 본문 런타임 계약의 Backend 1차 구현이 완료되었다.
+
+이번 구현은 FE가 문서 본문 상태를 일관되게 표시할 수 있도록 canonical payload와 error contract를 런타임 경로에 반영한 "계약/경로 안정화 MVP"다. 최종 보강으로 원문 1차 필수 파일군인 DOCX/PPTX/HWPX extractor도 함께 반영했다.
+
+FE에서 기대할 수 있는 핵심 변화:
+
+- `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment에 `content_status`, `content_error`, `content_metadata`가 포함된다.
+- 기존 호환을 위해 `extracted_text`, `extraction_status`도 유지된다.
+- preview response metadata에 실제 본문 포함 여부 기준 `content_policy`가 포함된다.
+- `content_metadata.limits`가 기본 포함된다.
+- 크기 제한 초과 시 `content_status=too_large`와 사용자 표시 가능한 `content_error`가 생성된다.
+- Google Drive DOCX/PPTX/HWPX 파일도 본문 추출 대상에 포함된다.
+- 문서 본문이 필요한 LLM action에서 본문 추출 실패가 빈 성공 결과처럼 처리되지 않고 `DOCUMENT_CONTENT_*` error로 실패한다.
+- 실행 로그와 callback 경로에 저장되는 긴 `content`는 truncate될 수 있다.
+
+---
+
+## 2. FE 구현 시 기준으로 볼 필드
+
+### 2.1 File payload 공통 필드
+
+Backend는 파일 payload에 아래 필드를 공통으로 포함한다.
+
+```json
+{
+  "filename": "report.pdf",
+  "mime_type": "application/pdf",
+  "size": 12345,
+  "content": null,
+  "content_status": "not_requested",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "none",
+    "content_kind": "none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 60000,
+      "max_llm_input_chars": 60000
+    }
+  },
+  "extracted_text": null,
+  "extraction_status": "not_requested"
+}
+```
+
+FE 권장 처리:
+
+- 신규 표시는 `content_status`, `content_error`, `content_metadata`, `content`를 우선 사용한다.
+- `content`가 없고 `extracted_text`가 있으면 legacy fallback으로 표시할 수 있다.
+- Spring public API에서 camelCase로 변환될 수 있으므로 FE helper는 snake_case와 camelCase를 모두 읽는 것이 안전하다.
+
+### 2.2 Content status
+
+Backend 표준 상태는 아래 6개다.
+
+| status | 의미 | FE 표시 권장 |
+|--------|------|--------------|
+| `available` | 본문 사용 가능 | 본문 읽기 완료 |
+| `empty` | 추출 가능한 본문 없음 | 읽을 수 있는 본문 없음 |
+| `unsupported` | 지원하지 않는 형식 | 지원하지 않는 파일 형식 |
+| `too_large` | 크기 제한 초과 | 파일 크기 제한 초과 |
+| `failed` | 추출 실패 | 본문 읽기 실패 |
+| `not_requested` | 본문 추출 미요청 | 본문 미포함 |
+
+요약/분석처럼 본문이 필요한 action에서는 `empty`, `unsupported`, `too_large`, `failed`, `not_requested`가 실패로 처리될 수 있다.
+
+### 2.3 Content metadata
+
+현재 Backend가 내려줄 수 있는 주요 metadata:
+
+| field | 의미 |
+|-------|------|
+| `extraction_method` | 추출 방식. 예: `none`, `google_export`, `pdf_text`, `text_decode`, `csv_parse` |
+| `content_kind` | 본문 종류. 예: `none`, `plain_text`, `table_text`, `slide_text` |
+| `truncated` | 추출 단계에서 본문이 잘렸는지 여부 |
+| `char_count` | 현재 content 길이 |
+| `original_char_count` | 원본 추출 본문 길이 |
+| `limits.max_download_bytes` | 다운로드/추출 전 byte 크기 제한 |
+| `limits.max_extracted_chars` | 추출 후 content 최대 문자 수 |
+| `limits.max_llm_input_chars` | LLM 입력 기준 최대 문자 수 |
+| `truncated_for_log` | 실행 로그 저장 전 잘렸는지 여부 |
+| `stored_content_truncated` | 저장/조회용 content가 잘렸는지 여부 |
+| `stored_char_count` | 저장된 content 길이 |
+
+FE 표시에서는 `truncated`, `stored_content_truncated` 중 하나라도 true이면 "본문 일부만 표시됨" 계열의 안내를 붙이는 것이 좋다.
+
+---
+
+## 3. Preview contract
+
+### 3.1 Metadata-only preview
+
+기본 source preview는 비용과 latency를 줄이기 위해 metadata-only다.
+
+```json
+{
+  "metadata": {
+    "preview_scope": "source_metadata",
+    "content_policy": "metadata_only",
+    "include_content": false
+  },
+  "data": {
+    "type": "SINGLE_FILE",
+    "content_status": "not_requested"
+  }
+}
+```
+
+FE 권장 표시:
+
+- `preview_scope`는 기존 preview 범위 호환 필드로 유지한다.
+- `content_policy`를 본문 포함 여부의 의미 필드로 사용한다.
+- `metadata_only`이면 "본문 미포함 미리보기"로 표시한다.
+
+### 3.2 Content-included preview
+
+`include_content=true`로 preview가 호출되면 가능한 경우 본문 추출 결과가 포함된다. 다만 `content_policy=content_included`는 실제 `content`가 있거나 `content_status=available`일 때만 내려간다.
+
+```json
+{
+  "metadata": {
+    "preview_scope": "source_metadata",
+    "content_policy": "content_included",
+    "include_content": true
+  },
+  "data": {
+    "type": "SINGLE_FILE",
+    "filename": "report.pdf",
+    "content": "문서 본문...",
+    "content_status": "available",
+    "content_error": null,
+    "content_metadata": {
+      "extraction_method": "pdf_text",
+      "content_kind": "plain_text",
+      "truncated": false,
+      "char_count": 8,
+      "original_char_count": 8,
+      "limits": {
+        "max_download_bytes": 10485760,
+        "max_extracted_chars": 60000,
+        "max_llm_input_chars": 60000
+      }
+    },
+    "extracted_text": "문서 본문...",
+    "extraction_status": "success"
+  }
+}
+```
+
+본문을 요청했지만 추출 결과가 `unsupported`, `too_large`, `failed`, `empty`, `not_requested`이면 `content_policy`는 `content_included`가 아니라 `content_status_only` 또는 `metadata_only`로 내려간다.
+
+```json
+{
+  "metadata": {
+    "preview_scope": "source_metadata",
+    "content_policy": "content_status_only",
+    "include_content": true
+  },
+  "data": {
+    "type": "SINGLE_FILE",
+    "filename": "archive.zip",
+    "content": null,
+    "content_status": "unsupported",
+    "content_error": "이 파일 형식은 아직 본문 읽기를 지원하지 않습니다."
+  }
+}
+```
+
+FE 1차 구현에서는 기존 설계대로 source preview의 기본값을 `includeContent=false`로 유지해도 된다. `본문 포함 미리보기` 버튼은 Backend/Spring public API 정책이 확정된 뒤 2차로 열어도 무방하다.
+
+### 3.3 Content policy 값
+
+현재 FE helper에서 수용해야 할 값:
+
+| policy | 의미 |
+|--------|------|
+| `metadata_only` | 본문 미포함 |
+| `content_included` | 본문 포함 |
+| `content_status_only` | 본문 상태만 포함 |
+| `content_required_but_unavailable` | 본문이 필요한 단계지만 현재 본문 없음 |
+| `required_by_downstream` | Spring public alias 가능값 |
+
+FastAPI raw 기준은 snake_case field와 `content_required_but_unavailable`이다. Spring public API가 `required_by_downstream`을 쓰는 경우 FE는 alias로 같이 수용하면 된다.
+
+---
+
+## 4. Gmail attachment contract
+
+Gmail attachment도 파일 카드 helper로 처리할 수 있도록 content 상태 필드를 가진다.
+
+metadata-only 상태 예시:
+
+```json
+{
+  "filename": "attached.pdf",
+  "mime_type": "application/pdf",
+  "source": "gmail",
+  "messageId": "msg_1",
+  "attachmentId": "att_1",
+  "content": null,
+  "content_status": "not_requested",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "none",
+    "content_kind": "none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 60000,
+      "max_llm_input_chars": 60000
+    }
+  }
+}
+```
+
+현재 1차 Backend 구현에는 Gmail attachment download + 공통 extractor 연결이 아직 후속 과제로 남아 있다. 따라서 FE는 Gmail attachment의 `not_requested` 또는 미지원 상태를 자연스럽게 표시하면 된다.
+
+---
+
+## 5. Error contract
+
+Backend에 아래 error code를 추가했다.
+
+| code | HTTP 성격 | FE fallback 문구 권장 |
+|------|-----------|------------------------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | 422 | 이 파일 형식은 아직 본문 읽기를 지원하지 않습니다. |
+| `DOCUMENT_CONTENT_TOO_LARGE` | 413 | 파일이 너무 커서 본문을 읽을 수 없습니다. |
+| `DOCUMENT_CONTENT_EMPTY` | 422 | 파일에서 읽을 수 있는 본문이 없습니다. |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 502 | 파일 본문을 읽는 중 오류가 발생했습니다. |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 409 | 본문이 필요한 작업이지만 본문 추출이 요청되지 않았습니다. |
+
+실행 실패 시 Backend error detail에는 context가 포함될 수 있다.
+
+```json
+{
+  "code": "DOCUMENT_CONTENT_UNSUPPORTED",
+  "message": "이 파일 형식은 아직 본문 읽기를 지원하지 않습니다",
+  "context": {
+    "filename": "archive.zip",
+    "content_status": "unsupported",
+    "content_error": "이 파일 형식은 아직 본문 읽기를 지원하지 않습니다."
+  }
+}
+```
+
+`content_error`는 FE에 표시 가능한 짧은 메시지로 정규화된다. raw parser exception, stack trace, 문서 일부 내용은 `content_error`로 내려가지 않는다.
+
+FE 표시 우선순위 권장:
+
+1. Spring public API가 내려준 사용자 친화적 message
+2. `DOCUMENT_CONTENT_*` code 기반 FE fallback 문구
+3. 기존 OAuth/column/not found/rate limit 등 기존 매핑
+4. generic 실행 실패 문구
+
+---
+
+## 6. 현재 지원 범위와 후속 과제
+
+이번 Backend 구현에서 안정화된 범위:
+
+- canonical content status field 추가
+- preview `content_policy` 추가
+- `content_metadata.limits` 기본 포함
+- 다운로드/추출 크기 제한 초과 시 `too_large` status 생성
+- Google Drive TXT/CSV/TSV/PDF text/DOCX/PPTX/HWPX/Google Workspace export 계열 추출 경로 정리
+- DOCX paragraph/table text 추출
+- PPTX slide order/title/body/note text 추출
+- HWPX zip XML body text 추출
+- 텍스트 레이어 없는 PDF는 OCR 미지원 `unsupported`로 반환
+- LLM content-dependent action의 본문 실패 처리
+- execution log/callback payload truncate 경계 정리
+- 사용자 표시 가능한 `content_error` 정규화
+- 상태별 sample payload fixture 제공
+- legacy `extracted_text`/`extraction_status` 병행 유지
+
+아직 제품 안정화와 확장 지원을 위해 남은 범위:
+
+- scan PDF OCR 실제 지원
+- image OCR/vision 실제 지원
+- Gmail attachment download + extractor 연결
+
+Spring public API의 `DOCUMENT_CONTENT_*` error shape 변환은 Spring Boot 팀에서 완료된 상태로 정리한다.
+
+FE fixture/sample payload는 `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`에 제공했다.
+
+따라서 FE 문서나 UI 문구에서는 현재 범위를 "문서 본문 런타임 계약 1차 반영" 또는 "계약/경로 안정화 MVP + 원문 1차 필수 파일군 extractor 1차 구현"으로 부르는 것이 안전하다. "다양한 파일 완전 호환" 같은 표현은 Gmail attachment/OCR/vision 확장 전까지 피한다.
+
+---
+
+## 7. FE 구현 체크리스트
+
+FE 쪽에서 바로 반영하면 좋은 항목:
+
+- `content_status`, `content_error`, `content_metadata`, `content` helper 추가
+- snake_case와 camelCase 동시 지원
+- `content` 우선, `extracted_text`/`extractedText` fallback
+- `SINGLE_FILE` 상태 표시
+- `FILE_LIST.items[]` 상태 집계와 개별 상태 표시
+- Gmail attachment 상태 표시
+- preview metadata의 `contentPolicy`/`content_policy` 표시
+- `DOCUMENT_CONTENT_*` error fallback 문구 매핑
+- `truncated`/`stored_content_truncated` 안내 표시
+
+1차에서 보수적으로 유지할 항목:
+
+- source preview 기본 요청은 `includeContent=false`
+- `본문 포함 미리보기` 버튼은 2차 확장
+- AI 노드 preview는 Backend/Spring dry-run capability 확정 후 노출
+- FE에서 파일 본문 직접 다운로드/파싱하지 않음
+
+---
+
+## 8. Backend 검증 결과
+
+검증 환경:
+
+- Conda env: `cse_2`
+- 실행 방식: `/opt/homebrew/anaconda3/bin/conda run -n cse_2 ...`
+
+검증 결과:
+
+```text
+py_compile: 통과
+targeted regression suite: 122 passed in 0.37s
+full test suite: 393 passed in 23.82s
+```
+
+참고:
+
+- 최초 `cse_2` 환경에는 `feedparser`가 없어 설치 후 재실행했다.
+- sandbox network 제한 상태에서는 MongoDB SRV DNS 조회 때문에 `tests/test_trigger_api.py` 6건이 error였으나, 네트워크 허용 재실행에서 전체 통과했다.
+
+---
+
+## 9. FE 팀에 요청하는 확인 사항
+
+1. Spring public API에서 field casing이 최종적으로 camelCase인지, FastAPI raw snake_case가 일부 노출될 수 있는지 확인이 필요하다.
+2. `content_required_but_unavailable`과 `required_by_downstream` 중 public API 대표값을 하나로 정하되, FE helper는 둘 다 수용하는 방향을 권장한다.
+3. 실행 결과 화면에서 `content`는 전체 원문이 아니라 truncate될 수 있는 "본문 미리보기"로 표시해야 한다.
+4. Gmail attachment는 1차에서 본문 추출 완료가 아니라 상태 표시 중심으로 처리하는 것이 맞다.
+5. DOCX/PPTX/HWPX extractor는 Backend에 반영되었고, OCR/vision/Gmail attachment extraction은 후속 구현 후 fixture를 추가로 공유할 예정이다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_FINAL_IMPLEMENTATION_REVIEW.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_FINAL_IMPLEMENTATION_REVIEW.md
@@ -1,0 +1,219 @@
+# 문서 본문 런타임 최종 구현 검토
+
+> 작성일: 2026-05-14  
+> FE 브랜치: `feat#172-document_content_runtime`  
+> Spring Boot 브랜치: `feat/30-runtime-document`  
+> FastAPI 브랜치: `feat/26-runtime-document`  
+> 검토 기준:
+> - `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md`
+> - `DOCUMENT_CONTENT_RUNTIME_FRONTEND_INTEGRATION_REVIEW.md`
+> - `DOCUMENT_CONTENT_RUNTIME_SPRING_BOOT_IMPLEMENTATION_REPORT.md`
+> - `DOCUMENT_CONTENT_RUNTIME_BACKEND_IMPLEMENTATION_HANDOFF.md`
+> - `DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md`
+> - `DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`
+
+---
+
+## 1. 최종 결론
+
+Spring Boot, FastAPI, FE 구현은 현재 보고서 기준으로 **문서 본문 런타임 계약/경로 안정화 MVP + 원문 1차 필수 파일군 extractor 1차 구현** 범위까지 완료된 것으로 판단한다.
+
+완료로 판단하는 핵심 근거:
+
+- Spring Boot가 content-dependent 노드에 `runtime_config.requires_content`를 안정적으로 전달한다.
+- Spring Boot가 FastAPI `DOCUMENT_CONTENT_*` error code를 public ErrorCode로 보존한다.
+- Spring Boot public 조회 경로에서 `nodeLogs[].error.code/context`와 `content_status/content_error/content_metadata`가 보존된다.
+- FastAPI가 `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment에 `content_status`, `content_error`, `content_metadata`, `content` 기본 필드를 제공한다.
+- FastAPI가 preview `content_policy`를 실제 본문 포함 여부 기준으로 보정한다.
+- FastAPI가 본문이 필요한 LLM action에서 본문 추출 실패를 빈 요약 성공으로 처리하지 않는다.
+- FastAPI가 DOCX, PPTX, HWPX extractor와 LLM 입력 integration-like 테스트를 추가했다.
+- FastAPI가 텍스트 레이어 없는 PDF를 OCR 미지원 `unsupported`로 명확히 반환한다.
+- 실행 로그와 callback output의 긴 `content`는 truncate되고 기존 `content_metadata`는 보존된다.
+- FE는 snake_case/camelCase payload, content status, preview policy, document content error code를 표시할 수 있다.
+
+단, 아래 항목은 완료 범위가 아니다.
+
+- Gmail attachment 본문 download/extraction
+- scan PDF OCR 실제 지원
+- image OCR/vision 실제 지원
+- “모든 파일 완전 호환” 수준의 제품 보장
+
+따라서 현재 릴리즈/PR 표현은 아래처럼 잡는다.
+
+| 표현 | 사용 가능 여부 |
+|------|----------------|
+| 문서 본문 런타임 계약/경로 안정화 MVP 완료 | 가능 |
+| 원문 1차 필수 파일군 extractor 1차 구현 완료 | 가능 |
+| Google Drive 기반 PDF text/TXT/CSV/TSV/DOCX/PPTX/HWPX/Google Workspace 본문 추출 경로 반영 | 가능 |
+| Gmail 첨부 본문 추출 완료 | 불가 |
+| scan PDF OCR/image OCR/vision 완료 | 불가 |
+| 다양한 파일 완전 호환 | 불가 |
+
+---
+
+## 2. 이전 피드백 수용 여부
+
+| 피드백 | 반영 여부 | 판단 |
+|--------|-----------|------|
+| `includeContent=true`여도 실제 본문이 없으면 `content_included`로 표시하지 않기 | 반영됨 | Spring/FastAPI 모두 실제 `content` 또는 `content_status=available` 기준으로 보정 |
+| FastAPI metadata 병합 시 `null`이 Spring 기본값을 덮지 않게 하기 | 반영됨 | Spring 보고서에 null merge 방어 명시 |
+| `content_metadata.limits` 기본 포함 | 반영됨 | sample payload와 handoff에 `max_download_bytes`, `max_extracted_chars`, `max_llm_input_chars` 포함 |
+| `too_large` status 실제 생성 | 반영됨 | Google Drive extraction에서 알려진 파일 크기 또는 다운로드 byte 기준 제한 초과 처리 |
+| 로그 truncate 시 기존 `content_metadata` 보존 | 반영됨 | `stored_content_truncated`, `stored_char_count`, `truncated_for_log`가 metadata 내부 병합됨 |
+| `content_error` raw exception 노출 방지 | 반영됨 | 사용자 표시 가능한 짧은 메시지만 내려가는 것으로 보고됨 |
+| `DOCUMENT_CONTENT_NOT_REQUESTED`를 별도 Spring public code로 보존 | 반영됨 | Spring ErrorCode와 FE fallback 문구 반영 |
+| Spring public 조회에서 node error `code/context` 보존 | 반영됨 | Spring `ErrorDetail.context` 추가 및 조회 테스트 반영 |
+| DOCX/PPTX/HWPX extractor | 반영됨 | FastAPI report 기준 extractor와 LLM 입력 integration-like 테스트 추가 |
+| 상태별 sample payload fixture | 반영됨 | `DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json` 추가 |
+
+---
+
+## 3. Spring Boot 최종 검토
+
+### 3.1 완료로 볼 수 있는 항목
+
+- `choiceActionId=summarize` + `action=process` 경로가 `requires_content=true`가 되도록 고정됐다.
+- legacy `choiceSelections`와 명시적 `requires_content=false` 우선순위가 테스트됐다.
+- preview metadata 기본값과 `includeContent=true` content 포함 여부 보정이 반영됐다.
+- FastAPI metadata의 null 값이 Spring 기본 metadata를 덮지 않는다.
+- `DOCUMENT_CONTENT_UNSUPPORTED`, `DOCUMENT_CONTENT_TOO_LARGE`, `DOCUMENT_CONTENT_EMPTY`, `DOCUMENT_CONTENT_EXTRACTION_FAILED`, `DOCUMENT_CONTENT_NOT_REQUESTED`가 Spring public ErrorCode로 보존된다.
+- `nodeLogs[].error.code/context`가 public execution detail/node data 조회 경로에서 보존된다.
+- execution complete update에서 output의 nested document content fields가 보존된다.
+
+### 3.2 남은 Spring Boot 후속
+
+| 우선순위 | 항목 | 판단 |
+|----------|------|------|
+| P1 | Spring 저장 전 2차 sanitize 방어 | FastAPI sanitize가 1차 방어선이지만 운영 안정화를 위해 후속 필요 |
+| P1 | 실제 Mongo 통합 fixture 기반 E2E | service 단위 contract test는 반영됨. 더 넓은 E2E는 후속 권장 |
+| P1 | `contentRequiredReason=downstream` graph 분석 | 현재 기본 false/null 정책. UX 고도화 시 후속 |
+| P2 | AI/중간 노드 preview capability | 현재 source preview 중심. backend capability 확정 후 후속 |
+| P2 | Spring `CONTENT_ACTIONS`에 `extract` alias 추가 여부 | FastAPI는 alias 지원. Spring 템플릿은 명시 `requires_content=true`라 차단 아님 |
+
+Spring Boot 쪽에 현재 PR을 막을 차단급 문제는 없다.
+
+---
+
+## 4. FastAPI 최종 검토
+
+### 4.1 완료로 볼 수 있는 항목
+
+- canonical content fields가 `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment에 추가됐다.
+- legacy `extracted_text`, `extraction_status`가 병행 유지된다.
+- `content_metadata.limits`가 기본 포함된다.
+- TXT/CSV/TSV, PDF text layer, Google Workspace export 경로가 정리됐다.
+- DOCX paragraph/table text extractor가 추가됐다.
+- PPTX slide order/title/body/note text extractor가 추가됐다.
+- HWPX zip XML body text extractor와 손상 HWPX 실패 처리 테스트가 추가됐다.
+- DOCX/PPTX/HWPX가 `SINGLE_FILE -> LLM summarize` 경로에서 실제 LLM input으로 들어가는 integration-like 테스트가 추가됐다.
+- 텍스트 레이어 없는 PDF는 OCR 미지원 `unsupported`로 반환된다.
+- `too_large`, `empty`, `unsupported`, `failed`, `not_requested` 상태가 content-dependent action에서 빈 성공으로 처리되지 않는다.
+- LOOP body 실패 시 기존 content error context와 iteration/body node context가 병합된다.
+- safe error message 정책과 log/callback sanitize 정책이 반영됐다.
+- full test suite가 네트워크 허용 환경에서 통과한 것으로 보고됐다.
+
+### 4.2 남은 FastAPI 후속
+
+| 우선순위 | 항목 | 판단 |
+|----------|------|------|
+| P1 | Gmail attachment download + extractor 연결 | 아직 후속. 현재는 metadata/status 표시 중심 |
+| P1 | scan PDF OCR 실제 지원 | 아직 후속. OCR 미지원이면 `unsupported` 유지 |
+| P1 | image OCR/vision 실제 지원 | 아직 후속. vision 미구현이면 `unsupported` 유지 |
+| P1 | cross-service fixture 기반 E2E | sample payload는 제공됨. 실제 Spring-FastAPI-FE E2E는 후속 |
+| P2 | extractor registry 일반화 | Gmail/upload/url 확장 시 후속 검토 |
+
+FastAPI 쪽에 현재 PR을 막을 차단급 문제는 없다.
+
+---
+
+## 5. FE 최종 검토
+
+FE는 현재 Spring/FastAPI 계약을 소비할 수 있다.
+
+반영 완료:
+
+- `content_status`, `content_error`, `content_metadata`, `content` helper.
+- snake_case와 camelCase fallback.
+- `content -> extracted_text -> extractedText` fallback.
+- `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment 상태 표시.
+- `contentPolicy/content_policy`, `contentRequired/content_required`, `contentRequiredReason/content_required_reason` 파싱.
+- `DOCUMENT_CONTENT_*` execution error fallback 문구.
+- `DOCUMENT_CONTENT_NOT_REQUESTED` 실행 오류 문구 보정.
+
+후속 권장:
+
+| 우선순위 | 항목 | 판단 |
+|----------|------|------|
+| P1 | sample payload 기반 UI regression test 확장 | fixture가 생겼으므로 후속으로 추가 권장 |
+| P2 | `contentPolicy`와 `contentRequired*` 중복 표시 방지 | legacy/raw 값 동시 수신 방어 polish |
+| P2 | content included preview UI | backend capability가 제품 정책으로 열릴 때 후속 |
+| P2 | 템플릿/도움말 문구 | Gmail attachment/OCR/vision 후속 범위 명확화 |
+
+FE 쪽에 현재 PR을 막을 차단급 문제는 없다.
+
+---
+
+## 6. 요구사항 충족 현황
+
+| 요구사항 | Spring Boot | FastAPI | FE | 최종 판단 |
+|----------|-------------|---------|----|-----------|
+| canonical file content contract | 보존/전달 | 생성 | 표시 | 충족 |
+| `requires_content` 생성/수용 | 생성 | 수용/방어 판별 | N/A | 충족 |
+| `FILE_LIST -> LOOP -> SINGLE_FILE` content 보존 | runtime config 전달 | 보존/LLM 사용 | 표시 | 충족 |
+| LLM이 file content 사용 | N/A | 반영 | N/A | 충족 |
+| content failure를 빈 요약 성공으로 처리하지 않기 | error mapping | 실패 변환 | 오류 표시 | 충족 |
+| preview content policy | 기본값/보정 | raw policy 생성 | 표시 | 충족 |
+| `includeContent=true` 실제 content 기준 보정 | 보정 | 보정 | 표시 | 충족 |
+| error code/context contract | public ErrorCode/context | FastAPI code/context | 문구 매핑 | 충족 |
+| log/callback sanitize | 조회/저장 보존 | truncate | truncated 안내 | 충족 |
+| TXT/CSV/TSV/PDF text/Google Workspace | N/A | 구현 보고됨 | 표시 | 충족 |
+| DOCX/PPTX/HWPX | N/A | 구현 보고됨 | 표시 | 충족 |
+| scan PDF OCR/image OCR/vision | N/A | 후속 | 표시 가능 | 후속 |
+| Gmail attachment 본문 추출 | N/A | 후속 | 상태 표시 | 후속 |
+| AI/중간 노드 preview | source 중심 | 제한 | 노출 보류 | 후속 |
+
+---
+
+## 7. 최종 남은 항목
+
+### P1. 기능 후속
+
+1. Gmail attachment download + common extractor 연결.
+2. scan PDF OCR 실제 지원.
+3. image OCR/vision 실제 지원.
+4. 실제 Mongo 통합 fixture 기반 E2E 검증.
+5. Spring 저장 전 full content/token/signed URL 2차 sanitize 방어.
+
+### P2. UX/문서/테스트 후속
+
+1. FE sample payload 기반 rendering test 확장.
+2. FE `contentPolicy` legacy 값과 `contentRequired*` 신규 필드 중복 표시 방지.
+3. Spring/FastAPI action alias 목록 문서화.
+4. 템플릿/도움말에서 현재 지원 파일군과 후속 범위를 명확히 표현.
+
+---
+
+## 8. 릴리즈/PR 문구 권장
+
+사용 가능한 표현:
+
+- “문서 본문 런타임 계약/경로 안정화 MVP를 반영했습니다.”
+- “Google Drive 기반 PDF text, TXT/CSV/TSV, DOCX/PPTX/HWPX, Google Workspace 문서 본문 추출 경로를 반영했습니다.”
+- “본문 추출 실패, 미지원, 크기 초과, 미요청 상태를 canonical payload와 execution error로 구분합니다.”
+- “Spring public 조회 경로에서 문서 본문 error code/context를 보존합니다.”
+
+피해야 할 표현:
+
+- “모든 문서 완전 호환”
+- “Gmail 첨부파일 본문 추출 완료”
+- “스캔 PDF OCR 완료”
+- “이미지 OCR/vision 완료”
+
+---
+
+## 9. 최종 판단
+
+현재 구현은 Spring Boot, FastAPI, FE 통합 관점에서 다음 리뷰/PR 단계로 넘길 수 있다.
+
+Gmail attachment 본문 추출, scan PDF OCR, image OCR/vision을 이번 완료 범위에서 제외한다는 전제라면, 세 팀 간 계약 정합성에서 추가 차단 요소는 없다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_FRONTEND_INTEGRATION_REVIEW.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_FRONTEND_INTEGRATION_REVIEW.md
@@ -1,0 +1,250 @@
+# 문서 본문 런타임 FE 반영 설계 검토
+
+> 작성일: 2026-05-14  
+> 대상 FE 브랜치: `feat#172-document_content_runtime`  
+> BE 브랜치: `feat/30-runtime-document`  
+> 기준 문서:
+> - `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS_ANALYSIS.md`
+> - `DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md`
+
+---
+
+## 1. 검토 결론
+
+프론트 설계 방향은 백엔드 문서 본문 런타임 계약과 대체로 일치한다.
+
+특히 아래 판단은 맞다.
+
+- FE는 파일 본문을 직접 다운로드/파싱/OCR하지 않는다.
+- FE는 Spring/FastAPI가 내려주는 canonical payload의 `content_status`, `content_error`, `content_metadata`를 표시한다.
+- 1차 FE 범위는 source preview와 실행 결과 표시를 안정화하고, AI 노드 preview는 backend capability가 열린 뒤 확장한다.
+- `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment를 같은 파일 content 상태 표시 계층으로 처리한다.
+- full content 복원/저장은 FE 범위가 아니며, Spring/FastAPI의 sanitize/truncate 결과를 표시한다.
+
+다만 백엔드 계약과 맞추기 위해 아래 보정이 필요하다.
+
+1. `DOCUMENT_CONTENT_NOT_REQUESTED`는 기본적으로 에러가 아니라 content policy/status다. `requires_content=true`인데 실행 단계에서 본문이 없을 때만 실패 문구로 보정한다.
+2. `contentPolicy=required_by_downstream`은 “본문 포함 방식”이라기보다 “본문 필요 사유”에 가깝다. FE 표시에서는 허용하되, 백엔드는 가능하면 `contentPolicy=metadata_only|content_included|content_status_only`와 `contentRequiredReason=downstream`을 분리하는 편이 명확하다.
+3. `previewScope=source_metadata`는 기존 호환 필드로 유지하고, 신규 의미는 `contentPolicy`, `contentIncluded`, `contentStatusScope`로 표현한다.
+4. `content_error`는 사용자 표시 가능한 메시지여야 하지만, raw external error가 섞일 수 있으므로 FE는 error code 매핑을 우선하고 `content_error`는 보조 설명으로 표시하는 것이 안전하다.
+5. `contentPolicy=content_required_but_unavailable`은 FastAPI raw/legacy fallback으로 FE가 수용할 수 있지만, Spring public API에서는 `contentPolicy=metadata_only|content_status_only`, `contentRequired=true` 조합으로 정규화하는 것이 좋다.
+
+---
+
+## 2. 백엔드가 보장해야 할 FE 계약
+
+### 2.1 Canonical file payload
+
+FE가 안정적으로 표시할 수 있도록 Spring/FastAPI는 snake_case 필드를 기본으로 내려준다. FE는 camelCase fallback을 둘 수 있다.
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "file_id": "file-1",
+  "filename": "report.pdf",
+  "mime_type": "application/pdf",
+  "size": 1024,
+  "url": "https://drive.google.com/...",
+  "content": "저장 정책에 따라 truncate된 본문 미리보기",
+  "content_status": "available",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "pdf_text",
+    "content_kind": "plain_text",
+    "truncated": true,
+    "char_count": 4000,
+    "original_char_count": 82000,
+    "stored_content_truncated": true,
+    "stored_char_count": 1000,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 80000,
+      "max_llm_input_chars": 20000
+    }
+  }
+}
+```
+
+`FILE_LIST.items[]`와 Gmail `attachments[]`도 가능한 한 같은 shape를 사용한다.
+
+### 2.2 Content status 의미
+
+| status | FE 표시 | 백엔드 의미 |
+|--------|---------|-------------|
+| `available` | 본문 읽기 완료 | `content`가 LLM/UI용 텍스트로 존재 |
+| `empty` | 읽을 수 있는 본문 없음 | 추출은 수행했으나 텍스트가 없음 |
+| `unsupported` | 지원하지 않는 파일 형식 | extractor 미지원 또는 조건부 지원군 미구현 |
+| `too_large` | 파일 크기 제한 초과 | 다운로드/추출/LLM 입력 제한 초과 |
+| `failed` | 본문 읽기 실패 | 외부 API/파서/변환 오류 |
+| `not_requested` | 본문 미포함 | preview 또는 metadata-only 경로에서 본문 추출을 요청하지 않음 |
+
+FE 설계의 상태 문구는 이 의미와 맞다.
+
+### 2.3 Preview metadata 병행 정책
+
+프론트 설계의 `previewScope` 유지 방향은 맞다. 백엔드는 아래 형태를 우선한다.
+
+```json
+{
+  "metadata": {
+    "previewScope": "source_metadata",
+    "contentPolicy": "metadata_only",
+    "contentIncluded": false,
+    "contentStatusScope": "item",
+    "contentRequired": false,
+    "contentRequiredReason": null
+  }
+}
+```
+
+필드 의미:
+
+| 필드 | 값 | 의미 |
+|------|----|------|
+| `previewScope` | `source_metadata` | 기존 source preview 범위. FE 호환용 |
+| `contentPolicy` | `metadata_only` | 본문 추출/본문 미리보기 없음 |
+| `contentPolicy` | `content_included` | `content`가 포함됨 |
+| `contentPolicy` | `content_status_only` | 본문 없이 상태만 포함됨 |
+| `contentIncluded` | boolean | 응답에 실제 content text가 포함됐는지 |
+| `contentStatusScope` | `none|item|attachment|node` | status가 붙은 단위 |
+| `contentRequired` | boolean | downstream 또는 target node가 본문을 필요로 하는지 |
+| `contentRequiredReason` | `downstream|user_request|runtime_config|null` | 본문 필요 사유 |
+
+`required_by_downstream`은 FE가 문구로 표시할 수는 있지만, 백엔드 신규 계약에서는 `contentRequiredReason=downstream`으로 분리하는 것을 권장한다.
+`content_required_but_unavailable`도 같은 이유로 canonical `contentPolicy` 값으로 두지 않는다. Spring이 FastAPI raw response를 public API로 재노출해야 한다면, 가능한 한 아래처럼 정규화한다.
+
+```json
+{
+  "metadata": {
+    "previewScope": "source_metadata",
+    "contentPolicy": "content_status_only",
+    "contentIncluded": false,
+    "contentRequired": true,
+    "contentRequiredReason": "runtime_config"
+  }
+}
+```
+
+---
+
+## 3. FE 설계 항목별 검토
+
+### 3.1 Preview API 타입
+
+검토 결과: 적절하다.
+
+`NodePreviewRequest.includeContent?: boolean`은 이미 백엔드 `NodePreviewRequest.includeContent`와 맞는다. `NodePreviewResponse.metadata`가 확장 가능한 map이면 신규 metadata를 받을 수 있다.
+
+백엔드 보강:
+
+- source preview 기본값은 `includeContent=false`.
+- metadata에 `previewScope=source_metadata`, `contentPolicy=metadata_only`, `contentIncluded=false`를 명시한다.
+- `includeContent=true` 요청 시 FastAPI가 본문을 포함하지 못하면 `content_status`와 `content_error`를 내려준다.
+
+### 3.2 AI 노드 preview
+
+검토 결과: 1차 제외가 맞다.
+
+현재 Spring preview service는 start node만 지원한다. FE가 AI 노드 preview를 먼저 열면 UX가 backend capability와 어긋난다.
+
+1차 정책:
+
+- FE는 source preview 버튼을 유지한다.
+- AI/content preview는 backend가 start node 외 dry-run을 지원할 때 연다.
+- 백엔드 capability가 열리면 FE의 `canRequestPreview`를 node role 고정 조건에서 capability 기반으로 바꾼다.
+
+### 3.3 `DataPreviewBlock`
+
+검토 결과: 적절하다.
+
+`previewMetadata` props 추가는 백엔드 응답 구조와 맞다. Spring의 public API 응답은 이미 `metadata`를 포함할 수 있으므로, FE가 이 값을 `InputPanel`/`OutputPanel`에서 전달하는 방식이 자연스럽다.
+
+주의:
+
+- `content_error`는 너무 긴 raw error일 수 있으므로 FE는 한 줄/짧은 영역에 표시하고, 백엔드는 가능하면 사용자 표시 가능한 message로 정규화한다.
+- `content_metadata.limits`는 표시 대상이 될 수 있으나 1차 UI 필수는 아니다. 단, `too_large` 또는 truncate 상태에서는 제한값을 그대로 나열하기보다 “현재 처리 가능한 크기를 초과했습니다”, “본문 일부만 표시됩니다” 같은 보조 문구로 쓰는 방향이 적절하다.
+- `content_metadata.truncated=true` 또는 `stored_content_truncated=true`이면 FE가 보여주는 본문은 전체 원문이 아니라 저장/표시 정책에 따라 잘린 preview일 수 있다.
+
+### 3.4 Legacy fallback
+
+검토 결과: 허용 가능하다.
+
+FE의 `content -> extracted_text -> extractedText` fallback은 하위 호환에 유리하다. 다만 백엔드 신규 계약의 canonical field는 `content`다. 신규 payload에서 `extracted_text`를 새로 만들 필요는 없다.
+
+### 3.5 Gmail attachment
+
+검토 결과: 적절하다.
+
+Gmail attachment가 `FileItemCard`를 공유하는 구조는 백엔드 payload shape와 잘 맞는다. 1차에서 attachment content가 미지원이면 아래처럼 표시된다.
+
+```json
+{
+  "filename": "agenda.pdf",
+  "mime_type": "application/pdf",
+  "size": 512,
+  "content": null,
+  "content_status": "unsupported",
+  "content_error": "Gmail 첨부파일 본문 추출은 현재 지원하지 않습니다."
+}
+```
+
+### 3.6 Error UX
+
+검토 결과: 방향은 맞지만 `DOCUMENT_CONTENT_NOT_REQUESTED`는 주의가 필요하다.
+
+권장 FE 매핑:
+
+| code/status | FE 문구 | severity |
+|-------------|---------|----------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | 이 파일 형식은 아직 본문 읽기를 지원하지 않습니다. | warning |
+| `DOCUMENT_CONTENT_TOO_LARGE` | 파일이 너무 커서 본문을 읽을 수 없습니다. | warning |
+| `DOCUMENT_CONTENT_EMPTY` | 파일에서 읽을 수 있는 본문이 없습니다. | warning |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 파일 본문을 읽는 중 오류가 발생했습니다. | error |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 본문 미포함 미리보기입니다. | info |
+
+`DOCUMENT_CONTENT_NOT_REQUESTED`가 실행 실패 code로 내려오는 경우에는 backend가 `requires_content=true` 상황에서 실패로 판단한 것이다. Spring public error code도 `DOCUMENT_CONTENT_NOT_REQUESTED`로 보존되므로, FE는 “본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다.”로 보정할 수 있다.
+
+`DataStateNotice`와 `getExecutionStatusNotice`가 서로 다른 문구를 만들지 않도록 같은 error helper를 재사용하는 FE 보강안은 적절하다. 백엔드는 가능하면 `error.code`, `error.message`, `metadata.fastApiErrorCode` 중 적어도 하나로 `DOCUMENT_CONTENT_*`를 보존한다.
+
+---
+
+## 4. Backend 문서/구현 반영 항목
+
+FE 설계를 지원하려면 Spring Boot 설계에 아래 항목을 반영한다.
+
+| 우선순위 | 항목 | 설명 |
+|----------|------|------|
+| P0 | preview metadata 명시 | `previewScope`, `contentPolicy`, `contentIncluded`, `contentStatusScope` |
+| P0 | content status 보존 | FastAPI preview/execution payload의 `content_*` 필드 보존 |
+| P0 | error code 매핑 | `DOCUMENT_CONTENT_*`를 Spring reason/metadata/user message로 보존 |
+| P1 | sanitize/truncate metadata | `stored_content_truncated`, `stored_char_count` 보존 |
+| P1 | AI preview capability | start node 외 preview 지원 시 FE capability로 노출 |
+| P1 | raw content policy 정규화 | FastAPI raw `required_by_downstream`, `content_required_but_unavailable`을 Spring public metadata의 `contentRequired*` 필드로 정규화 |
+
+---
+
+## 5. FE 1차 구현 수용 기준
+
+FE 1차 구현은 아래를 만족하면 백엔드 계약과 호환된다.
+
+- source preview는 기본 `includeContent=false`를 유지한다.
+- `DataPreviewBlock`은 `previewMetadata`를 받아 `contentPolicy`를 표시한다.
+- `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment에서 `content_status`, `content_error`, `content_metadata`를 표시한다.
+- `content_status=available`이고 `content`가 있으면 본문 preview를 표시한다.
+- `not_requested`는 오류가 아니라 본문 미포함 상태로 표시한다.
+- `unsupported|too_large|failed|empty`는 빈 본문 성공처럼 보이지 않게 상태/오류를 표시한다.
+- `DOCUMENT_CONTENT_*` code를 사용자 문구로 매핑한다.
+- AI 노드 preview는 backend capability가 열리기 전까지 노출하지 않는다.
+- `content_metadata.limits`는 `too_large`/truncate 상태의 보조 설명에만 사용하고, 기본 카드에 모든 제한값을 노출하지 않는다.
+- `content_required_but_unavailable` 또는 `required_by_downstream`을 받더라도 신규 백엔드 계약의 `contentRequired`, `contentRequiredReason`가 있으면 그 값을 우선한다.
+
+---
+
+## 6. 추가 확인 필요
+
+1. FE 브랜치명은 `feat#172-document_content_runtime`이고 BE 브랜치는 `feat/30-runtime-document`다. PR/문서에서 서로 참조할 때 브랜치명을 명확히 구분한다.
+2. FE가 이미 `contentPolicy=required_by_downstream` 또는 `content_required_but_unavailable`을 구현했다면 legacy/raw fallback 표시값으로만 처리한다. 신규 백엔드 계약은 `contentRequired=true`, `contentRequiredReason=downstream|runtime_config` 분리다.
+3. `content_error`를 FE가 그대로 노출할지, code 매핑 문구를 항상 우선할지 결정해야 한다. 권장은 code 매핑 우선, `content_error` 보조 표시다.
+4. backend가 `includeContent=true` preview에서 full content를 내려줄 수 있는지, 저장용 truncate content만 내려줄지 결정해야 한다. 현재 권장은 truncate/sanitize된 content만 public API에 반환하는 것이다.
+5. `Google Drive source preview content included` QA는 FE가 `includeContent=true`를 호출하는 UI를 추가하거나 backend 안정화가 끝난 뒤 확장 검증으로 둔다. 1차 필수 검증은 metadata-only preview와 실행 결과 content status 표시다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,273 @@
+# 문서 본문 런타임 구현 점검 보고서
+
+> 작성일: 2026-05-14  
+> 브랜치: `feat/26-runtime-document`  
+> 기준 문서:
+> - `.docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `.docs/DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN.md`
+> - `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_FE_DESIGN_REVIEW.md`
+
+---
+
+## 1. 구현 결론
+
+계약/경로 안정화 MVP 기준 구현은 반영되었다.
+
+이번 구현은 문서 본문 canonical contract가 런타임 경로에 안정적으로 흐르도록 만드는 1차 기반 작업이며, 최종 보강으로 원문 1차 필수 파일군인 DOCX/PPTX/HWPX extractor도 반영했다.
+
+완료된 범위:
+
+- `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment에 `content_status`, `content_error`, `content_metadata` 기본 필드 추가
+- legacy `extracted_text`, `extraction_status` 병행 유지
+- preview metadata에 실제 본문 포함 여부 기준 `content_policy` 추가
+- Google Drive extraction result를 legacy shape와 신규 content shape로 동시 반환
+- `content_metadata.limits` 기본 포함
+- 다운로드/추출 크기 제한 초과 시 `content_status=too_large` 생성
+- 사용자 표시 가능한 짧은 `content_error`만 payload에 노출
+- DOCX paragraph/table text 추출
+- PPTX slide order/title/body/note text 추출
+- HWPX zip XML body text 추출
+- 텍스트 레이어 없는 PDF는 OCR 미지원 `unsupported`로 반환
+- LLM content-dependent action에서 본문 추출 실패를 빈 요약 성공으로 처리하지 않도록 변경
+- `DOCUMENT_CONTENT_*` error code 추가
+- 실행 로그 저장 전 긴 `content` truncate 처리 및 기존 `content_metadata` 보존
+- `ErrorDetail.context`에 `content_status`, `content_error` 같은 실패 context 보존
+- FE/Spring 계약 검토 문서 추가
+
+---
+
+## 2. 주요 변경 파일
+
+### 신규 파일
+
+- `app/core/document_content.py`
+  - 문서 본문 상태 기본값, extraction result builder, legacy mapping, log truncate helper
+- `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_FE_DESIGN_REVIEW.md`
+  - FE 설계 검토 및 BE contract 정합성 문서
+- `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`
+  - FE/Spring contract test용 상태별 sample payload fixture
+- `.docs/DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md`
+  - 본 보고서
+
+### 수정 파일
+
+- `app/common/errors.py`
+  - `DOCUMENT_CONTENT_UNSUPPORTED`
+  - `DOCUMENT_CONTENT_TOO_LARGE`
+  - `DOCUMENT_CONTENT_EXTRACTION_FAILED`
+  - `DOCUMENT_CONTENT_NOT_REQUESTED`
+  - `DOCUMENT_CONTENT_EMPTY`
+- `app/models/canonical.py`
+  - file/email attachment canonical model에 content 상태 필드 추가
+- `app/models/execution.py`
+  - `ErrorDetail.context` 추가
+- `app/core/nodes/input_node.py`
+  - Google Drive file payload와 Gmail attachment payload에 content 상태 기본값 추가
+- `app/core/engine/preview_executor.py`
+  - preview metadata `content_policy` 추가
+  - `include_content=true` 요청이어도 실제 content가 없으면 `content_status_only`/`metadata_only`로 보정
+  - preview file payload content 상태 필드 추가
+  - include_content extraction 결과를 신규/legacy field에 동시 반영
+- `app/services/integrations/google_drive.py`
+  - extraction result 표준화
+  - 다운로드/추출 크기 제한 및 `too_large` status 생성
+  - UTF-8 BOM/UTF-8/CP949 decode fallback
+  - CSV/TSV table text representation 추가
+  - DOCX/PPTX/HWPX zip XML extractor 추가
+  - PDF/text/Google Workspace export 경로 metadata 기록
+- `app/services/integrations/gmail.py`
+  - attachment metadata에 content 상태 기본값 추가
+- `app/core/nodes/llm_node.py`
+  - `requires_content`/`requiresContent` 처리
+  - content-dependent action fallback 판별
+  - Drive lazy extraction 결과 payload 반영
+  - `FILE_LIST.items[].content` LLM input 포함
+  - 본문 실패 상태를 `DOCUMENT_CONTENT_*` 실패로 변환
+- `app/core/engine/executor.py`
+  - execution log/snapshot sanitize 시 긴 `content` truncate
+
+---
+
+## 3. 구현 점검 결과
+
+### 3.1 Canonical payload
+
+정상 반영됨.
+
+metadata-only file payload는 아래 기본 필드를 가진다.
+
+```json
+{
+  "content": null,
+  "content_status": "not_requested",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "none",
+    "content_kind": "none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 60000,
+      "max_llm_input_chars": 60000
+    }
+  },
+  "extracted_text": null,
+  "extraction_status": "not_requested"
+}
+```
+
+### 3.2 Preview contract
+
+정상 반영됨.
+
+FastAPI preview metadata는 기존 `preview_scope`를 유지하면서 신규 `content_policy`를 추가한다.
+
+```json
+{
+  "preview_scope": "source_metadata",
+  "content_policy": "metadata_only",
+  "include_content": false
+}
+```
+
+`include_content=true` 요청이어도 `content_policy=content_included`는 실제 `content`가 있거나 `content_status=available`일 때만 내려간다.
+
+본문이 비어 있거나 `unsupported`, `too_large`, `failed`, `empty`, `not_requested` 상태이면 `content_status_only` 또는 `metadata_only`로 보정한다.
+
+### 3.3 LLM content-dependent failure
+
+정상 반영됨.
+
+요약/분석/추출 계열 action에서 파일 본문이 `unsupported`, `too_large`, `failed`, `empty`, `not_requested` 상태로 남으면 `DOCUMENT_CONTENT_*` error로 실패한다.
+
+특히 기존처럼 unsupported 파일을 "File content could not be extracted" 문장으로 LLM에 넘긴 뒤 성공 요약처럼 처리하는 경로를 차단했다.
+
+### 3.4 Log/callback sanitize
+
+정상 반영됨.
+
+FastAPI execution log에 저장되는 `inputData`, `outputData`, snapshot에는 긴 `content`가 4,000자 기준으로 truncate된다.
+
+truncate 시 기존 `content_metadata`를 보존하면서 아래 필드를 `content_metadata` 내부에 병합한다.
+
+```json
+{
+  "truncated_for_log": true,
+  "stored_content_truncated": true,
+  "stored_char_count": 4000
+}
+```
+
+현재 Spring callback은 execution log의 마지막 output을 읽으므로 sanitized payload를 받는다.
+
+### 3.5 FE contract
+
+정상 반영됨.
+
+FE 보강 설계와 맞춰 아래 방침을 문서화했다.
+
+- FastAPI raw 표준값: `content_required_but_unavailable`
+- Spring public alias 가능값: `required_by_downstream`
+- FE는 두 값을 모두 수용
+- `previewScope`와 `contentPolicy`는 역할 분리
+- 받은 `content`는 전체 본문이 아니라 "본문 미리보기"로 표시
+
+---
+
+## 4. 보강 중 발견해 수정한 문제
+
+1. `requires_content="false"` 문자열이 Python `bool("false") == True`로 처리될 수 있었다.
+   - `_coerce_bool()`을 추가해 문자열 boolean을 안전하게 처리했다.
+2. `ai_summarize`, `extract_info`, `ai_analyze` 같은 content-dependent action이 `validate()`에서 false가 될 수 있었다.
+   - content-dependent action도 validate에서 허용하도록 수정했다.
+3. `extract_info`, `ai_analyze`, `ocr`, `describe_image`가 prompt 없이 빈 요청으로 LLM `process()`에 들어갈 수 있었다.
+   - action별 기본 prompt를 추가했다.
+4. node error에 `content_status` context를 담을 곳이 없었다.
+   - `ErrorDetail.context`를 추가했다.
+5. `include_content=true` preview가 실제 본문이 없어도 `content_included`로 표시될 수 있었다.
+   - preview payload를 재귀적으로 확인해 실제 content 또는 `content_status=available`일 때만 `content_included`를 내려주도록 수정했다.
+6. metadata-only payload와 extraction result의 limits 기준이 일관되지 않았다.
+   - 모든 `content_metadata` 기본값에 `limits.max_download_bytes`, `limits.max_extracted_chars`, `limits.max_llm_input_chars`를 포함했다.
+7. `DOCUMENT_CONTENT_TOO_LARGE` code는 있었지만 실제 `too_large` status 생성 경로가 부족했다.
+   - Google Drive extraction에서 알려진 파일 크기 또는 다운로드된 byte 크기가 제한을 넘으면 `content_status=too_large`를 반환하도록 보강했다.
+8. raw parser exception이 `content_error`로 노출될 수 있었다.
+   - `content_error`를 사용자 표시 가능한 짧은 메시지로 정규화했다. raw exception은 서버 로그/exception context 영역에만 남긴다.
+
+---
+
+## 5. 현재 미완료 또는 후속 과제
+
+원문 요구사항 1차 필수 파일군 extractor는 반영되었다.
+
+아직 제품 안정화와 확장 지원을 위해 남은 항목:
+
+- scan PDF OCR 실제 지원
+- image OCR/vision 실제 지원
+- Gmail attachment download + 공통 extractor 연결
+
+FE contract sample payload fixture는 `.docs/front_docs/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`에 추가했다.
+
+Spring public API의 `DOCUMENT_CONTENT_*` error shape 변환은 Spring Boot 팀에서 완료된 상태로 확인되어 FastAPI 후속 과제 목록에서 제외했다.
+
+현재 구현은 "계약/경로 안정화 MVP + 원문 1차 필수 파일군 extractor 1차 구현"으로 볼 수 있다. 다만 Gmail attachment 본문 추출, OCR/vision, cross-service fixture는 후속으로 남아 있으므로 "다양한 파일 완전 호환"으로 표현하면 안 된다.
+
+---
+
+## 6. 검증 결과
+
+실행한 검증:
+
+```bash
+/opt/homebrew/anaconda3/bin/conda run -n cse_2 python -m py_compile app/core/document_content.py app/common/errors.py app/models/canonical.py app/models/execution.py app/core/nodes/input_node.py app/core/engine/preview_executor.py app/services/integrations/google_drive.py app/services/integrations/gmail.py app/core/nodes/llm_node.py app/core/engine/executor.py tests/test_input_node.py tests/test_preview_executor.py tests/test_integrations/test_google_drive.py tests/test_llm_node.py tests/test_executor.py
+```
+
+결과:
+
+- 통과
+
+targeted regression suite:
+
+```bash
+/opt/homebrew/anaconda3/bin/conda run -n cse_2 python -m pytest tests/test_input_node.py tests/test_preview_executor.py tests/test_integrations/test_google_drive.py tests/test_llm_node.py tests/test_executor.py tests/test_spring_callback_service.py -q
+```
+
+결과:
+
+- `122 passed in 0.37s`
+
+full test suite:
+
+```bash
+/opt/homebrew/anaconda3/bin/conda run -n cse_2 python -m pytest -q
+```
+
+결과:
+
+- sandbox network 제한 상태: `387 passed, 6 errors`
+- 네트워크 허용 재실행: `393 passed in 23.82s`
+
+사유:
+
+- 최초 full suite의 6 errors는 `tests/test_trigger_api.py`가 FastAPI lifespan에서 MongoDB SRV DNS를 조회하다가 sandbox 네트워크 제한에 막힌 환경 이슈였다.
+- 동일 명령을 네트워크 허용 상태에서 재실행했을 때 전체 테스트가 통과했다.
+
+환경 보강:
+
+```text
+cse_2 환경에 feedparser가 없어 최초 테스트 수집이 실패했다.
+/opt/homebrew/anaconda3/bin/conda run -n cse_2 python -m pip install 'feedparser>=6.0.11'
+```
+
+설치 후 targeted regression suite와 full test suite 모두 통과했다.
+
+---
+
+## 7. 최종 판단
+
+현재 구현은 설계 문서의 핵심 경로를 반영한 상태다.
+
+`cse_2` 환경 기준 targeted regression suite와 full test suite가 모두 통과했으므로, 현재 구현은 추가 보강 없이 다음 리뷰 단계로 넘길 수 있다.
+
+다만 Gmail attachment 본문 추출, OCR/vision 계열, cross-service sample fixture는 아직 후속 과제로 남아 있다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS_ANALYSIS.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS_ANALYSIS.md
@@ -1,0 +1,499 @@
+# 문서 본문 런타임 요구사항 분석
+
+> 작성일: 2026-05-14  
+> 원문: `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`  
+> 목적: Google Drive/Gmail 파일 입력이 LLM 요약/분석 노드에서 실제 문서 본문을 사용하도록 만들기 위한 백엔드 요구사항, 현재 gap, 구현 우선순위, 확인 질문 정리
+
+---
+
+## 1. 결론
+
+현재 요구사항의 핵심은 파일 metadata가 아니라 **추출된 문서 본문을 canonical payload의 표준 필드로 보장**하는 것이다.
+
+기존 `FASTAPI_CONTRACT_SPEC.md`에는 `SINGLE_FILE.content`가 존재하지만 의미가 `base64-or-text-content` 수준으로 모호하다. 이 상태로는 LLM이 “파일 업로드용 바이너리 content”와 “요약 가능한 추출 텍스트”를 구분할 수 없다. 따라서 `content`, `content_status`, `content_error`, `content_metadata`를 하나의 런타임 계약으로 확정해야 한다.
+
+Spring Boot 쪽 현재 구현은 FE config와 choice 기반 prompt를 FastAPI runtime model로 전달하지만, 원문 요구사항의 핵심 플래그인 `runtime_config.requires_content`는 아직 생성하지 않는다. Preview도 source 노드만 지원하며, `includeContent`는 사용자가 요청한 값을 그대로 전달할 뿐 content-dependent 노드 여부를 자동 판단하지 않는다.
+
+따라서 1차 구현은 아래 순서가 적절하다.
+
+1. Spring `WorkflowTranslator`가 content-dependent action에 `runtime_config.requires_content=true`를 넣는다.
+2. FastAPI 계약 문서의 `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment payload를 본문 추출 상태 중심으로 확장한다.
+3. FastAPI가 Drive source, Loop, LLM strategy에서 content 필드를 보존하고 소비한다.
+4. Preview는 metadata-only 기본값을 유지하되, 본문 미포함/포함 상태를 응답 metadata에 명시한다.
+
+---
+
+## 2. 원문 요구사항 재정의
+
+### 2.1 해결해야 하는 사용자 문제
+
+사용자는 “Google Drive 문서 요약”, “폴더에 새로 올라온 문서 요약”, “Gmail 첨부 문서 요약” 같은 자동화를 기대한다. 그러나 런타임 payload가 파일명, MIME type, URL만 전달하면 LLM은 문서 내부를 읽을 수 없다.
+
+정상 동작하려면 LLM 직전 입력 payload에 아래 정보가 있어야 한다.
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "filename": "report.pdf",
+  "mime_type": "application/pdf",
+  "url": "https://drive.google.com/...",
+  "content": "문서에서 추출된 텍스트",
+  "content_status": "available",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "pdf_text",
+    "content_kind": "plain_text",
+    "truncated": false,
+    "char_count": 1234,
+    "original_char_count": 1234
+  }
+}
+```
+
+### 2.2 본문이 필요한 action
+
+원문은 아래 action을 content-dependent로 본다.
+
+| action | 본문 필요성 |
+|--------|-------------|
+| `summarize` | 문서/메일 본문 기반 요약 |
+| `extract_info` | 본문에서 정보 추출 |
+| `translate` | 본문 번역 |
+| `classify_by_content` | 내용 기반 분류 |
+| `describe_image` | 이미지 설명 생성 |
+| `ocr` | 이미지/스캔 문서 텍스트화 |
+| `ai_summarize` | AI 요약 alias |
+| `ai_analyze` | AI 분석 alias |
+
+Spring은 이 목록을 기준으로 `requires_content`를 생성할 수 있다. FastAPI는 이 값이 `true`인 경우 본문 추출 실패를 빈 요약 성공으로 처리하면 안 된다.
+
+### 2.3 canonical payload 표준화 대상
+
+이번 요구사항이 직접 바꾸는 payload는 아래 셋이다.
+
+| payload | 변경 방향 |
+|---------|-----------|
+| `SINGLE_FILE` | 추출 본문과 추출 상태 필드 표준화 |
+| `FILE_LIST.items[]` | 각 item을 `SINGLE_FILE`과 같은 shape로 맞춤 |
+| `SINGLE_EMAIL.attachments[]` | Gmail 첨부파일도 파일 payload와 같은 content 상태를 가짐 |
+
+---
+
+## 3. 현재 코드 기준 gap
+
+### 3.1 `WorkflowTranslator`
+
+파일: `src/main/java/org/github/flowify/execution/service/WorkflowTranslator.java`
+
+현재 동작:
+
+- input 노드에는 `runtime_source`를 만든다.
+- output 노드에는 `runtime_sink`를 만든다.
+- llm/loop/branch 노드에는 `runtime_config`를 만들고 기존 config, choice prompt, branch config를 병합한다.
+- `node_type`, `output_data_type`은 마지막에 덮어써 안정적으로 전달한다.
+
+gap:
+
+- `runtime_config.requires_content` 생성 로직이 없다.
+- `choiceActionId`, `action`, `node_type`, `dataType`, `outputDataType`를 조합한 content-dependent 판별이 없다.
+- 파일 본문이 필요한 템플릿의 LLM 노드는 prompt만 있을 뿐 `choiceActionId`가 없는 경우도 있다. 예: `TemplateSeeder`의 folder document summary, file upload auto share 템플릿.
+- choice 기반 AI 노드는 `ChoicePromptResolver`가 `action=process`를 기본값으로 넣는다. 따라서 `action`만 보고 content-dependent 여부를 판별하면 `summarize`, `extract_info`, `translate`, `ocr` 같은 선택지 기반 AI 노드를 놓친다.
+
+영향:
+
+- FastAPI가 “이 LLM 노드는 반드시 본문 추출이 필요하다”는 신호를 받을 수 없다.
+- FastAPI가 metadata-only 입력으로도 요약을 시도할 가능성이 남는다.
+
+판별 시 우선순위:
+
+1. node config의 명시적 `requires_content`가 있으면 최우선으로 사용한다.
+2. `choiceActionId` 또는 `choice_action_id`가 content-dependent action 목록에 있으면 `true`.
+3. 명시적 `action`이 `process`가 아닌 실제 action id이고 content-dependent 목록에 있으면 `true`.
+4. `summaryFormat` 또는 `prompt_source=manual`인 템플릿성 AI 노드는 `dataType`이 파일/메일 계열이고 `outputDataType`이 `TEXT` 또는 `SPREADSHEET_DATA`이면 보수적으로 `true`.
+5. `PASSTHROUGH`, metadata filter, 단순 정렬/중복 제거 계열은 `false`.
+
+### 3.2 Preview
+
+파일:
+
+- `src/main/java/org/github/flowify/workflow/service/WorkflowPreviewService.java`
+- `src/main/java/org/github/flowify/workflow/dto/NodePreviewRequest.java`
+- `src/main/java/org/github/flowify/execution/service/FastApiClient.java`
+
+현재 동작:
+
+- preview는 `role=start` source 노드만 지원한다.
+- `includeContent` 기본값은 `false`다.
+- Spring은 요청의 `includeContent` 값을 `include_content`로 FastAPI에 전달한다.
+- preview metadata에는 `previewScope=source_metadata`가 고정으로 들어간다.
+
+gap:
+
+- LLM 노드 preview를 지원하지 않는다.
+- target node가 content-dependent인지 자동 판단해 `includeContent=true`로 바꾸는 로직이 없다.
+- 본문 미포함 preview임을 사용자에게 더 구체적으로 설명하는 metadata가 부족하다.
+
+영향:
+
+- 사용자는 source preview에서 파일 카드만 보고 “본문 요약이 가능한지”를 판단하기 어렵다.
+- 실제 실행에서는 본문이 필요하지만 preview는 metadata-only라서 실행 전 검증력이 낮다.
+
+### 3.3 `FASTAPI_CONTRACT_SPEC.md`
+
+파일: `src/main/resources/docs/FASTAPI_CONTRACT_SPEC.md`
+
+현재 동작:
+
+- `SINGLE_FILE` 예시는 `content: "base64-or-text-content..."`로 되어 있다.
+- `FILE_LIST.items[]` 예시는 metadata 중심이다.
+- Gmail attachment 예시는 `filename`, `mime_type`, `size`만 있다.
+
+gap:
+
+- `content`가 추출 텍스트인지, 원본 바이너리/base64인지 불명확하다.
+- `content_status`가 없어 unsupported/too_large/failed/not_requested를 구분할 수 없다.
+- `content_metadata.extraction_method`, `content_kind`, truncate 여부, char count, limit 정보가 없다.
+
+영향:
+
+- Spring, FastAPI, FE가 같은 `SINGLE_FILE`을 다르게 해석할 수 있다.
+- LLM 소비용 payload와 sink 업로드용 payload가 충돌할 수 있다.
+
+### 3.4 템플릿
+
+파일: `src/main/java/org/github/flowify/config/TemplateSeeder.java`
+
+관찰:
+
+- 폴더 문서 요약 템플릿들은 `google_drive(folder_new_file) -> llm(SINGLE_FILE) -> slack/gmail/sheets` 구조다.
+- 파일 업로드 자동 공유 템플릿도 `SINGLE_FILE`을 LLM으로 넘긴다.
+- LLM prompt는 “입력된 문서/파일 내용을 바탕으로”라고 명시한다.
+
+gap:
+
+- 이 템플릿들의 LLM config에는 `choiceActionId=summarize` 같은 표준 action id가 없다.
+- 따라서 Spring이 `choiceActionId`만 보고 `requires_content`를 판별하면 템플릿 기반 workflow가 누락된다.
+
+권장:
+
+- `choiceActionId`, `action`, `summaryFormat`, `dataType`, `outputDataType`, prompt pattern 중 최소한 `action` 또는 명시적 `requires_content`를 템플릿 config에 넣는 것이 안정적이다.
+
+### 3.5 기존 source/sink 계약과의 충돌
+
+파일: `src/main/resources/docs/WORKFLOW_SOURCE_SINK_SPEC.md`
+
+현재 source/sink 명세는 `SINGLE_FILE`을 단일 파일 데이터 타입으로 정의하고, sink 쪽에서는 Gmail/Google Drive가 `SINGLE_FILE.content`를 첨부파일 또는 업로드 파일의 본문처럼 소비할 수 있다고 본다. 반면 이번 요구사항은 `SINGLE_FILE.content`를 LLM이 읽을 수 있는 추출 텍스트로 표준화하려 한다.
+
+이 충돌을 해결하지 않으면 다음 문제가 생긴다.
+
+- LLM 노드는 `content`를 추출 텍스트로 해석한다.
+- Drive/Gmail sink는 같은 `content`를 원본 파일 bytes/base64로 해석할 수 있다.
+- 파일 요약 후 원본 파일을 재전달하는 workflow에서 추출 텍스트가 원본 파일처럼 업로드될 위험이 있다.
+
+권장 해결안:
+
+- `content`는 canonical text representation, 즉 LLM/preview/UI용 추출 텍스트로 고정한다.
+- 원본 파일 전달이 필요한 sink는 `file_id`, `url`, `download_url`, `raw_content_base64`, `content_ref` 중 하나를 명시적으로 사용한다.
+- FastAPI sink 계약에서 `SINGLE_FILE` 업로드/첨부 시 어떤 필드를 소비하는지 다시 정의한다.
+
+### 3.6 데이터 보존과 로깅 위험
+
+문서 본문은 개인정보, 내부 자료, 첨부파일 원문을 포함할 수 있다. 현재 Spring은 FastAPI가 보내는 node data를 `inputData`, `outputData`, `snapshot` 형태로 저장하고 반환할 수 있으므로, 본문 추출을 도입하면 저장소에 원문이 남는 범위가 커진다.
+
+필요한 결정:
+
+- 실행 로그에 `content` 전체를 저장할지, preview/최근 실행 조회용으로 truncate해서 저장할지 정해야 한다.
+- 보존 목적이 없는 대용량 본문은 FastAPI 내부 실행 컨텍스트에서만 사용하고 Spring에는 metadata와 일부 preview만 보내는 선택지도 있다.
+- 최소한 로그에는 OAuth token, download URL signed token, 원문 bytes/base64를 남기지 않아야 한다.
+- `content_metadata`에 `stored_content_truncated`, `stored_char_count` 같은 저장 관점 metadata를 추가할지 검토한다.
+
+---
+
+## 4. 요구사항을 구현 단위로 분해
+
+### 4.1 Spring Boot
+
+| 우선순위 | 작업 | 설명 |
+|----------|------|------|
+| P0 | content-dependent 판별 함수 추가 | `choiceActionId`, `action`, `summaryFormat`, `dataType` 기준으로 본문 필요 여부 판별 |
+| P0 | `runtime_config.requires_content` 생성 | llm/loop/branch runtime_config에 boolean 추가. 최소 llm 노드부터 시작 |
+| P0 | translator 테스트 추가 | `summarize`/`ai_analyze`는 true, `passthrough`는 false 검증 |
+| P0 | 명시값 보존 정책 확정 | node config에 이미 `requires_content`가 있으면 자동 추론보다 우선 |
+| P1 | 템플릿 config 보강 | 문서 요약/파일 공유 LLM 노드에 `action=summarize` 또는 `requires_content=true` 추가 |
+| P1 | preview 정책 개선 | source preview metadata에 `content_policy`, `preview_scope` 명시 |
+| P1 | node data 보존 정책 정리 | FastAPI가 반환한 `content_*` 필드를 저장/응답에서 보존하되, 원문 저장 범위는 제한값과 함께 합의 |
+| P2 | LLM 노드 preview 지원 검토 | 현재 source-only preview 제약을 확장할지 결정 |
+
+Spring의 1차 책임은 파일 추출 자체가 아니라, FastAPI가 추출해야 한다는 의도를 잃지 않게 전달하는 것이다.
+
+### 4.2 FastAPI
+
+| 우선순위 | 작업 | 설명 |
+|----------|------|------|
+| P0 | `SINGLE_FILE` content 계약 구현 | `content_status`, `content_error`, `content_metadata` 포함 |
+| P0 | `content` 의미 분리 | `content`는 추출 텍스트로 고정하고 원본 bytes/base64는 별도 필드 또는 ref로 분리 |
+| P0 | Google Drive single file 추출 | Google Docs/Workspace export, plain text, PDF text layer 등 필수 지원부터 |
+| P0 | LLM input builder 수정 | `SINGLE_FILE.content`, `FILE_LIST.items[].content`, `SINGLE_EMAIL.body` 우선순위 적용 |
+| P0 | 실패 처리 | `requires_content=true`인데 본문 없음이면 빈 요약 성공 금지 |
+| P1 | Loop item content 보존 | `FILE_LIST.items[] -> SINGLE_FILE` 변환 시 content 관련 필드 유지 |
+| P1 | extractor metadata 기록 | `extraction_method`, `content_kind`, char count, truncate 기록 |
+| P2 | Gmail attachment content | 지원 여부 확정 후 payload 확장 또는 명시적 unsupported 반환 |
+
+FastAPI의 핵심 책임은 “파일을 읽는 것”과 “읽을 수 없을 때 그 사실을 payload로 명확히 표현하는 것”이다.
+
+### 4.3 FE
+
+| 우선순위 | 작업 | 설명 |
+|----------|------|------|
+| P1 | content status 표시 | `content_status`, `content_error`, `truncated`를 preview/result UI에 표시 |
+| P1 | LLM preview 요청 정책 | content-dependent 노드 preview 시 `includeContent=true` 전달 또는 Spring 자동화에 맞춤 |
+| P2 | 템플릿 설명 정리 | 실제 지원 파일 타입/제한과 템플릿 문구 일치 |
+
+FE는 본문을 직접 읽지 않는다. FE의 주된 책임은 런타임이 내려준 상태를 사용자가 이해할 수 있게 표시하는 것이다.
+
+---
+
+## 5. 권장 runtime contract
+
+### 5.1 `SINGLE_FILE`
+
+```json
+{
+  "type": "SINGLE_FILE",
+  "file_id": "string",
+  "filename": "string",
+  "mime_type": "string",
+  "size": 12345,
+  "url": "string|null",
+  "content": "string|null",
+  "content_status": "available|empty|unsupported|too_large|failed|not_requested",
+  "content_error": "string|null",
+  "content_metadata": {
+    "extraction_method": "google_export|pdf_text|csv_parse|pptx_text|word_text|hwpx_xml|plain_text|ocr|vision|gmail_attachment|none",
+    "content_kind": "plain_text|table_text|slide_text|ocr_text|image_description|mixed|none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0,
+    "limits": {
+      "max_download_bytes": 0,
+      "max_extracted_chars": 0,
+      "max_llm_input_chars": 0
+    }
+  }
+}
+```
+
+권장 해석:
+
+- `content`는 LLM이 바로 읽을 수 있는 추출 텍스트다.
+- 원본 파일 업로드/전달용 바이너리가 필요하면 별도 필드명을 사용한다. 예: `raw_content_base64`, `download_url`, `attachment_bytes_ref`.
+- `content_status=available`이면 `content`는 null이 아니어야 한다. 단, 빈 문서는 `empty`로 구분한다.
+
+### 5.2 `FILE_LIST`
+
+```json
+{
+  "type": "FILE_LIST",
+  "items": [
+    {
+      "type": "SINGLE_FILE",
+      "file_id": "file-1",
+      "filename": "doc.pdf",
+      "mime_type": "application/pdf",
+      "size": 12345,
+      "url": "https://drive.google.com/...",
+      "content": null,
+      "content_status": "not_requested",
+      "content_error": null,
+      "content_metadata": {
+        "extraction_method": "none",
+        "content_kind": "none",
+        "truncated": false,
+        "char_count": 0,
+        "original_char_count": 0
+      }
+    }
+  ]
+}
+```
+
+목록 preview에서는 `content_status=not_requested`를 허용한다. 단, 다음 노드가 content-dependent이면 실행 시점에 eager extraction 또는 lazy extraction을 수행해야 한다.
+
+### 5.3 LLM runtime config
+
+```json
+{
+  "runtime_type": "llm",
+  "runtime_config": {
+    "node_type": "AI",
+    "output_data_type": "TEXT",
+    "action": "summarize",
+    "choiceActionId": "summarize",
+    "requires_content": true
+  }
+}
+```
+
+권장 규칙:
+
+- Spring은 명시적 `requires_content`가 config에 있으면 그 값을 우선한다.
+- 없으면 `choiceActionId` 또는 `action`을 content-dependent 목록과 비교한다.
+- `choiceActionId`가 없고 `choiceSelections` 내부에 action id가 key로 저장된 마이그레이션 데이터는 제한적으로 fallback한다.
+- 그래도 없으면 `dataType=SINGLE_FILE|FILE_LIST|SINGLE_EMAIL|EMAIL_LIST`이고 `outputDataType=TEXT|SPREADSHEET_DATA`인 AI/LLM 노드는 보수적으로 `requires_content=true`로 둘 수 있다.
+
+### 5.4 Spring 판별 로직 초안
+
+아래는 구현 의도를 고정하기 위한 pseudo-code다. 실제 코드는 `WorkflowTranslator` 내부 private method 또는 별도 resolver로 분리할 수 있다.
+
+```java
+boolean requiresContent(NodeDefinition node, String semanticNodeType, Map<String, Object> runtimeConfig) {
+    Object explicit = firstPresent(
+            node.getConfig().get("requires_content"),
+            node.getConfig().get("requiresContent"),
+            runtimeConfig.get("requires_content"),
+            runtimeConfig.get("requiresContent"));
+    if (explicit != null) {
+        return Boolean.parseBoolean(String.valueOf(explicit));
+    }
+
+    String choiceActionId = firstText(
+            node.getConfig().get("choiceActionId"),
+            node.getConfig().get("choice_action_id"));
+    if (CONTENT_ACTIONS.contains(choiceActionId)) {
+        return true;
+    }
+
+    String action = firstText(node.getConfig().get("action"), runtimeConfig.get("action"));
+    if (!"process".equals(action) && CONTENT_ACTIONS.contains(action)) {
+        return true;
+    }
+
+    if (containsContentActionKey(node.getConfig().get("choiceSelections"))) {
+        return true;
+    }
+
+    boolean contentCarrier = Set.of("SINGLE_FILE", "FILE_LIST", "SINGLE_EMAIL", "EMAIL_LIST")
+            .contains(node.getDataType());
+    boolean generatedOutput = Set.of("TEXT", "SPREADSHEET_DATA").contains(node.getOutputDataType());
+    boolean promptNode = Set.of("AI", "AI_FILTER").contains(semanticNodeType);
+    return promptNode && contentCarrier && generatedOutput;
+}
+```
+
+주의점:
+
+- `ChoicePromptResolver`가 choice 기반 AI 노드의 `action`을 `process`로 치환하므로 `choiceActionId`를 먼저 본다.
+- `choiceSelections` fallback은 legacy/migration 방어용이다. 모든 selection value를 action으로 해석하면 style id나 option id를 오판할 수 있으므로, key가 content-dependent action id와 정확히 일치하는 경우만 허용한다.
+- prompt text 기반 fallback은 마지막 방어선으로만 둔다. 예를 들어 prompt에 `요약`, `번역`, `OCR`, `문서 내용` 같은 단어가 있어도 사용자가 metadata-only 요약을 의도했을 수 있으므로, 기본 정책은 `dataType`/`outputDataType`/prompt node 여부를 함께 만족할 때만 `true`로 추론한다.
+- Loop 노드 자체는 본문을 생성하지 않지만, 다음 노드가 content-dependent이면 item content 보존 또는 lazy extraction key 보존이 필요하다. 이 판단은 FastAPI graph-level 분석으로 처리하는 편이 자연스럽다.
+- Branch 노드는 `classify_by_content`일 때만 본문이 필요하고, `classify_by_type`처럼 metadata 기반 분기는 필요하지 않다.
+
+### 5.5 Preview 응답 metadata 권장값
+
+현재 Spring preview metadata는 `previewScope=source_metadata`로 고정된다. 본문 추출 요구사항 이후에는 아래처럼 상태를 더 명확히 나누는 것이 좋다.
+
+| key | 예시 | 의미 |
+|-----|------|------|
+| `preview_scope` | `metadata_only` | 본문 미포함 preview |
+| `preview_scope` | `content_included` | 본문 추출 포함 preview |
+| `preview_scope` | `content_status_only` | 본문 원문 없이 추출 가능/불가 상태만 포함 |
+| `content_policy` | `not_requested` | 요청상 본문 추출하지 않음 |
+| `content_policy` | `required_by_downstream` | 다음 노드 때문에 본문 필요 |
+| `content_policy` | `requested_by_user` | 사용자가 `includeContent=true`로 요청 |
+| `content_limit` | `{...}` | 적용된 다운로드/추출/LLM 제한값 |
+
+Spring public API는 camelCase를 쓰는 경향이 있으므로 FE 응답 metadata에서는 `previewScope`, `contentPolicy`를 유지할 수도 있다. FastAPI runtime request/response의 내부 필드는 snake_case로 유지해도 된다. 이 dual-convention은 기존 source/sink 명세와 일치한다.
+
+---
+
+## 6. 파일 타입 지원 기준
+
+원문 기준 1차 완료에 포함해야 하는 필수 지원군은 아래다.
+
+| 파일군 | 1차 기준 |
+|--------|----------|
+| Google Docs/Slides/Sheets | export 후 추출 |
+| PDF text layer | `pdf_text`로 텍스트 추출 |
+| CSV/TSV | UTF-8, UTF-8 BOM, CP949 처리 |
+| PPTX | slide 순서 유지, title/body/note 구분 |
+| HWPX | zip 내부 XML 본문 추출 |
+| DOCX | paragraph/table/header/footer 추출 |
+| TXT/Markdown | 인코딩 감지 후 원문 사용 |
+
+조건부 지원군은 아래처럼 처리한다.
+
+| 파일군 | 미구현 시 응답 |
+|--------|----------------|
+| 스캔 PDF | `content_status=unsupported`, OCR 미지원 사유 |
+| PPT | `content_status=unsupported`, legacy 변환 미지원 사유 |
+| DOC | `content_status=unsupported`, legacy 변환 미지원 사유 |
+| 이미지 | OCR/vision 미지원이면 `unsupported` |
+| GIF/HEIC | 대표 frame/변환 미지원이면 `unsupported` |
+
+중요한 점은 미지원 파일도 실패를 삼키지 않고 `content_error`로 사용자 표시 가능한 사유를 내려야 한다는 것이다.
+
+---
+
+## 7. 구현 순서 제안
+
+### Phase 1: 계약과 Spring 신호 보강
+
+1. `FASTAPI_CONTRACT_SPEC.md`의 `SINGLE_FILE`, `FILE_LIST`, Gmail attachment schema를 본문 추출 상태 중심으로 개정한다.
+2. `WorkflowTranslator`에 `requires_content` 판별을 추가한다. 이때 `choiceActionId`를 `action`보다 우선한다.
+3. 문서 요약/파일 공유 템플릿의 LLM config에 명시적 `action` 또는 `requires_content`를 추가한다.
+4. `WorkflowTranslatorTest`에 content-dependent action 테스트를 추가한다.
+5. `WorkflowPreviewService` metadata에 본문 미포함 preview임을 나타내는 `contentPolicy` 또는 동등 필드를 추가한다.
+
+### Phase 2: FastAPI 본문 추출과 소비
+
+1. Google Drive `single_file`, `folder_new_file`, `folder_all_files`에서 content policy를 적용한다.
+2. LLM input builder가 `SINGLE_FILE.content`를 최우선으로 읽도록 수정한다.
+3. Loop strategy가 content 관련 필드를 유지한다.
+4. 추출 실패/미지원/크기 초과를 node data와 preview data에 남긴다.
+5. 원본 파일 전달용 필드와 LLM 추출 텍스트 필드를 분리한다.
+
+### Phase 3: Preview와 사용자 표시
+
+1. source preview metadata에 `preview_scope=metadata_only|content_included|content_status_only`를 명확히 둔다.
+2. FE가 `content_status`와 `content_error`를 표시한다.
+3. LLM 노드 preview를 지원할지, source preview만 유지할지 결정한다.
+
+---
+
+## 8. 확인 필요 질문
+
+아래 항목은 구현 전에 결정하면 재작업을 줄일 수 있다.
+
+1. `SINGLE_FILE.content`를 “LLM용 추출 텍스트”로 고정해도 되는가?
+   현재 기존 계약에는 `base64-or-text-content`라고 되어 있어, 파일 업로드 sink가 원본 바이너리를 기대할 가능성이 있다. 원본 파일 전달이 필요하면 `raw_content_base64` 같은 별도 필드로 분리하는 편이 안전하다.
+
+2. Spring이 `requires_content`를 보수적으로 자동 추론해도 되는가?
+   예를 들어 `dataType=SINGLE_FILE`, `runtime_type=llm`, `outputDataType=TEXT`이면 action id가 없어도 `requires_content=true`로 볼 수 있다. 이 규칙은 템플릿 누락에는 강하지만, 파일 metadata만 요약하려는 특수 workflow에는 과할 수 있다.
+
+3. Preview는 source 노드만 계속 지원할 것인가, LLM 노드 preview까지 확장할 것인가?
+   현재 Spring preview는 source-only다. 원문은 “LLM 노드 preview 요청 시 includeContent true”도 언급하므로 FE/BE 범위를 맞춰야 한다.
+
+4. Gmail 첨부파일 본문 추출은 1차 범위인가?
+   원문은 기존 Gmail 계획에서 attachment content가 제외였다고 분석한다. 1차에서 제외한다면 Gmail 첨부 문서 요약 템플릿/선택지는 제한 문구를 표시해야 한다.
+
+5. 파일 크기와 추출 문자 수 제한값은 어디서 관리할 것인가?
+   FastAPI 환경변수/설정으로 관리하고 payload metadata에 내려주는 방식이 자연스럽다. Spring도 UI 표시를 위해 그대로 보존해야 한다.
+
+6. 실행 로그에 문서 본문 전체를 저장해도 되는가?
+   저장한다면 조회 편의성은 높지만 개인정보/대용량 저장 위험이 커진다. 저장하지 않거나 truncate한다면 디버깅 정보가 줄어든다.
+
+---
+
+## 9. 완료 기준
+
+아래가 모두 충족되면 원문 요구사항의 1차 완료로 볼 수 있다.
+
+- `SINGLE_FILE`과 `FILE_LIST.items[]`에 `content_status`, `content_error`, `content_metadata` 계약이 문서화되어 있다.
+- Spring runtime model의 content-dependent LLM 노드에 `runtime_config.requires_content=true`가 포함된다.
+- `choiceActionId=summarize`처럼 choice 기반 AI 노드는 `action=process`여도 `requires_content=true`가 된다.
+- Google Drive 문서 요약 실행 시 LLM inputData에 실제 추출 텍스트가 존재한다.
+- `FILE_LIST -> LOOP -> LLM` 경로에서 content 또는 lazy extraction key가 손실되지 않는다.
+- 본문 추출 실패가 빈 요약 성공으로 처리되지 않는다.
+- Preview와 실제 실행 결과에서 본문 포함/미포함 상태가 구분된다.
+- Gmail 첨부파일 요약은 지원 또는 미지원 상태가 사용자에게 명확히 표시된다.
+- 원본 파일 업로드/첨부용 데이터와 LLM 추출 텍스트의 필드 의미가 충돌하지 않는다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json
@@ -1,0 +1,206 @@
+{
+  "metadata_only": {
+    "metadata": {
+      "preview_scope": "source_metadata",
+      "content_policy": "metadata_only",
+      "include_content": false
+    },
+    "data": {
+      "type": "SINGLE_FILE",
+      "filename": "report.pdf",
+      "mime_type": "application/pdf",
+      "content": null,
+      "content_status": "not_requested",
+      "content_error": null,
+      "content_metadata": {
+        "extraction_method": "none",
+        "content_kind": "none",
+        "truncated": false,
+        "char_count": 0,
+        "original_char_count": 0,
+        "limits": {
+          "max_download_bytes": 10485760,
+          "max_extracted_chars": 60000,
+          "max_llm_input_chars": 60000
+        }
+      },
+      "extracted_text": null,
+      "extraction_status": "not_requested"
+    }
+  },
+  "content_included": {
+    "metadata": {
+      "preview_scope": "source_metadata",
+      "content_policy": "content_included",
+      "include_content": true
+    },
+    "data": {
+      "type": "SINGLE_FILE",
+      "filename": "report.docx",
+      "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "content": "문서 본문 예시",
+      "content_status": "available",
+      "content_error": null,
+      "content_metadata": {
+        "extraction_method": "docx_xml",
+        "content_kind": "plain_text",
+        "truncated": false,
+        "char_count": 8,
+        "original_char_count": 8,
+        "limits": {
+          "max_download_bytes": 10485760,
+          "max_extracted_chars": 60000,
+          "max_llm_input_chars": 60000
+        }
+      },
+      "extracted_text": "문서 본문 예시",
+      "extraction_status": "success"
+    }
+  },
+  "content_status_only": {
+    "metadata": {
+      "preview_scope": "source_metadata",
+      "content_policy": "content_status_only",
+      "include_content": true
+    },
+    "data": {
+      "type": "SINGLE_FILE",
+      "filename": "archive.zip",
+      "mime_type": "application/zip",
+      "content": null,
+      "content_status": "unsupported",
+      "content_error": "이 파일 형식은 아직 본문 읽기를 지원하지 않습니다.",
+      "content_metadata": {
+        "extraction_method": "none",
+        "content_kind": "none",
+        "truncated": false,
+        "char_count": 0,
+        "original_char_count": 0,
+        "limits": {
+          "max_download_bytes": 10485760,
+          "max_extracted_chars": 60000,
+          "max_llm_input_chars": 60000
+        }
+      },
+      "extracted_text": null,
+      "extraction_status": "unsupported"
+    }
+  },
+  "too_large": {
+    "type": "SINGLE_FILE",
+    "filename": "large.pdf",
+    "mime_type": "application/pdf",
+    "content": null,
+    "content_status": "too_large",
+    "content_error": "파일이 현재 처리 가능한 크기를 초과했습니다.",
+    "content_metadata": {
+      "extraction_method": "none",
+      "content_kind": "none",
+      "truncated": false,
+      "char_count": 0,
+      "original_char_count": 0,
+      "limits": {
+        "max_download_bytes": 10485760,
+        "max_extracted_chars": 60000,
+        "max_llm_input_chars": 60000,
+        "observed_size_bytes": 10485761
+      }
+    },
+    "extracted_text": null,
+    "extraction_status": "failed"
+  },
+  "unsupported": {
+    "type": "SINGLE_FILE",
+    "filename": "image.png",
+    "mime_type": "image/png",
+    "content": null,
+    "content_status": "unsupported",
+    "content_error": "이 파일 형식은 아직 본문 읽기를 지원하지 않습니다.",
+    "content_metadata": {
+      "extraction_method": "none",
+      "content_kind": "none",
+      "truncated": false,
+      "char_count": 0,
+      "original_char_count": 0,
+      "limits": {
+        "max_download_bytes": 10485760,
+        "max_extracted_chars": 60000,
+        "max_llm_input_chars": 60000
+      }
+    },
+    "extracted_text": null,
+    "extraction_status": "unsupported"
+  },
+  "empty": {
+    "type": "SINGLE_FILE",
+    "filename": "blank.txt",
+    "mime_type": "text/plain",
+    "content": null,
+    "content_status": "empty",
+    "content_error": "파일에서 읽을 수 있는 텍스트를 찾지 못했습니다.",
+    "content_metadata": {
+      "extraction_method": "none",
+      "content_kind": "none",
+      "truncated": false,
+      "char_count": 0,
+      "original_char_count": 0,
+      "limits": {
+        "max_download_bytes": 10485760,
+        "max_extracted_chars": 60000,
+        "max_llm_input_chars": 60000
+      }
+    },
+    "extracted_text": null,
+    "extraction_status": "success"
+  },
+  "failed": {
+    "type": "SINGLE_FILE",
+    "filename": "broken.hwpx",
+    "mime_type": "application/vnd.hancom.hwpx",
+    "content": null,
+    "content_status": "failed",
+    "content_error": "파일 본문을 읽는 중 오류가 발생했습니다.",
+    "content_metadata": {
+      "extraction_method": "none",
+      "content_kind": "none",
+      "truncated": false,
+      "char_count": 0,
+      "original_char_count": 0,
+      "limits": {
+        "max_download_bytes": 10485760,
+        "max_extracted_chars": 60000,
+        "max_llm_input_chars": 60000
+      }
+    },
+    "extracted_text": null,
+    "extraction_status": "failed"
+  },
+  "not_requested": {
+    "type": "FILE_LIST",
+    "items": [
+      {
+        "filename": "attachment.pdf",
+        "mime_type": "application/pdf",
+        "source": "gmail",
+        "content": null,
+        "content_status": "not_requested",
+        "content_error": null,
+        "content_metadata": {
+          "extraction_method": "none",
+          "content_kind": "none",
+          "truncated": false,
+          "char_count": 0,
+          "original_char_count": 0,
+          "limits": {
+            "max_download_bytes": 10485760,
+            "max_extracted_chars": 60000,
+            "max_llm_input_chars": 60000
+          }
+        },
+        "extracted_text": null,
+        "extraction_status": "not_requested"
+      }
+    ],
+    "truncated": false
+  }
+}

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_SPRING_BOOT_IMPLEMENTATION_REPORT.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_SPRING_BOOT_IMPLEMENTATION_REPORT.md
@@ -136,6 +136,7 @@ FE 참고:
 | `DOCUMENT_CONTENT_TOO_LARGE` | 413 | 파일이 너무 커서 본문을 읽을 수 없습니다. |
 | `DOCUMENT_CONTENT_EMPTY` | 422 | 파일에서 읽을 수 있는 본문이 없습니다. |
 | `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 502 | 파일 본문 추출 중 오류가 발생했습니다. |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | 422 | 본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다. |
 
 FastAPI error code 매핑:
 
@@ -233,9 +234,10 @@ Spring이 FastAPI message를 받으면 해당 message를 우선 전달한다. me
 
 - 파일 다운로드/본문 추출 extractor 구현
 - `content_status`, `content_error`, `content_metadata` 생성
-- FastAPI callback payload sanitize/truncate 실제 필터링
+- FastAPI callback payload sanitize/truncate 실제 필터링. FastAPI sanitize가 1차 방어선이지만, Spring 저장 전 full content/token/signed URL 방어 필터는 운영 안정화 전 별도 후속으로 유지한다.
 - start node 외 AI/중간 노드 preview capability API
-- `contentRequiredReason=downstream`을 graph 분석으로 자동 계산
+- `contentRequiredReason=downstream`을 graph 분석으로 자동 계산. 구현 전까지 Spring 기본값은 `contentRequired=false`, `contentRequiredReason=null`이다.
+- FastAPI callback payload의 `content_status`, `content_error`, `content_metadata`가 node log/public 조회 API까지 보존되는지 더 넓은 통합 테스트를 추가하는 작업. 현재는 service 단위 contract test로 저장 update와 node data 조회 보존을 검증한다.
 
 위 항목은 FastAPI 구현 또는 후속 Spring 작업으로 남긴다.
 
@@ -246,7 +248,7 @@ Spring이 FastAPI message를 받으면 해당 message를 우선 전달한다. me
 실행한 테스트:
 
 ```bash
-./gradlew test --tests org.github.flowify.execution.WorkflowTranslatorTest --tests org.github.flowify.workflow.WorkflowPreviewServiceTest --tests org.github.flowify.execution.FastApiClientTest
+./gradlew test --tests org.github.flowify.execution.WorkflowTranslatorTest --tests org.github.flowify.workflow.WorkflowPreviewServiceTest --tests org.github.flowify.execution.FastApiClientTest --tests org.github.flowify.execution.ExecutionServiceTest
 ```
 
 결과:
@@ -264,3 +266,5 @@ BUILD SUCCESSFUL
 - `includeContent=true` preview metadata가 실제 content/status 기반으로 보정됨
 - FastAPI metadata의 null 값은 Spring 기본 metadata를 덮지 않음
 - `DOCUMENT_CONTENT_UNSUPPORTED`, `DOCUMENT_CONTENT_TOO_LARGE`, `DOCUMENT_CONTENT_NOT_REQUESTED` FastAPI error mapping
+- node data 조회에서 `content_status`, `content_error`, `content_metadata` 보존
+- execution complete update에서 output의 문서 content 상태 필드 보존

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_SPRING_BOOT_IMPLEMENTATION_REPORT.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_SPRING_BOOT_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,266 @@
+# 문서 본문 런타임 Spring Boot 구현 보고
+
+> 작성일: 2026-05-14  
+> 브랜치: `feat/30-runtime-document`  
+> 전달 대상: FE `feat#172-document_content_runtime`, FastAPI 문서 본문 런타임 담당  
+> 기준 문서:
+> - `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS_ANALYSIS.md`
+> - `DOCUMENT_CONTENT_RUNTIME_ANALYSIS_AND_IMPLEMENTATION_PLAN_SPRING_BOOT.md`
+> - `DOCUMENT_CONTENT_RUNTIME_FRONTEND_INTEGRATION_REVIEW.md`
+
+---
+
+## 1. 구현 요약
+
+Spring Boot에 문서 본문 런타임 계약의 1차 지원 코드를 반영했다.
+
+이번 구현은 파일 본문 추출 자체가 아니라, Spring이 FastAPI와 FE 사이에서 아래 계약을 안정적으로 전달/보존하는 데 집중한다.
+
+- content-dependent 노드에 `runtime_config.requires_content` 전달
+- source preview metadata에 FE 표시용 content policy 기본값 부여
+- FastAPI `DOCUMENT_CONTENT_*` error code를 Spring public error code로 매핑
+- 문서 요약/파일 공유 템플릿에 본문 필요 의도 명시
+
+---
+
+## 2. 변경 파일
+
+### 2.1 Runtime translator
+
+파일:
+
+- `src/main/java/org/github/flowify/execution/service/WorkflowTranslator.java`
+- `src/test/java/org/github/flowify/execution/WorkflowTranslatorTest.java`
+
+반영 내용:
+
+- `runtime_config.requires_content`를 모든 `llm`, `loop`, `if_else` runtime_config에 포함한다.
+- `requires_content` 판별 우선순위:
+  1. node config의 명시적 `requires_content` 또는 `requiresContent`
+  2. `choiceActionId` 또는 `choice_action_id`
+  3. `action`, 단 `process`는 choice prompt resolver 기본값이므로 content action으로 보지 않음
+  4. legacy `choiceSelections` key가 content-dependent action id와 정확히 일치하는 경우
+  5. 파일/메일 계열 `dataType` + 생성형 `outputDataType` + AI/AI_FILTER 노드 조합
+
+content-dependent action 목록:
+
+```text
+summarize
+extract_info
+translate
+classify_by_content
+describe_image
+ocr
+ai_summarize
+ai_analyze
+```
+
+예시 runtime_config:
+
+```json
+{
+  "choiceActionId": "summarize",
+  "action": "process",
+  "node_type": "AI",
+  "output_data_type": "TEXT",
+  "requires_content": true
+}
+```
+
+주의:
+
+- choice 기반 AI 노드는 `ChoicePromptResolver`가 `action=process`를 넣을 수 있으므로 FE/FastAPI는 `action`만 보면 안 된다.
+- 명시적 `requires_content=false`가 있으면 자동 추론보다 우선한다.
+
+### 2.2 Preview metadata
+
+파일:
+
+- `src/main/java/org/github/flowify/workflow/service/WorkflowPreviewService.java`
+- `src/test/java/org/github/flowify/workflow/WorkflowPreviewServiceTest.java`
+
+반영 내용:
+
+- source preview 응답 metadata에 FE 표시용 기본 필드를 항상 보강한다.
+- FastAPI가 metadata를 내려주면 Spring 기본값 위에 병합한다.
+
+기본 metadata:
+
+```json
+{
+  "limit": 5,
+  "includeContent": false,
+  "previewScope": "source_metadata",
+  "contentPolicy": "metadata_only",
+  "contentIncluded": false,
+  "contentStatusScope": "none",
+  "contentRequired": false,
+  "contentRequiredReason": null,
+  "nodeRole": "start",
+  "nodeType": "google_drive"
+}
+```
+
+`includeContent=true`로 FastAPI preview를 호출하더라도 Spring은 응답 payload 또는 status를 확인한 뒤 `content_included` 여부를 보정한다. FastAPI가 더 구체적인 metadata를 내려주면 null이 아닌 값만 Spring 기본값 위에 병합한다.
+
+```json
+{
+  "includeContent": true,
+  "contentPolicy": "content_included",
+  "contentIncluded": true
+}
+```
+
+위 값은 응답 payload에 실제 `content`, `extracted_text`, `extractedText`가 있거나 `content_status=available`인 경우에만 Spring 기본값으로 설정된다. `includeContent=true` 요청이었지만 실제 content/status가 없으면 `contentPolicy=metadata_only`, `contentIncluded=false`로 유지된다.
+
+FE 참고:
+
+- 1차 FE는 기존대로 source preview 기본 요청을 `includeContent=false`로 유지해도 된다.
+- `previewScope=source_metadata`는 API 범위이고, `contentPolicy`는 본문 포함 정책이다.
+- downstream 본문 필요 여부는 향후 `contentRequired`, `contentRequiredReason`으로 표현한다.
+
+### 2.3 FastAPI error mapping
+
+파일:
+
+- `src/main/java/org/github/flowify/common/exception/ErrorCode.java`
+- `src/main/java/org/github/flowify/execution/service/FastApiClient.java`
+- `src/test/java/org/github/flowify/execution/FastApiClientTest.java`
+
+추가된 Spring ErrorCode:
+
+| Spring ErrorCode | HTTP status | 기본 메시지 |
+|------------------|-------------|-------------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | 422 | 이 파일 형식은 아직 본문 읽기를 지원하지 않습니다. |
+| `DOCUMENT_CONTENT_TOO_LARGE` | 413 | 파일이 너무 커서 본문을 읽을 수 없습니다. |
+| `DOCUMENT_CONTENT_EMPTY` | 422 | 파일에서 읽을 수 있는 본문이 없습니다. |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | 502 | 파일 본문 추출 중 오류가 발생했습니다. |
+
+FastAPI error code 매핑:
+
+| FastAPI error_code | Spring ErrorCode |
+|--------------------|------------------|
+| `DOCUMENT_CONTENT_UNSUPPORTED` | `DOCUMENT_CONTENT_UNSUPPORTED` |
+| `DOCUMENT_CONTENT_TOO_LARGE` | `DOCUMENT_CONTENT_TOO_LARGE` |
+| `DOCUMENT_CONTENT_EMPTY` | `DOCUMENT_CONTENT_EMPTY` |
+| `DOCUMENT_CONTENT_EXTRACTION_FAILED` | `DOCUMENT_CONTENT_EXTRACTION_FAILED` |
+| `DOCUMENT_CONTENT_NOT_REQUESTED` | `DOCUMENT_CONTENT_NOT_REQUESTED` |
+
+`DOCUMENT_CONTENT_NOT_REQUESTED`는 기본적으로 preview/content policy 상태다. FastAPI가 에러로 내려주는 경우는 `requires_content=true`인데 본문 추출이 요청/수행되지 않은 실패 상황으로 보고 Spring public error code도 `DOCUMENT_CONTENT_NOT_REQUESTED`로 보존한다.
+
+### 2.4 Template config
+
+파일:
+
+- `src/main/java/org/github/flowify/config/TemplateSeeder.java`
+
+반영 내용:
+
+- 문서 요약/파일 업로드 공유 템플릿의 LLM config에 본문 필요 의도를 명시했다.
+
+추가 필드:
+
+```json
+{
+  "action": "summarize",
+  "requires_content": true
+}
+```
+
+Sheets 기록형 문서 분석 템플릿은 `action=ai_analyze`, `requires_content=true`로 설정했다.
+
+---
+
+## 3. FE 전달 사항
+
+FE는 아래 값을 그대로 사용할 수 있다.
+
+### 3.1 Preview metadata
+
+Spring source preview 응답은 최소 아래 metadata를 포함한다.
+
+```json
+{
+  "previewScope": "source_metadata",
+  "contentPolicy": "metadata_only",
+  "contentIncluded": false,
+  "contentStatusScope": "none",
+  "contentRequired": false,
+  "contentRequiredReason": null
+}
+```
+
+FE 표시 우선순위 권장:
+
+1. `contentPolicy`
+2. `contentIncluded`
+3. `contentStatusScope`
+4. payload 내부의 `content_status`, `content_error`, `content_metadata`
+
+### 3.2 Runtime config
+
+AI/LLM 노드 preview 또는 실행 debug 화면에서 runtime model을 표시한다면 `requires_content`를 볼 수 있다.
+
+```json
+{
+  "runtime_config": {
+    "requires_content": true
+  }
+}
+```
+
+`choiceActionId=summarize`인 노드는 `action=process`여도 `requires_content=true`가 된다.
+
+### 3.3 Error code
+
+FE는 Spring public API error code로 `DOCUMENT_CONTENT_*`를 받을 수 있다.
+
+```json
+{
+  "code": "DOCUMENT_CONTENT_TOO_LARGE",
+  "message": "파일이 너무 커서 본문을 읽을 수 없습니다."
+}
+```
+
+Spring이 FastAPI message를 받으면 해당 message를 우선 전달한다. message가 없으면 Spring ErrorCode 기본 메시지가 사용된다.
+
+---
+
+## 4. 미구현/후속 범위
+
+이번 Spring 구현에는 아래가 포함되지 않았다.
+
+- 파일 다운로드/본문 추출 extractor 구현
+- `content_status`, `content_error`, `content_metadata` 생성
+- FastAPI callback payload sanitize/truncate 실제 필터링
+- start node 외 AI/중간 노드 preview capability API
+- `contentRequiredReason=downstream`을 graph 분석으로 자동 계산
+
+위 항목은 FastAPI 구현 또는 후속 Spring 작업으로 남긴다.
+
+---
+
+## 5. 검증
+
+실행한 테스트:
+
+```bash
+./gradlew test --tests org.github.flowify.execution.WorkflowTranslatorTest --tests org.github.flowify.workflow.WorkflowPreviewServiceTest --tests org.github.flowify.execution.FastApiClientTest
+```
+
+결과:
+
+```text
+BUILD SUCCESSFUL
+```
+
+검증된 항목:
+
+- `choiceActionId=summarize` + `action=process` -> `requires_content=true`
+- 명시적 `requires_content=false` 우선
+- legacy `choiceSelections` action key fallback
+- source preview metadata 기본값 보강
+- `includeContent=true` preview metadata가 실제 content/status 기반으로 보정됨
+- FastAPI metadata의 null 값은 Spring 기본 metadata를 덮지 않음
+- `DOCUMENT_CONTENT_UNSUPPORTED`, `DOCUMENT_CONTENT_TOO_LARGE`, `DOCUMENT_CONTENT_NOT_REQUESTED` FastAPI error mapping

--- a/src/entities/execution/model/nodeRuntimeIssue.test.ts
+++ b/src/entities/execution/model/nodeRuntimeIssue.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { toNodeRuntimeIssueMap } from "./nodeRuntimeIssue";
+import {
+  getExecutionErrorDisplayMessage,
+  toNodeRuntimeIssueMap,
+} from "./nodeRuntimeIssue";
 
 describe("node runtime issue", () => {
   it("maps only failed execution logs to node issues", () => {
@@ -82,5 +85,33 @@ describe("node runtime issue", () => {
         message: "서비스 연결을 다시 확인해 주세요.",
       },
     });
+  });
+
+  it("maps document content runtime errors to actionable messages", () => {
+    expect(
+      getExecutionErrorDisplayMessage({
+        code: "DOCUMENT_CONTENT_REQUIRED_BUT_UNAVAILABLE",
+        message: "content_required_but_unavailable",
+        stackTrace: null,
+      }),
+    ).toBe(
+      "다음 단계에서 파일 본문이 필요하지만 현재 본문을 사용할 수 없습니다.",
+    );
+
+    expect(
+      getExecutionErrorDisplayMessage({
+        code: "DOCUMENT_CONTENT_TOO_LARGE",
+        message: "max_download_bytes exceeded",
+        stackTrace: null,
+      }),
+    ).toBe("파일이 현재 처리 가능한 크기 제한을 초과했습니다.");
+
+    expect(
+      getExecutionErrorDisplayMessage({
+        code: "DOCUMENT_CONTENT_NOT_REQUESTED",
+        message: "metadata only preview",
+        stackTrace: null,
+      }),
+    ).toBe("본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다.");
   });
 });

--- a/src/entities/execution/model/nodeRuntimeIssue.ts
+++ b/src/entities/execution/model/nodeRuntimeIssue.ts
@@ -7,12 +7,88 @@ const DEFAULT_RUNTIME_ISSUE_MESSAGE = "이 단계 실행 중 문제가 발생했
 const includesAny = (value: string, keywords: string[]) =>
   keywords.some((keyword) => value.includes(keyword));
 
-export const getUserFriendlyExecutionErrorMessage = (
+export const getExecutionErrorDisplayMessage = (
   error: ExecutionErrorDetail | null | undefined,
 ) => {
   const code = error?.code?.toLowerCase() ?? "";
   const message = error?.message?.toLowerCase() ?? "";
   const text = `${code} ${message}`;
+
+  if (
+    includesAny(text, [
+      "document_content_empty",
+      "content_empty",
+      "content status empty",
+      "읽을 수 있는 본문",
+      "본문 없음",
+    ])
+  ) {
+    return "파일에서 읽을 수 있는 본문을 찾지 못했습니다.";
+  }
+
+  if (
+    includesAny(text, [
+      "document_content_unsupported",
+      "unsupported_file_type",
+      "unsupported content",
+      "unsupported document",
+      "지원하지 않는 파일",
+      "지원하지 않는 형식",
+    ])
+  ) {
+    return "현재 지원하지 않는 파일 형식입니다.";
+  }
+
+  if (
+    includesAny(text, [
+      "document_content_too_large",
+      "file_too_large",
+      "content_too_large",
+      "max_download_bytes",
+      "max_extracted_chars",
+      "크기 제한",
+      "용량 제한",
+    ])
+  ) {
+    return "파일이 현재 처리 가능한 크기 제한을 초과했습니다.";
+  }
+
+  if (
+    includesAny(text, [
+      "document_content_required_but_unavailable",
+      "content_required_but_unavailable",
+      "requires_content",
+      "required by downstream",
+      "본문이 필요한",
+      "본문 필요",
+    ])
+  ) {
+    return "다음 단계에서 파일 본문이 필요하지만 현재 본문을 사용할 수 없습니다.";
+  }
+
+  if (
+    includesAny(text, [
+      "document_content_extraction_failed",
+      "document_content_failed",
+      "content_extraction_failed",
+      "extract document content",
+      "본문 추출",
+      "본문 읽기 실패",
+    ])
+  ) {
+    return "파일 본문을 읽는 중 문제가 발생했습니다.";
+  }
+
+  if (
+    includesAny(text, [
+      "document_content_not_requested",
+      "content_not_requested",
+      "not requested",
+      "본문 미포함",
+    ])
+  ) {
+    return "본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다.";
+  }
 
   if (
     includesAny(text, [
@@ -78,6 +154,9 @@ export const getUserFriendlyExecutionErrorMessage = (
 
   return DEFAULT_RUNTIME_ISSUE_MESSAGE;
 };
+
+export const getUserFriendlyExecutionErrorMessage =
+  getExecutionErrorDisplayMessage;
 
 export const toNodeRuntimeIssueMap = (
   execution: ExecutionDetail | null | undefined,

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -226,6 +226,11 @@ export const InputPanel = () => {
                       : "입력 데이터"
                   }
                   data={nodeDataPanel.dataToDisplay}
+                  previewMetadata={
+                    nodeDataPanel.isPreviewDataDisplayed
+                      ? nodeDataPanel.nodePreviewData?.metadata
+                      : null
+                  }
                 />
               ) : null}
               {shouldShowSchemaPreview ? (

--- a/src/widgets/node-data-panel/model/document-content.test.ts
+++ b/src/widgets/node-data-panel/model/document-content.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDocumentContentMetadata,
+  getDocumentContentStatus,
+  getDocumentContentStatusDescription,
+  getDocumentContentText,
+  getPreviewContentMetadata,
+  getPreviewContentPolicyLabel,
+  getPreviewContentRequirementLabel,
+  isDocumentContentUnavailableForSummary,
+} from "./document-content";
+
+describe("document content helpers", () => {
+  it("reads snake_case content contract fields", () => {
+    const data = {
+      content: "본문",
+      content_status: "available",
+      content_metadata: {
+        extraction_method: "pdf_text",
+        content_kind: "plain_text",
+        truncated: true,
+        char_count: "1200",
+        original_char_count: 2400,
+        stored_content_truncated: true,
+        stored_char_count: 1000,
+        limits: {
+          max_download_bytes: 100,
+          max_extracted_chars: "2000",
+          max_llm_input_chars: 3000,
+        },
+      },
+    };
+
+    expect(getDocumentContentText(data)).toBe("본문");
+    expect(getDocumentContentStatus(data)).toBe("available");
+    expect(getDocumentContentMetadata(data)).toEqual({
+      extractionMethod: "pdf_text",
+      contentKind: "plain_text",
+      truncated: true,
+      charCount: 1200,
+      originalCharCount: 2400,
+      storedContentTruncated: true,
+      storedCharCount: 1000,
+      limits: {
+        maxDownloadBytes: 100,
+        maxExtractedChars: 2000,
+        maxLlmInputChars: 3000,
+      },
+    });
+  });
+
+  it("reads camelCase content contract fields", () => {
+    const data = {
+      contentStatus: "too_large",
+      contentMetadata: {
+        extractionMethod: "plain_text",
+        contentKind: "plain_text",
+        originalCharCount: 5000,
+        storedContentTruncated: false,
+        storedCharCount: null,
+        limits: {
+          maxDownloadBytes: 2048,
+          maxExtractedChars: 4000,
+          maxLlmInputChars: 3000,
+        },
+      },
+    };
+
+    expect(getDocumentContentStatus(data)).toBe("too_large");
+    expect(getDocumentContentMetadata(data).limits.maxDownloadBytes).toBe(2048);
+  });
+
+  it("falls back to legacy extracted text", () => {
+    expect(getDocumentContentText({ extracted_text: "legacy" })).toBe("legacy");
+    expect(getDocumentContentText({ extractedText: "legacy camel" })).toBe(
+      "legacy camel",
+    );
+  });
+
+  it("describes unavailable content states", () => {
+    expect(isDocumentContentUnavailableForSummary("empty")).toBe(true);
+    expect(isDocumentContentUnavailableForSummary("available")).toBe(false);
+    expect(
+      getDocumentContentStatusDescription({
+        error: "",
+        metadata: {
+          charCount: null,
+          contentKind: null,
+          extractionMethod: null,
+          limits: {
+            maxDownloadBytes: null,
+            maxExtractedChars: null,
+            maxLlmInputChars: null,
+          },
+          originalCharCount: null,
+          storedCharCount: null,
+          storedContentTruncated: true,
+          truncated: false,
+        },
+        status: "available",
+      }),
+    ).toBe("실행 로그에는 일부 본문만 저장되었습니다.");
+  });
+
+  it("reads preview content policy metadata", () => {
+    expect(
+      getPreviewContentMetadata({
+        contentPolicy: "content_required_but_unavailable",
+        contentStatusScope: "node",
+        previewScope: "source_metadata",
+        contentIncluded: false,
+        contentRequired: true,
+        contentRequiredReason: "downstream",
+      }),
+    ).toEqual({
+      contentIncluded: false,
+      contentPolicy: "content_required_but_unavailable",
+      contentRequired: true,
+      contentRequiredReason: "downstream",
+      contentStatusScope: "node",
+      previewScope: "source_metadata",
+    });
+    expect(
+      getPreviewContentPolicyLabel("content_required_but_unavailable"),
+    ).toContain("본문이 필요한 단계");
+    expect(
+      getPreviewContentRequirementLabel({
+        contentIncluded: false,
+        contentPolicy: "content_status_only",
+        contentRequired: true,
+        contentRequiredReason: "downstream",
+        contentStatusScope: "item",
+        previewScope: "source_metadata",
+      }),
+    ).toContain("현재 미리보기에는 본문이 포함되지 않았습니다");
+  });
+});

--- a/src/widgets/node-data-panel/model/document-content.ts
+++ b/src/widgets/node-data-panel/model/document-content.ts
@@ -1,0 +1,351 @@
+type DataRecord = Record<string, unknown>;
+
+export type DocumentContentStatus =
+  | "available"
+  | "empty"
+  | "unsupported"
+  | "too_large"
+  | "failed"
+  | "not_requested";
+
+export type DocumentContentKind =
+  | "plain_text"
+  | "table_text"
+  | "slide_text"
+  | "ocr_text"
+  | "image_description"
+  | "mixed"
+  | "none";
+
+export type DocumentContentMetadata = {
+  extractionMethod: string | null;
+  contentKind: DocumentContentKind | string | null;
+  truncated: boolean;
+  charCount: number | null;
+  originalCharCount: number | null;
+  storedContentTruncated: boolean;
+  storedCharCount: number | null;
+  limits: {
+    maxDownloadBytes: number | null;
+    maxExtractedChars: number | null;
+    maxLlmInputChars: number | null;
+  };
+};
+
+export type PreviewContentPolicy =
+  | "metadata_only"
+  | "content_included"
+  | "content_status_only"
+  | "required_by_downstream"
+  | "content_required_but_unavailable";
+
+export type PreviewContentMetadata = {
+  contentIncluded: boolean | null;
+  contentPolicy: PreviewContentPolicy | string | null;
+  contentRequired: boolean | null;
+  contentRequiredReason: string | null;
+  contentStatusScope: string | null;
+  previewScope: string | null;
+};
+
+const DOCUMENT_CONTENT_STATUSES = new Set<string>([
+  "available",
+  "empty",
+  "unsupported",
+  "too_large",
+  "failed",
+  "not_requested",
+]);
+
+const DOCUMENT_CONTENT_PROBLEM_STATUSES = new Set<DocumentContentStatus>([
+  "empty",
+  "unsupported",
+  "too_large",
+  "failed",
+]);
+
+const isRecord = (value: unknown): value is DataRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getNestedRecord = (record: DataRecord, ...keys: string[]) => {
+  for (const key of keys) {
+    const value = record[key];
+    if (isRecord(value)) {
+      return value;
+    }
+  }
+
+  return null;
+};
+
+const getString = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : "";
+
+const getBoolean = (value: unknown) =>
+  typeof value === "boolean" ? value : null;
+
+const getNumber = (value: unknown) => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  const stringValue = getString(value);
+  if (!stringValue) {
+    return null;
+  }
+
+  const numberValue = Number(stringValue);
+  return Number.isFinite(numberValue) ? numberValue : null;
+};
+
+const getFirstString = (record: DataRecord, keys: readonly string[]) => {
+  for (const key of keys) {
+    const value = getString(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return "";
+};
+
+const getFirstBoolean = (record: DataRecord, keys: readonly string[]) => {
+  for (const key of keys) {
+    const value = getBoolean(record[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  return false;
+};
+
+const getFirstNumber = (record: DataRecord, keys: readonly string[]) => {
+  for (const key of keys) {
+    const value = getNumber(record[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  return null;
+};
+
+export const getDocumentContentStatus = (
+  value: unknown,
+): DocumentContentStatus | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const status = getFirstString(value, ["content_status", "contentStatus"]);
+  return DOCUMENT_CONTENT_STATUSES.has(status)
+    ? (status as DocumentContentStatus)
+    : null;
+};
+
+export const getDocumentContentError = (value: unknown) => {
+  if (!isRecord(value)) {
+    return "";
+  }
+
+  return getFirstString(value, ["content_error", "contentError"]);
+};
+
+export const getDocumentContentText = (value: unknown) => {
+  if (!isRecord(value)) {
+    return "";
+  }
+
+  return getFirstString(value, ["content", "extracted_text", "extractedText"]);
+};
+
+export const getDocumentContentMetadata = (
+  value: unknown,
+): DocumentContentMetadata => {
+  const metadata = isRecord(value)
+    ? (getNestedRecord(value, "content_metadata", "contentMetadata") ?? {})
+    : {};
+  const limits = getNestedRecord(metadata, "limits") ?? {};
+
+  return {
+    extractionMethod:
+      getFirstString(metadata, ["extraction_method", "extractionMethod"]) ||
+      null,
+    contentKind:
+      getFirstString(metadata, ["content_kind", "contentKind"]) || null,
+    truncated: getFirstBoolean(metadata, ["truncated"]),
+    charCount: getFirstNumber(metadata, ["char_count", "charCount"]),
+    originalCharCount: getFirstNumber(metadata, [
+      "original_char_count",
+      "originalCharCount",
+    ]),
+    storedContentTruncated: getFirstBoolean(metadata, [
+      "stored_content_truncated",
+      "storedContentTruncated",
+    ]),
+    storedCharCount: getFirstNumber(metadata, [
+      "stored_char_count",
+      "storedCharCount",
+    ]),
+    limits: {
+      maxDownloadBytes: getFirstNumber(limits, [
+        "max_download_bytes",
+        "maxDownloadBytes",
+      ]),
+      maxExtractedChars: getFirstNumber(limits, [
+        "max_extracted_chars",
+        "maxExtractedChars",
+      ]),
+      maxLlmInputChars: getFirstNumber(limits, [
+        "max_llm_input_chars",
+        "maxLlmInputChars",
+      ]),
+    },
+  };
+};
+
+export const getDocumentContentStatusLabel = (
+  status: DocumentContentStatus | null,
+) => {
+  switch (status) {
+    case "available":
+      return "본문 읽기 완료";
+    case "empty":
+      return "읽을 수 있는 본문 없음";
+    case "unsupported":
+      return "지원하지 않는 파일 형식";
+    case "too_large":
+      return "파일 크기 제한 초과";
+    case "failed":
+      return "본문 읽기 실패";
+    case "not_requested":
+      return "본문 미포함";
+    default:
+      return "";
+  }
+};
+
+export const getDocumentContentStatusDescription = ({
+  error,
+  metadata,
+  status,
+}: {
+  error?: string;
+  metadata: DocumentContentMetadata;
+  status: DocumentContentStatus | null;
+}) => {
+  if (error) {
+    return error;
+  }
+
+  if (status === "too_large") {
+    return "현재 처리 가능한 크기를 초과했습니다.";
+  }
+
+  if (metadata.storedContentTruncated) {
+    return "실행 로그에는 일부 본문만 저장되었습니다.";
+  }
+
+  if (metadata.truncated) {
+    return "본문 일부만 표시됩니다.";
+  }
+
+  return "";
+};
+
+export const isDocumentContentProblem = (
+  status: DocumentContentStatus | null,
+) => Boolean(status && DOCUMENT_CONTENT_PROBLEM_STATUSES.has(status));
+
+export const isDocumentContentUnavailableForSummary = (
+  status: DocumentContentStatus | null,
+) =>
+  Boolean(
+    status &&
+    ["empty", "unsupported", "too_large", "failed", "not_requested"].includes(
+      status,
+    ),
+  );
+
+export const getPreviewContentMetadata = (
+  metadata: unknown,
+): PreviewContentMetadata => {
+  if (!isRecord(metadata)) {
+    return {
+      contentIncluded: null,
+      contentPolicy: null,
+      contentRequired: null,
+      contentRequiredReason: null,
+      contentStatusScope: null,
+      previewScope: null,
+    };
+  }
+
+  return {
+    contentIncluded:
+      getBoolean(metadata.contentIncluded) ??
+      getBoolean(metadata.content_included),
+    contentPolicy:
+      getFirstString(metadata, ["contentPolicy", "content_policy"]) || null,
+    contentRequired:
+      getBoolean(metadata.contentRequired) ??
+      getBoolean(metadata.content_required),
+    contentRequiredReason:
+      getFirstString(metadata, [
+        "contentRequiredReason",
+        "content_required_reason",
+      ]) || null,
+    contentStatusScope:
+      getFirstString(metadata, [
+        "contentStatusScope",
+        "content_status_scope",
+      ]) || null,
+    previewScope:
+      getFirstString(metadata, ["previewScope", "preview_scope"]) || null,
+  };
+};
+
+export const getPreviewContentPolicyLabel = (
+  policy: PreviewContentPolicy | string | null,
+) => {
+  switch (policy) {
+    case "metadata_only":
+      return "본문 미포함 미리보기";
+    case "content_included":
+      return "본문 포함 미리보기";
+    case "content_status_only":
+      return "본문 상태만 포함된 미리보기";
+    case "required_by_downstream":
+      return "다음 단계에서 본문 필요";
+    case "content_required_but_unavailable":
+      return "본문이 필요한 단계지만 현재 미리보기에는 본문이 포함되지 않았습니다.";
+    default:
+      return "";
+  }
+};
+
+export const getPreviewContentRequirementLabel = ({
+  contentIncluded,
+  contentRequired,
+  contentRequiredReason,
+}: PreviewContentMetadata) => {
+  if (!contentRequired) {
+    return "";
+  }
+
+  if (contentIncluded === false) {
+    return "본문이 필요한 단계지만 현재 미리보기에는 본문이 포함되지 않았습니다.";
+  }
+
+  switch (contentRequiredReason) {
+    case "downstream":
+      return "다음 단계에서 본문 필요";
+    case "user_request":
+      return "사용자 요청에 따라 본문 필요";
+    case "runtime_config":
+      return "실행 설정상 본문 필요";
+    default:
+      return "본문이 필요한 미리보기입니다.";
+  }
+};

--- a/src/widgets/node-data-panel/model/index.ts
+++ b/src/widgets/node-data-panel/model/index.ts
@@ -1,5 +1,6 @@
 export * from "./node-data-panel-display";
 export * from "./node-data-panel-utils";
+export * from "./document-content";
 export * from "./spreadsheet-preview";
 export * from "./types";
 export * from "./useNodeDataPanelModel";

--- a/src/widgets/node-data-panel/model/node-data-panel-display.ts
+++ b/src/widgets/node-data-panel/model/node-data-panel-display.ts
@@ -3,6 +3,7 @@ import {
   type NodeStatusSummaryResponse,
   type SourceConfigSummaryResponse,
   getCanonicalInputTypeLabel,
+  getExecutionErrorDisplayMessage,
   getExecutionStatusLabel,
   getNodeDataReasonLabel,
   getTriggerKindLabel,
@@ -107,7 +108,9 @@ export const getExecutionStatusNotice = (
 
   const reasonLabel = getNodeDataReasonLabel(executionData.reason);
   const statusLabel = getExecutionStatusLabel(executionData.status);
-  const errorMessage = executionData.error?.message ?? null;
+  const errorMessage = executionData.error
+    ? getExecutionErrorDisplayMessage(executionData.error)
+    : null;
 
   if (executionData.error || executionData.reason === "NODE_FAILED") {
     return {

--- a/src/widgets/node-data-panel/ui/DataPreviewBlock.test.tsx
+++ b/src/widgets/node-data-panel/ui/DataPreviewBlock.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ChakraProvider } from "@chakra-ui/react";
+import { describe, expect, it } from "vitest";
+
+import { system } from "@/shared";
+
+import { DataPreviewBlock } from "./DataPreviewBlock";
+
+const renderDataPreviewBlock = (
+  props: React.ComponentProps<typeof DataPreviewBlock>,
+) =>
+  renderToStaticMarkup(
+    <ChakraProvider value={system}>
+      <DataPreviewBlock {...props} />
+    </ChakraProvider>,
+  );
+
+describe("DataPreviewBlock", () => {
+  it("shows document content status and extracted content for files", () => {
+    const html = renderDataPreviewBlock({
+      data: {
+        type: "FILE_LIST",
+        files: [
+          {
+            filename: "report.pdf",
+            content_status: "available",
+            content: "요약 가능한 본문입니다.",
+            content_metadata: {
+              char_count: 120,
+            },
+          },
+          {
+            filename: "large.pdf",
+            content_status: "too_large",
+            content_error: "limit exceeded",
+          },
+        ],
+      },
+      previewMetadata: {
+        contentPolicy: "content_included",
+        contentRequired: true,
+        contentRequiredReason: "downstream",
+      },
+    });
+
+    expect(html).toContain("본문 포함 미리보기");
+    expect(html).toContain("다음 단계에서 본문 필요");
+    expect(html).toContain("본문 읽기 완료 1개");
+    expect(html).toContain("파일 크기 제한 초과 1개");
+    expect(html).toContain("본문: 요약 가능한 본문입니다.");
+    expect(html).toContain("limit exceeded");
+  });
+});

--- a/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
+++ b/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
@@ -3,11 +3,26 @@ import { type ReactNode } from "react";
 import { Box, Link, Text } from "@chakra-ui/react";
 
 import { getDataTypeDisplayLabel } from "@/entities";
+
+import {
+  type DocumentContentStatus,
+  getDocumentContentError,
+  getDocumentContentMetadata,
+  getDocumentContentStatus,
+  getDocumentContentStatusDescription,
+  getDocumentContentStatusLabel,
+  getDocumentContentText,
+  getPreviewContentMetadata,
+  getPreviewContentPolicyLabel,
+  getPreviewContentRequirementLabel,
+  isDocumentContentProblem,
+} from "../model/document-content";
 import { getSpreadsheetPreviewSummary } from "../model/spreadsheet-preview";
 
 type Props = {
   title?: string;
   data: unknown;
+  previewMetadata?: Record<string, unknown> | null;
 };
 
 type DataRecord = Record<string, unknown>;
@@ -15,6 +30,14 @@ type DataRecord = Record<string, unknown>;
 const MAX_TEXT_PREVIEW_LENGTH = 1400;
 const MAX_LIST_PREVIEW_COUNT = 12;
 const MAX_TABLE_ROW_COUNT = 12;
+const DOCUMENT_CONTENT_STATUS_ORDER: DocumentContentStatus[] = [
+  "available",
+  "empty",
+  "unsupported",
+  "too_large",
+  "failed",
+  "not_requested",
+];
 
 const isRecord = (value: unknown): value is DataRecord =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -160,7 +183,78 @@ const SummaryCard = ({
   </Box>
 );
 
-const FileItemCard = ({ item, index }: { item: DataRecord; index: number }) => {
+const DocumentContentStatusRows = ({ item }: { item: DataRecord }) => {
+  const status = getDocumentContentStatus(item);
+  if (!status) {
+    return null;
+  }
+
+  const metadata = getDocumentContentMetadata(item);
+  const description = getDocumentContentStatusDescription({
+    error: getDocumentContentError(item),
+    metadata,
+    status,
+  });
+  const charCount = metadata.charCount ?? metadata.storedCharCount;
+
+  return (
+    <>
+      <FieldText
+        label="본문 상태"
+        value={getDocumentContentStatusLabel(status)}
+      />
+      <FieldText
+        label="본문 길이"
+        value={charCount === null ? "" : `${charCount.toLocaleString()}자`}
+      />
+      {description ? (
+        <Text
+          fontSize="xs"
+          color={
+            isDocumentContentProblem(status) ? "red.500" : "text.secondary"
+          }
+        >
+          {description}
+        </Text>
+      ) : null}
+    </>
+  );
+};
+
+const DocumentContentInlinePreview = ({
+  item,
+  label,
+}: {
+  item: DataRecord;
+  label: string;
+}) => {
+  const status = getDocumentContentStatus(item);
+  const content = getDocumentContentText(item);
+
+  if (status && status !== "available") {
+    return null;
+  }
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <Text fontSize="xs" color="text.secondary" whiteSpace="pre-wrap">
+      {label}: {truncateText(content, 240)}
+    </Text>
+  );
+};
+
+const FileItemCard = ({
+  item,
+  index,
+  contentLabel = "본문",
+}: {
+  item: DataRecord;
+  index: number;
+  contentLabel?: string;
+}) => {
   const filename = getString(item.filename) || `파일 ${index + 1}`;
   const mimeType = getString(item.mime_type) || getString(item.mimeType);
   const size = formatFileSize(item.size);
@@ -184,9 +278,44 @@ const FileItemCard = ({ item, index }: { item: DataRecord; index: number }) => {
           label="수정일"
           value={formatDateTime(item.modified_time ?? item.modifiedTime)}
         />
+        <DocumentContentStatusRows item={item} />
+        <DocumentContentInlinePreview item={item} label={contentLabel} />
         <ExternalLink href={item.url} />
       </Box>
     </Box>
+  );
+};
+
+const getDocumentContentStatusCounts = (items: DataRecord[]) => {
+  const counts = new Map<DocumentContentStatus, number>();
+
+  for (const item of items) {
+    const status = getDocumentContentStatus(item);
+    if (status) {
+      counts.set(status, (counts.get(status) ?? 0) + 1);
+    }
+  }
+
+  return counts;
+};
+
+const DocumentContentStatusSummary = ({ items }: { items: DataRecord[] }) => {
+  const counts = getDocumentContentStatusCounts(items);
+  if (counts.size === 0) {
+    return null;
+  }
+
+  const labels = DOCUMENT_CONTENT_STATUS_ORDER.flatMap((status) => {
+    const count = counts.get(status) ?? 0;
+    return count > 0
+      ? [`${getDocumentContentStatusLabel(status)} ${count}개`]
+      : [];
+  });
+
+  return (
+    <Text fontSize="xs" color="text.secondary">
+      {labels.join(" · ")}
+    </Text>
   );
 };
 
@@ -204,7 +333,9 @@ const FileListPreview = ({ data }: { data: DataRecord }) => {
             ? "다음 단계로 전달된 파일 목록입니다."
             : "전달된 파일이 없습니다."
         }
-      />
+      >
+        <DocumentContentStatusSummary items={items} />
+      </SummaryCard>
       {previewItems.map((item, index) => (
         <FileItemCard
           key={`${getString(item.filename)}-${index}`}
@@ -223,7 +354,8 @@ const FileListPreview = ({ data }: { data: DataRecord }) => {
 
 const SingleFilePreview = ({ data }: { data: DataRecord }) => {
   const filename = getString(data.filename) || "파일";
-  const content = getString(data.content);
+  const status = getDocumentContentStatus(data);
+  const content = getDocumentContentText(data);
 
   return (
     <Box display="flex" flexDirection="column" gap={3}>
@@ -241,9 +373,10 @@ const SingleFilePreview = ({ data }: { data: DataRecord }) => {
           label="수정일"
           value={formatDateTime(data.modified_time ?? data.modifiedTime)}
         />
+        <DocumentContentStatusRows item={data} />
         <ExternalLink href={data.url} />
       </SummaryCard>
-      {content ? (
+      {content && (!status || status === "available") ? (
         <SummaryCard
           title="본문 미리보기"
           description={truncateText(content)}
@@ -365,6 +498,7 @@ const SingleEmailPreview = ({ data }: { data: DataRecord }) => {
               key={`${getString(item.filename)}-${index}`}
               item={item}
               index={index}
+              contentLabel="첨부 본문"
             />
           ))}
         </Box>
@@ -704,9 +838,17 @@ const CanonicalPreview = ({ data }: { data: unknown }) => {
 export const DataPreviewBlock = ({
   title = "데이터 미리보기",
   data,
+  previewMetadata,
 }: Props) => {
   const payloadType = getPayloadType(data);
   const payloadLabel = payloadType ? getDisplayTypeLabel(payloadType) : null;
+  const parsedPreviewMetadata = getPreviewContentMetadata(previewMetadata);
+  const contentPolicyLabel = getPreviewContentPolicyLabel(
+    parsedPreviewMetadata.contentPolicy,
+  );
+  const contentRequirementLabel = getPreviewContentRequirementLabel(
+    parsedPreviewMetadata,
+  );
 
   return (
     <Box display="flex" flexDirection="column" gap={3}>
@@ -717,6 +859,16 @@ export const DataPreviewBlock = ({
         {payloadLabel ? (
           <Text mt={1} fontSize="xs" color="text.secondary">
             {payloadLabel}
+          </Text>
+        ) : null}
+        {contentPolicyLabel ? (
+          <Text mt={1} fontSize="xs" color="text.secondary">
+            {contentPolicyLabel}
+          </Text>
+        ) : null}
+        {contentRequirementLabel ? (
+          <Text mt={1} fontSize="xs" color="text.secondary">
+            {contentRequirementLabel}
           </Text>
         ) : null}
       </Box>

--- a/src/widgets/node-data-panel/ui/DataStateNotice.tsx
+++ b/src/widgets/node-data-panel/ui/DataStateNotice.tsx
@@ -1,6 +1,9 @@
 import { Box, Spinner, Text } from "@chakra-ui/react";
 
-import { type ExecutionNodeData } from "@/entities";
+import {
+  type ExecutionNodeData,
+  getExecutionErrorDisplayMessage,
+} from "@/entities";
 
 import { type NodeDataPanelKind, type NodeDataPanelState } from "../model";
 
@@ -68,8 +71,9 @@ const getNoticeDescription = (
       return "이번 실행에서 해당 노드는 조건에 의해 실행되지 않았습니다.";
     case "node-failed":
       return (
-        executionData?.error?.message ??
-        "이번 실행에서 해당 노드가 실패했습니다."
+        (executionData?.error
+          ? getExecutionErrorDisplayMessage(executionData.error)
+          : null) ?? "이번 실행에서 해당 노드가 실패했습니다."
       );
     case "node-not-executed":
       return "최근 실행 기록에 해당 노드 실행 정보가 없습니다.";

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -717,6 +717,11 @@ export const OutputPanel = ({ wizardController }: Props) => {
                     : "출력 데이터"
                 }
                 data={nodeDataPanel.dataToDisplay}
+                previewMetadata={
+                  nodeDataPanel.isPreviewDataDisplayed
+                    ? nodeDataPanel.nodePreviewData?.metadata
+                    : null
+                }
               />
             ) : null}
             {shouldShowSchemaPreview ? (


### PR DESCRIPTION
## Summary

- Implemented the FE side of the document content runtime contract against the Spring Boot public API.
- Added document content preview helpers for `content_status`, `content_error`, `content_metadata`, preview content policy metadata, and legacy extracted text fallback.
- Surfaced document content status, snippets, truncate hints, and `DOCUMENT_CONTENT_*` execution error messages in node data panels.
- Added and updated backend handoff/review docs for the Spring Boot and FastAPI alignment.

## Scope Notes

- This PR reflects the Spring Boot team contract and the FastAPI implementation report.
- FastAPI now reports DOCX/PPTX/HWPX extractor support in the backend docs.
- Gmail attachment body extraction, scan PDF OCR, and image OCR/vision remain follow-up scope and are intentionally not described as completed.

## Validation

- `vitest run --passWithNoTests` passed via commit hook.
- `eslint --cache --fix .` passed via commit hook.
- `tsc --noEmit` passed via commit hook.

## Key Commits

- `6436f03 feat: support document content runtime preview contract`
- `1bb67bf docs: finalize document content runtime integration review`
