### PR TITLE
Feat#176 dashboard error card fix

### DIFF
--- a/docs/DASHBOARD_ISSUE_CARD_NAVIGATION_DETAIL_DESIGN.md
+++ b/docs/DASHBOARD_ISSUE_CARD_NAVIGATION_DETAIL_DESIGN.md
@@ -1,0 +1,758 @@
+# Dashboard Issue Card Navigation and Detail Toggle Design
+
+> **작성일:** 2026-05-14
+> **대상 영역:** Dashboard `오늘 발생한 에러`
+> **대상 저장소:** `flowify-FE`
+> **범위:** FE UI/interaction 설계
+
+---
+
+## 0. 3회 검토 요약
+
+### 0.1 1차 검토: 현재 Dashboard Issue Card 구조 분석
+
+확인한 파일:
+
+- `src/pages/dashboard/DashboardPage.tsx`
+- `src/pages/dashboard/ui/section/DashboardSection.tsx`
+- `src/pages/dashboard/ui/DashboardIssueCardItem.tsx`
+- `src/pages/dashboard/ui/DashboardErrorCard.tsx`
+- `src/pages/dashboard/model/useDashboardData.ts`
+- `src/pages/dashboard/model/useDashboardActions.ts`
+- `src/pages/dashboard/model/dashboard.ts`
+- `src/pages/dashboard/model/types.ts`
+- `src/entities/dashboard/api/types.ts`
+- `src/entities/dashboard/api/get-dashboard-summary.api.ts`
+- `src/features/workflow-execution/model/useWorkflowExecutionAction.ts`
+- `src/shared/constants/route-path.ts`
+- `src/app/routes/Router.tsx`
+- `src/pages/workflows/ui/WorkflowRow.tsx`
+- `src/pages/templates/ui/TemplateRow.tsx`
+- `src/pages/dashboard/ui/ServiceConnectionCard.tsx`
+- `package.json`
+
+현재 issue card 렌더링 구조:
+
+- `DashboardPage`는 `DashboardSection`만 렌더링한다.
+- `DashboardSection`의 `오늘 발생한 에러` 영역은 `issues.map`으로 `DashboardIssueCardItem`을 렌더링한다.
+- `DashboardIssueCardItem`은 `useWorkflowExecutionAction(issue.workflowId)`로 실행/중지 액션 상태를 만든 뒤 `DashboardErrorCard`에 전달한다.
+- `DashboardErrorCard`는 현재 카드 전체 `Box`에 `onClick={onToggle}`, `role="button"`, `tabIndex={0}`, `aria-expanded={isExpanded}`를 달아 카드 전체 클릭/Enter/Space로 상세 내역을 펼친다.
+
+현재 issue 데이터 구조:
+
+- API 응답 타입 `DashboardIssueResponse`는 `id`, `type`, `workflowId`, `workflowName`, `isActive`, `startService`, `endService`, `occurredAt`, `message`, `items`를 가진다.
+- FE 모델 `DashboardIssue`도 `workflowId: string`을 가진다.
+- `getDashboardIssuesFromSummary`는 `DashboardIssueResponse`를 `DashboardIssue`로 변환하며, `message`는 `buildProgressLabel`로 들어간다.
+- `items`가 비어 있으면 `getDashboardIssueItems`에서 `issue.message` 또는 `type`을 fallback item으로 만든다.
+
+현재 클릭/action 구조:
+
+- 현재 카드 전체 클릭은 펼치기 토글이다.
+- 오른쪽 끝에는 이미 실행/중지 `IconButton`이 있다.
+- 실행/중지 버튼은 `event.stopPropagation()`을 호출해 카드 전체 토글과 충돌하지 않는다.
+- `useDashboardActions`는 `expandedIssueId` 하나만 관리하므로 동시에 하나의 issue만 펼쳐진다.
+
+workflowId 사용 가능 여부:
+
+- 현재 타입 기준으로 `workflowId`는 필수 string이다.
+- `useWorkflowExecutionAction`은 `workflowId: string | undefined`를 받을 수 있어 방어 로직이 이미 있다.
+- 요구사항상 `workflowId`가 없거나 빈 값인 issue 가능성을 고려해야 하므로, 구현 시 타입을 성급히 바꾸기보다 card/item 레벨에서 `typeof issue.workflowId === "string" && issue.workflowId.trim().length > 0` 형태의 runtime guard를 둔다.
+
+기존 레퍼런스와 유지할 부분:
+
+- `DashboardIssueCardItem -> DashboardErrorCard` 분리 구조는 유지한다.
+- `DashboardSection`의 `expandedIssueId` 단일 확장 상태는 유지한다.
+- `dashboard summary API`, `DashboardIssueResponse`, `DashboardIssue` 변환 흐름은 유지한다.
+- `issue.items` fallback 생성 로직은 유지한다.
+- 실행/중지 액션과 `useWorkflowExecutionAction`은 유지한다.
+- `WorkflowRow`, `TemplateRow`, `ServiceConnectionCard`에서 쓰는 내부 액션 `stopPropagation` 패턴을 따른다.
+
+### 0.2 2차 검토: 이벤트 충돌 가능성 분석
+
+카드 가운데 클릭과 오른쪽 펼치기 클릭의 충돌 가능성:
+
+- 현재는 root card 전체가 펼치기 버튼 역할을 하기 때문에, 가운데 클릭을 workflow 이동으로 바꾸면 root `onClick={onToggle}`와 목적이 충돌한다.
+- root container에 click handler를 유지하면 오른쪽 펼치기 버튼, 실행/중지 버튼, 상세 item 클릭이 모두 bubbling 충돌 가능성을 갖는다.
+- 따라서 root card는 시각적 container로만 두고, interaction은 `MainClickableArea`, `ExecutionActionButton`, `RightToggleButton`으로 분리한다.
+
+event.stopPropagation 필요 지점:
+
+- `RightToggleButton` 클릭은 `event.stopPropagation()` 후 `onToggle()`만 호출한다.
+- 기존 `ExecutionActionButton` 클릭은 지금처럼 `event.stopPropagation()` 후 `onExecutionAction()`만 호출한다.
+- 만약 오른쪽 action group 전체에 pointer/key handler를 둔다면 `onPointerDown`, `onClick`, `onKeyDown`에서 propagation을 막는 기존 menu 패턴을 참고한다.
+- 펼쳐진 상세 영역은 root click handler를 제거하면 별도 stopPropagation이 필수는 아니지만, 상세 영역 내부에 향후 링크/버튼이 생길 가능성을 고려해 root click 의존을 만들지 않는다.
+
+Link/useNavigate 중 어떤 방식이 적절한지:
+
+- 현재 프로젝트의 목록 row navigation은 `WorkflowRow`, `TemplateRow`, `useWorkflowListActions`, `useCreateWorkflowShortcut`에서 `useNavigate`와 callback 기반 `onOpen` 패턴을 많이 쓴다.
+- `DashboardIssueCardItem`이 `useNavigate`와 `buildPath.workflowEditor(issue.workflowId)`를 사용해 `onOpenWorkflow`를 만들고, `DashboardErrorCard`는 routing을 모르는 presentational component로 유지하는 방식이 적절하다.
+- `<Link>`로 main area를 감쌀 수도 있지만, 현재 카드 안에 실행/중지와 펼치기 `IconButton`이 함께 존재하므로 sibling action 영역과 명확히 분리해야 한다. 기존 callback 패턴과 일관성을 위해 `useNavigate`를 우선한다.
+
+버튼/클릭 영역 분리 방식:
+
+- `IssueCard` root는 `Box` container로 유지한다.
+- 가운데 영역은 `Box as="button"` 또는 `Flex as="button"` 형태의 `MainClickableArea`로 분리한다.
+- 오른쪽 끝에는 `RightToggleButton`을 둔다.
+- 기존 실행/중지 버튼은 오른쪽 action group 안에 유지하되, 펼치기 버튼을 가장 오른쪽에 둔다.
+- main area와 right action group은 sibling이어야 하며, main area 안에 `IconButton`이 중첩되지 않게 한다.
+
+키보드 접근성 고려:
+
+- main clickable area는 native `button`을 쓰는 것이 가장 안전하다. 그러면 Enter/Space 동작은 브라우저 기본 버튼 동작을 사용할 수 있다.
+- workflowId가 없으면 main clickable area는 `disabled` 또는 `aria-disabled` 상태가 되어야 한다.
+- toggle button은 `aria-label={isExpanded ? "에러 상세 접기" : "에러 상세 펼치기"}`와 `aria-expanded={isExpanded}`를 가진다.
+- toggle button은 `aria-controls`로 상세 영역 id를 참조할 수 있다.
+- root container에 `role="button"`을 남기지 않는다. interactive element가 여러 개 있는 card에서 root button role은 스크린 리더와 키보드 탐색에 혼란을 줄 수 있다.
+
+workflowId가 없을 때 처리:
+
+- `workflowId`가 없거나 빈 문자열이면 main area 이동을 비활성화한다.
+- 비활성 상태에서는 cursor를 `default`로 두고 hover elevation을 적용하지 않는다.
+- 보조 문구는 과하게 추가하지 않고, 필요하면 `title="연결된 워크플로우 정보가 없습니다."` 정도만 둔다.
+- 실행/중지 action은 `useWorkflowExecutionAction`의 기존 guard가 있으므로, 구현 시 action disabled 조건에도 `!canNavigateWorkflow`를 반영하는 것을 검토한다.
+
+### 0.3 3차 검토: 구현 범위와 회귀 위험 분석
+
+수정할 파일:
+
+- `src/pages/dashboard/ui/DashboardIssueCardItem.tsx`
+- `src/pages/dashboard/ui/DashboardErrorCard.tsx`
+
+필요 시 수정할 파일:
+
+- `src/pages/dashboard/model/types.ts`
+
+단, `workflowId` optional 전환은 API/모델 계약 변경에 가까우므로 1차 구현에서는 피하고 runtime guard로 대응한다.
+
+수정하지 않을 파일:
+
+- `src/entities/dashboard/api/get-dashboard-summary.api.ts`
+- `src/entities/dashboard/api/types.ts`
+- `src/pages/dashboard/model/useDashboardData.ts`
+- `src/pages/dashboard/model/dashboard.ts`
+- `src/pages/dashboard/model/useDashboardActions.ts`
+- `src/features/workflow-execution/model/useWorkflowExecutionAction.ts`
+- Spring/FastAPI/DB/workflow execution 관련 파일
+
+서버/API/DB 영향 여부:
+
+- 없음.
+- dashboard summary API 응답 형태는 유지한다.
+- issue type, source, workflow 실행 흐름은 변경하지 않는다.
+
+dashboard summary API 변경 필요 여부:
+
+- 필요 없음.
+- 이미 `workflowId`, `message`, `items`가 존재한다.
+- `items`가 없는 경우 FE mapper에서 fallback item을 생성하고 있으므로 상세 영역 fallback도 기존 데이터 흐름으로 처리 가능하다.
+
+기존 실행/중지 액션 영향 여부:
+
+- 실행/중지 버튼은 유지한다.
+- 기존 `event.stopPropagation()` 패턴은 유지한다.
+- 오른쪽 action group에 펼치기 버튼이 추가되므로 버튼 순서와 touch target만 조정한다.
+
+수동 검증 항목:
+
+- issue main area 클릭 시 `/workflows/:workflowId` 편집 화면으로 이동한다.
+- 오른쪽 펼치기 버튼 클릭 시 상세 내역만 펼쳐지고 페이지 이동은 발생하지 않는다.
+- 실행/중지 버튼 클릭 시 상세 토글과 페이지 이동이 발생하지 않는다.
+- Enter/Space로 main area를 조작하면 workflow 편집 화면으로 이동한다.
+- Enter/Space로 toggle button을 조작하면 상세만 펼쳐진다.
+- workflowId가 없는 issue는 이동 UI가 비활성화되고 상세 펼치기는 가능하다.
+- 좁은 화면에서 main area와 right action button이 겹치거나 너무 작아지지 않는다.
+
+## 1. 목적
+
+`오늘 발생한 에러` 영역은 사용자가 실패한 자동화를 빠르게 확인하는 대시보드 진입점이다.
+
+이번 개선의 목적은 다음과 같다.
+
+- 에러 카드의 주요 내용 영역을 클릭하면 해당 workflow 편집 화면으로 바로 이동할 수 있게 한다.
+- 오른쪽 끝에는 에러 상세 내역을 펼치는 전용 액션을 둔다.
+- 가운데 이동 클릭과 오른쪽 펼치기 클릭이 이벤트 전파로 충돌하지 않게 한다.
+- 기존 dashboard API, issue 데이터 source, workflow 실행/중지 액션은 그대로 유지한다.
+
+## 2. 현재 상태 분석
+
+### 2.1 Dashboard issue card 컴포넌트
+
+현재 `오늘 발생한 에러` 영역은 다음 흐름으로 렌더링된다.
+
+```text
+DashboardPage
+  └─ DashboardSection
+      └─ DashboardIssueCardItem
+          └─ DashboardErrorCard
+```
+
+`DashboardSection`은 `useDashboardData()`에서 받은 `issues`를 순회하고, `useDashboardActions()`의 `expandedIssueId`와 `handleToggleIssue`를 각 card에 전달한다.
+
+`DashboardIssueCardItem`은 issue별 실행/중지 상태를 만들기 위해 `useWorkflowExecutionAction(issue.workflowId)`를 호출한다.
+
+`DashboardErrorCard`는 실제 카드 UI를 렌더링한다. 현재 root `Box`가 clickable이며, `onClick={onToggle}`로 상세 영역을 펼치거나 접는다.
+
+### 2.2 issue type 구조
+
+API 응답 타입:
+
+```ts
+export type DashboardIssueResponse = {
+  id: string;
+  type: "EXECUTION_FAILED" | "WORKFLOW_NOT_EXECUTABLE" | string;
+  workflowId: string;
+  workflowName: string | null;
+  isActive: boolean;
+  startService: string | null;
+  endService: string | null;
+  occurredAt: string | null;
+  message: string | null;
+  items: DashboardIssueItemResponse[];
+};
+```
+
+FE view model:
+
+```ts
+export type DashboardIssue = {
+  id: string;
+  workflowId: string;
+  name: string;
+  isActive: boolean;
+  startBadgeKey: ServiceBadgeKey;
+  endBadgeKey: ServiceBadgeKey;
+  relativeUpdateLabel: string;
+  buildProgressLabel: string;
+  items: DashboardIssueItem[];
+};
+```
+
+현재 타입상 `workflowId`는 존재하지만, 요구사항상 runtime data가 비어 있을 가능성을 고려한다.
+
+### 2.3 workflowId 존재 여부
+
+`DashboardIssueResponse.workflowId`와 `DashboardIssue.workflowId` 모두 string이다.
+
+다만 구현 시 다음 guard를 둔다.
+
+```ts
+const workflowId = issue.workflowId?.trim();
+const canOpenWorkflow = Boolean(workflowId);
+```
+
+더 방어적으로는 runtime data를 고려해 다음처럼 체크할 수 있다.
+
+```ts
+const workflowId =
+  typeof issue.workflowId === "string" ? issue.workflowId.trim() : "";
+const canOpenWorkflow = workflowId.length > 0;
+```
+
+이 guard는 API 타입을 바꾸지 않으면서 workflowId가 비어 있는 상황의 UI 회귀를 막는다.
+
+### 2.4 message/items 구조
+
+`dashboard.ts`의 `getDashboardIssueItems`는 `issue.items.length === 0`이면 fallback item을 만든다.
+
+fallback message 우선순위:
+
+1. `issue.message`
+2. `issue.type`
+3. `"Issue"`
+
+따라서 `DashboardErrorCard`는 지금처럼 `issue.items.map`을 사용해도 상세 내역이 비지 않는다.
+
+구현 시에도 이 mapper를 유지하고, card 내부에서 별도 API fallback을 만들지 않는다.
+
+### 2.5 현재 액션 버튼/상태 표시
+
+현재 오른쪽 끝에는 실행/중지 `IconButton`이 있다.
+
+- 실행 가능 상태: `MdPlayArrow`
+- 실행 중 상태: `MdStop`
+- pending 상태: `Spinner`
+- label: `워크플로우 실행` 또는 `워크플로우 중지`
+
+이 버튼은 `event.stopPropagation()`을 호출해 root card toggle과 충돌하지 않게 되어 있다.
+
+### 2.6 routing 방식
+
+workflow 편집 페이지 route:
+
+```ts
+DYNAMIC_ROUTE_PATHS.WORKFLOW_EDITOR = "/workflows/:id";
+buildPath.workflowEditor = (id: string) => `/workflows/${id}`;
+```
+
+router 연결:
+
+```tsx
+<Route
+  path={DYNAMIC_ROUTE_PATHS.WORKFLOW_EDITOR}
+  element={<WorkflowEditorPage />}
+/>
+```
+
+기존 코드에서는 workflow open 동작에 `useNavigate(buildPath.workflowEditor(id))` 패턴을 사용한다.
+
+### 2.7 기존 UI 컴포넌트 패턴
+
+기존 row click 패턴:
+
+- `WorkflowRow`는 row 전체를 `role="button"`으로 두고 `onClick={onOpen}`을 사용한다.
+- 내부 실행/삭제/menu 버튼에서는 `stopPropagation()`을 호출한다.
+- `TemplateRow`도 row click과 오른쪽 action button을 분리한다.
+
+이번 issue card는 interactive action이 둘 이상이므로 root 전체 `role="button"`보다는 main area button + right action buttons로 분리하는 편이 더 안전하다.
+
+기존 expand/collapse 패턴:
+
+- `DashboardErrorCard`는 Chakra `Accordion`/`Collapsible`을 쓰지 않고 `isExpanded ? <VStack /> : null` 조건부 렌더링을 사용한다.
+- 현재 프로젝트에서 `Accordion`, `Collapsible`, `Disclosure` 사용 패턴은 확인되지 않았다.
+- 따라서 새 dependency나 새 UI primitive를 도입하지 않고 기존 조건부 렌더링을 유지한다.
+
+## 3. 요구사항 정의
+
+### 3.1 가운데 클릭 동작
+
+- 카드의 주요 내용 영역 클릭 시 `/workflows/:workflowId`로 이동한다.
+- 이동 경로는 `buildPath.workflowEditor(workflowId)`를 사용한다.
+- `workflowId`가 없거나 빈 문자열이면 이동을 비활성화한다.
+- 이동 가능 상태에서는 `cursor="pointer"`와 hover/focus 스타일을 적용한다.
+- 이동 불가능 상태에서는 `cursor="default"` 또는 `not-allowed`를 적용하고 hover elevation은 제거한다.
+- 오른쪽 펼치기 버튼 클릭과 충돌하지 않는다.
+- 실행/중지 버튼 클릭과도 충돌하지 않는다.
+
+### 3.2 오른쪽 끝 펼치기 동작
+
+- 오른쪽 끝에 펼치기 전용 `IconButton`을 배치한다.
+- 버튼 클릭 시 상세 에러 내역을 표시한다.
+- 다시 클릭하면 상세 에러 내역을 접는다.
+- 펼치기 버튼 클릭 시 workflow 이동 이벤트가 발생하지 않는다.
+- `onClick`에서 `event.stopPropagation()`을 호출한다.
+- `aria-expanded`, `aria-controls`, 상태별 `aria-label`을 제공한다.
+- 상세 내역에는 `issue.items`를 표시한다.
+- `issue.items`가 비어 있는 경우는 mapper fallback이 이미 생성하지만, UI 레벨에서도 `issue.items.length === 0` 방어 메시지를 둘 수 있다.
+
+### 3.3 유지할 동작
+
+- 기존 dashboard issue 데이터 source를 유지한다.
+- 기존 `/dashboard/summary` API를 유지한다.
+- 기존 `DashboardIssueResponse`와 issue type 구조를 임의로 바꾸지 않는다.
+- 기존 `getDashboardIssuesFromSummary` mapper 흐름을 유지한다.
+- 기존 `expandedIssueId` 단일 확장 방식은 유지한다.
+- 기존 workflow execution action이 동작하는 경로와 mutation hook은 변경하지 않는다.
+- 기존 카드 시각 스타일은 최대한 유지한다.
+
+## 4. UI/Interaction 설계
+
+### 4.1 카드 레이아웃
+
+권장 구조:
+
+```text
+IssueCard
+  ├─ HeaderRow
+  │   ├─ MainClickableArea  -> navigate(`/workflows/${workflowId}`)
+  │   └─ RightActionGroup
+  │       ├─ ExecutionActionButton -> run/stop
+  │       └─ RightToggleButton     -> expand/collapse
+  └─ ExpandedErrorDetails
+```
+
+root `IssueCard`는 더 이상 click handler를 갖지 않는다.
+
+시각 스타일은 현재 `DashboardErrorCard` root의 값을 유지한다.
+
+```text
+bg="bg.surface"
+border="1px solid"
+borderColor="border.default"
+borderRadius="10px"
+boxShadow="0 0 4px rgba(239, 61, 61, 0.24)"
+```
+
+### 4.2 가운데 클릭 영역
+
+`MainClickableArea`는 서비스 badge, workflow name, 발생 시각, error message를 포함한다.
+
+권장 구현:
+
+```tsx
+<Flex
+  as="button"
+  type="button"
+  flex={1}
+  minW={0}
+  align="center"
+  gap={3}
+  textAlign="left"
+  disabled={!canOpenWorkflow}
+  cursor={canOpenWorkflow ? "pointer" : "default"}
+  onClick={canOpenWorkflow ? onOpenWorkflow : undefined}
+>
+  ...
+</Flex>
+```
+
+`button`을 사용하면 Enter/Space keyboard activation은 기본 동작으로 처리된다.
+
+주의:
+
+- 이 영역 내부에는 다른 `button`을 넣지 않는다.
+- `RightActionGroup`은 sibling으로 분리한다.
+- disabled 상태에서 `onClick`이 실행되지 않게 한다.
+
+### 4.3 오른쪽 펼치기 버튼 영역
+
+오른쪽 끝 action group은 최소 두 버튼을 가진다.
+
+```text
+RightActionGroup
+  ├─ ExecutionActionButton
+  └─ DetailToggleButton
+```
+
+펼치기 버튼이 오른쪽 끝 요구사항을 만족하도록 action group의 마지막에 둔다.
+
+권장 아이콘:
+
+- 접힘 상태: `MdKeyboardArrowDown` 또는 `MdExpandMore`
+- 펼침 상태: `MdKeyboardArrowUp` 또는 동일 아이콘 rotate
+
+권장 구현:
+
+```tsx
+const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  event.stopPropagation();
+  onToggle();
+};
+
+<IconButton
+  type="button"
+  aria-label={isExpanded ? "에러 상세 접기" : "에러 상세 펼치기"}
+  aria-expanded={isExpanded}
+  aria-controls={detailsId}
+  variant="ghost"
+  size="sm"
+  onClick={handleToggleClick}
+>
+  {isExpanded ? <MdKeyboardArrowUp /> : <MdKeyboardArrowDown />}
+</IconButton>
+```
+
+실행/중지 버튼은 기존 handler를 유지한다.
+
+```tsx
+const handleExecutionActionClick = (event: MouseEvent<HTMLButtonElement>) => {
+  event.stopPropagation();
+  onExecutionAction();
+};
+```
+
+### 4.4 펼쳐진 상세 영역
+
+현재 구조처럼 `isExpanded` 조건부 렌더링을 유지한다.
+
+권장 구조:
+
+```tsx
+{isExpanded ? (
+  <VStack id={detailsId} align="stretch" gap={2} mt={4}>
+    {issue.items.length > 0 ? (
+      issue.items.map(...)
+    ) : (
+      <Text fontSize="sm" color="text.secondary">
+        표시할 상세 에러 내역이 없습니다.
+      </Text>
+    )}
+  </VStack>
+) : null}
+```
+
+현재 mapper가 fallback item을 보장하므로 fallback text는 방어 용도다.
+
+### 4.5 hover/focus 스타일
+
+main clickable area:
+
+- 이동 가능 시 hover에서 text/background를 아주 약하게 강조한다.
+- root card 전체가 이동 가능한 것처럼 보이지 않게 hover는 main area에만 적용한다.
+- `focusVisible` outline을 main area에 제공한다.
+
+right action buttons:
+
+- 기존 `IconButton variant="ghost" size="sm"`를 유지한다.
+- toggle button은 expanded 상태에서 `_expanded` 또는 `bg="bg.overlay"`에 준하는 시각 피드백을 줄 수 있다.
+
+disabled 상태:
+
+- workflowId가 없으면 main area만 disabled 처리한다.
+- toggle button은 workflowId와 무관하게 사용할 수 있다.
+- 실행/중지 버튼은 workflowId가 없으면 disabled 처리를 검토한다.
+
+### 4.6 모바일/좁은 화면
+
+현재 `DashboardErrorCard`는 base에서 column, md 이상에서 row 방향을 쓴다.
+
+새 구조에서는 다음 중 하나를 선택한다.
+
+1. 기존처럼 base에서 column을 유지하고 action group을 오른쪽 아래에 둔다.
+2. base에서도 row를 유지하되 main area `minW={0}`와 action group `flexShrink={0}`를 강하게 둔다.
+
+권장:
+
+- base에서는 header row를 `align="flex-start"`로 두고, action group은 `alignSelf="flex-end"`로 둔다.
+- main area text는 `lineClamp={1}`를 유지한다.
+- action button target은 `size="sm"` 이상을 유지한다.
+- 상세 영역은 full width로 header row 아래에 표시한다.
+
+### 4.7 workflowId 없는 issue 처리
+
+처리 기준:
+
+- `canOpenWorkflow === false`이면 main area는 disabled.
+- `aria-disabled` 또는 `disabled`를 사용한다.
+- `title="연결된 워크플로우 정보가 없습니다."`를 줄 수 있다.
+- toggle button은 계속 활성화한다.
+- 상세 내역은 계속 확인 가능하다.
+
+권장 helper:
+
+```ts
+const getNavigableWorkflowId = (workflowId: unknown) =>
+  typeof workflowId === "string" ? workflowId.trim() : "";
+```
+
+이 helper는 card 내부 private helper로 둘 수 있다.
+
+### 4.8 error items 없는 경우 fallback 처리
+
+기본적으로 `getDashboardIssueItems`가 fallback item을 만든다.
+
+UI 방어는 다음 정도로 제한한다.
+
+```text
+issue.items.length > 0
+  -> item list 렌더링
+issue.items.length === 0
+  -> "표시할 상세 에러 내역이 없습니다."
+```
+
+API나 mapper를 변경해 fallback 정책을 중복 구현하지 않는다.
+
+## 5. 구현 설계
+
+### 5.1 `DashboardIssueCardItem.tsx`
+
+역할:
+
+- routing 책임을 가진 container component로 확장한다.
+- `useNavigate`와 `buildPath.workflowEditor`를 사용한다.
+- `issue.workflowId` runtime guard를 만든다.
+- `DashboardErrorCard`에 `canOpenWorkflow`, `onOpenWorkflow`를 전달한다.
+
+권장 흐름:
+
+```tsx
+const navigate = useNavigate();
+const workflowId = getNavigableWorkflowId(issue.workflowId);
+const canOpenWorkflow = workflowId.length > 0;
+
+const handleOpenWorkflow = () => {
+  if (!canOpenWorkflow) return;
+  navigate(buildPath.workflowEditor(workflowId));
+};
+```
+
+주의:
+
+- `onToggle`은 그대로 상세 전용 callback으로 유지한다.
+- `useWorkflowExecutionAction(issue.workflowId)`는 기존대로 유지하되, workflowId guard를 반영할지 검토한다.
+
+### 5.2 `DashboardErrorCard.tsx`
+
+props 추가 후보:
+
+```ts
+type Props = {
+  issue: DashboardIssue;
+  executionActionKind: "run" | "stop";
+  executionActionLabel: string;
+  isExecutionActionPending: boolean;
+  isExpanded: boolean;
+  canOpenWorkflow: boolean;
+  onOpenWorkflow: () => void;
+  onToggle: () => void;
+  onExecutionAction: () => void;
+};
+```
+
+구조 변경:
+
+- root `Box`에서 `cursor`, `onClick`, `onKeyDown`, `role="button"`, `tabIndex`, `aria-expanded` 제거
+- main area에 click/keyboard 이동 책임 부여
+- 오른쪽 toggle button에 `aria-expanded` 부여
+- 기존 실행/중지 button handler 유지
+
+### 5.3 `useDashboardActions.ts`
+
+변경하지 않는다.
+
+현재 `expandedIssueId` 단일 상태는 요구사항과 충돌하지 않는다.
+
+### 5.4 `dashboard.ts` / `types.ts`
+
+변경하지 않는다.
+
+`workflowId` optional 전환은 API 계약 변경처럼 보일 수 있고, 이번 요구사항은 FE interaction 설계다.
+
+## 6. 이벤트 설계
+
+### 6.1 클릭 이벤트 흐름
+
+```text
+MainClickableArea click
+  -> onOpenWorkflow()
+  -> navigate(buildPath.workflowEditor(workflowId))
+
+RightToggleButton click
+  -> event.stopPropagation()
+  -> onToggle()
+
+ExecutionActionButton click
+  -> event.stopPropagation()
+  -> onExecutionAction()
+```
+
+root container에는 click handler가 없으므로 bubbling에 의존하지 않는다.
+
+### 6.2 키보드 이벤트 흐름
+
+```text
+MainClickableArea Enter/Space
+  -> native button activation
+  -> onOpenWorkflow()
+
+RightToggleButton Enter/Space
+  -> native button activation
+  -> onToggle()
+
+ExecutionActionButton Enter/Space
+  -> native button activation
+  -> onExecutionAction()
+```
+
+custom `onKeyDown`은 최소화한다.
+
+`WorkflowRow`처럼 root `div role="button"`에 keydown을 직접 붙이는 방식은 여기서는 피한다. 하나의 card 안에 main action, run/stop action, toggle action이 공존하기 때문이다.
+
+## 7. 접근성 설계
+
+- main area는 이동 버튼 역할이므로 `aria-label={`${issue.name} 워크플로우 편집 화면 열기`}`를 제공한다.
+- workflowId가 없으면 main area는 disabled 처리한다.
+- toggle button은 `aria-expanded`를 가진다.
+- toggle button은 `aria-controls={detailsId}`를 가진다.
+- details 영역은 `id={detailsId}`를 가진다.
+- expanded details는 의미상 list에 가까우므로 현재 `VStack` 유지 또는 `role="list"`/item `role="listitem"` 적용을 검토한다.
+- 실행/중지 button은 기존 `executionActionLabel`을 그대로 `aria-label`로 사용한다.
+
+## 8. 회귀 위험과 대응
+
+### 8.1 기존 펼치기 UX 변경 위험
+
+위험:
+
+- 기존에는 카드 아무 곳이나 누르면 펼쳐졌지만, 변경 후 오른쪽 버튼만 펼치기가 된다.
+
+대응:
+
+- 요구사항이 명시적으로 가운데 이동, 오른쪽 펼치기 분리를 요구하므로 의도된 변경이다.
+- 오른쪽 button의 affordance를 명확히 한다.
+
+### 8.2 실행/중지 버튼 위치 충돌
+
+위험:
+
+- 현재 오른쪽 끝 실행/중지 버튼이 있으며, 새 펼치기 버튼도 오른쪽 끝을 요구한다.
+
+대응:
+
+- right action group을 만들고 실행/중지 버튼을 왼쪽, 펼치기 버튼을 가장 오른쪽에 배치한다.
+- 기존 실행/중지 버튼 기능은 그대로 유지한다.
+
+### 8.3 workflowId 누락
+
+위험:
+
+- API 타입은 string이지만 실제 응답이 비어 있으면 navigate가 잘못된 URL로 이동할 수 있다.
+
+대응:
+
+- runtime guard로 빈 workflowId 이동을 막는다.
+- toggle detail은 workflowId와 무관하게 동작하게 한다.
+
+### 8.4 모바일 레이아웃
+
+위험:
+
+- main area와 action group이 좁은 화면에서 겹칠 수 있다.
+
+대응:
+
+- main area에 `minW={0}`와 lineClamp 유지
+- action group에 `flexShrink={0}` 적용
+- base breakpoint에서 action group 위치를 명확히 한다.
+
+## 9. 테스트 / 검증 계획
+
+정적 검증:
+
+- `pnpm tsc`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+기존 mapper test 영향:
+
+- `src/pages/dashboard/model/dashboard.test.ts`는 변경하지 않아도 통과해야 한다.
+- workflowId mapper 구조를 바꾸지 않으므로 기존 test 영향은 없어야 한다.
+
+수동 검증:
+
+- 대시보드에서 error issue가 있는 상태로 진입한다.
+- main area 클릭 시 `/workflows/:workflowId`로 이동한다.
+- 오른쪽 펼치기 버튼 클릭 시 이동 없이 상세가 펼쳐진다.
+- 펼친 상태에서 다시 오른쪽 버튼 클릭 시 접힌다.
+- 실행/중지 버튼 클릭 시 이동/펼치기가 발생하지 않는다.
+- Tab 이동 순서가 main area -> 실행/중지 -> 상세 toggle 순서로 자연스러운지 확인한다.
+- 모바일 폭에서 action buttons가 텍스트를 덮지 않는지 확인한다.
+
+## 10. 최종 권장 구현 범위
+
+1차 구현은 다음 두 파일만 수정한다.
+
+```text
+src/pages/dashboard/ui/DashboardIssueCardItem.tsx
+src/pages/dashboard/ui/DashboardErrorCard.tsx
+```
+
+수정하지 않는다.
+
+```text
+src/entities/dashboard/**
+src/entities/workflow/**
+src/entities/execution/**
+src/features/workflow-execution/model/useWorkflowExecutionAction.ts
+src/pages/dashboard/model/dashboard.ts
+src/pages/dashboard/model/types.ts
+Spring / FastAPI / DB / workflow execution API
+```
+
+이 범위가 가장 안전한 이유:
+
+- routing 책임은 item container에만 추가한다.
+- card UI는 기존 props 기반 구조를 유지한다.
+- data source와 mapper는 그대로 둔다.
+- 기존 실행/중지 action은 유지한다.
+- 이벤트 충돌은 root click 제거와 sibling interactive area 분리로 해결한다.

--- a/docs/NODE_MORE_DELETE_MENU_DESIGN.md
+++ b/docs/NODE_MORE_DELETE_MENU_DESIGN.md
@@ -1,0 +1,554 @@
+# Node More Delete Menu Design
+
+> **작성일:** 2026-05-13
+> **대상 화면:** `/workflows/:workflowId` 워크플로우 편집 캔버스
+> **범위:** 노드의 `...` 버튼 클릭 시 삭제 메뉴 노출
+> **대상 저장소:** `flowify-FE`
+> **관련 이슈:** 노드 `...` 삭제 메뉴 예정
+> **최종 검토:** 3회 문서/설계 검토 반영 완료
+
+---
+
+## 0. 3회 검토 요약
+
+### 0.1 1차 검토: 현재 노드 삭제 흐름과 충돌 가능성
+
+확인 파일:
+
+- `src/entities/node/ui/BaseNode.tsx`
+- `src/entities/node/ui/NodeEditorContext.ts`
+- `src/widgets/canvas/ui/Canvas.tsx`
+- `src/entities/workflow/model/useDeleteWorkflowNodeMutation.ts`
+- `src/widgets/editor-remote-bar/ui/WorkflowToolMenuButton.tsx`
+
+결론:
+
+- 현재 노드는 hover 시 우측 상단에 `MdCancel` 아이콘을 보여주고, 클릭 즉시 `onRemoveNode(id)`를 호출한다.
+- 삭제 API와 store 동기화는 이미 `Canvas`에서 처리하고 있으므로, 이번 작업은 노드 UI의 action 진입 방식만 바꾸면 된다.
+- `Menu`를 노드 hover 조건부 렌더링 안에 그대로 넣으면, 포인터가 메뉴 포털로 이동하는 순간 hover가 풀려 trigger가 unmount될 수 있다.
+- 따라서 `isMenuOpen` 상태를 `BaseNode`가 들고, `isHovered || selected || isMenuOpen`일 때 메뉴 버튼을 유지해야 한다.
+- 노드 클릭은 패널 열기와 연결되어 있으므로, `...` trigger와 menu item은 `pointerdown/click/select` 이벤트 전파를 막아야 한다.
+- React Flow 내부 버튼이 노드 drag/pan으로 해석되지 않도록 trigger와 menu content에 `nodrag nopan` 클래스를 붙인다.
+
+### 0.2 2차 검토: 과한 설계 제거
+
+제외한 설계:
+
+- 삭제 확인 모달 추가
+- 전역 메뉴 상태 store 추가
+- 삭제 pending 상태를 `NodeEditorContext` 계약에 새로 추가
+- Spring/FastAPI API 변경
+- 노드별 권한 정책 재설계
+
+이유:
+
+- 요구사항은 "`...` 버튼 클릭 시 삭제 메뉴가 뜨도록" 만드는 것이다.
+- 기존 삭제 흐름은 이미 서버 API, store hydrate, toast error 처리가 구현되어 있다.
+- 확인 모달이나 pending 상태는 UX를 더 무겁게 만들 수 있고, 현재 직접 삭제 버튼을 메뉴 한 단계로 바꾸는 것만으로 실수 삭제 위험이 줄어든다.
+- 권한은 기존 `canEditNodes` 기준을 그대로 사용한다.
+
+### 0.3 3차 검토: 접근성, 터치, 구현 적합성
+
+보완 반영:
+
+- hover가 없는 환경에서도 선택된 노드에는 `...` 버튼을 노출한다.
+- trigger는 `aria-label="노드 메뉴 열기"`와 `title="노드 메뉴"`를 가진다.
+- menu item은 삭제 의도를 명확히 하기 위해 `MdDeleteOutline` 아이콘과 `삭제` 텍스트를 함께 쓴다.
+- 메뉴는 `placement="bottom-end"`로 노드 우측 상단 버튼 아래에 붙인다.
+- 메뉴가 열린 동안에는 hover가 풀려도 trigger가 unmount되지 않는다.
+- `canEditNodes=false`인 공유/읽기 전용 상태에서는 메뉴 자체를 노출하지 않는다.
+
+---
+
+## 1. 목적
+
+현재 워크플로우 캔버스 노드는 hover 시 작은 삭제 아이콘을 바로 노출한다. 사용자는 삭제 버튼을 실수로 누를 수 있고, 노드별 action 진입 방식도 워크플로우 상단 도구 메뉴와 다르다.
+
+이번 작업의 목적은 다음과 같다.
+
+- 노드 우측 상단 action을 직접 삭제 버튼에서 `...` 메뉴 버튼으로 변경한다.
+- `...` 클릭 시 삭제 메뉴를 노출한다.
+- 기존 노드 삭제 API, store 동기화, error toast 흐름은 그대로 유지한다.
+- 캔버스 클릭, 패널 열기, 드래그, React Flow 선택 동작과 충돌하지 않게 한다.
+
+---
+
+## 2. 현재 상태
+
+### 2.1 현재 `BaseNode` 삭제 UI
+
+현재 `BaseNode`는 hover 상태를 내부 state로 관리한다.
+
+```tsx
+const [isHovered, setIsHovered] = useState(false);
+```
+
+hover 중이고 편집 권한이 있으면 우측 상단에 직접 삭제 버튼을 보여준다.
+
+```tsx
+{isHovered && canEditNodes ? (
+  <IconButton
+    aria-label="노드 삭제"
+    size="xs"
+    position="absolute"
+    top={1}
+    right={1}
+    variant="ghost"
+    onClick={handleRemoveNode}
+  >
+    <MdCancel />
+  </IconButton>
+) : null}
+```
+
+삭제 버튼은 클릭 이벤트 전파를 막고 `onRemoveNode(id)`를 호출한다.
+
+```tsx
+const handleRemoveNode = (event: MouseEvent<HTMLButtonElement>) => {
+  event.stopPropagation();
+  onRemoveNode(id);
+};
+```
+
+### 2.2 삭제 실행 흐름
+
+삭제 실행은 `Canvas`가 담당한다.
+
+```text
+BaseNode
+  -> useNodeEditorContext().onRemoveNode(id)
+  -> Canvas.handleRemoveNode(nodeId)
+  -> useDeleteWorkflowNodeMutation()
+  -> workflowApi.deleteNode(workflowId, nodeId)
+  -> hydrateStore(nextWorkflow)
+```
+
+실패 시 `Canvas`에서 toast를 띄운다.
+
+```text
+title: "노드 삭제 실패"
+description: "노드를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요."
+```
+
+따라서 새 메뉴는 삭제 실행 경로를 새로 만들지 않고 `onRemoveNode(id)`만 호출하면 된다.
+
+### 2.3 재사용 가능한 메뉴 레퍼런스
+
+`WorkflowToolMenuButton`은 이미 Chakra `Menu`와 `Portal`을 사용한다.
+
+```text
+Menu.Root
+  -> Menu.Trigger asChild
+  -> Portal
+  -> Menu.Positioner
+  -> Menu.Content
+  -> Menu.Item value="delete"
+```
+
+노드 메뉴도 같은 구조를 따른다. 다만 노드는 부모 컨테이너 클릭이 패널 열기와 연결되어 있으므로 이벤트 전파 방지가 추가로 필요하다.
+
+---
+
+## 3. 설계 결정
+
+### 3.1 UI 결정
+
+기존:
+
+```text
+hover node -> X 아이콘 노출 -> 클릭 즉시 삭제
+```
+
+변경:
+
+```text
+hover 또는 selected node -> ... 버튼 노출 -> 클릭 -> 삭제 메뉴 노출 -> 삭제 선택
+```
+
+노출 조건:
+
+```ts
+const shouldShowNodeMenu = canEditNodes && (isHovered || selected || isMenuOpen);
+```
+
+이 조건을 쓰는 이유:
+
+- hover 중에는 기존처럼 action 진입점이 보인다.
+- selected 상태에서도 버튼이 보여 터치 환경에서 접근할 수 있다.
+- menu open 중에는 포인터가 메뉴로 이동해도 trigger가 사라지지 않는다.
+
+### 3.2 컴포넌트 분리
+
+`BaseNode`에 Chakra `Menu` 마크업을 직접 길게 넣지 않고, 작은 전용 컴포넌트를 추가한다.
+
+권장 파일:
+
+```text
+src/entities/node/ui/NodeMoreMenuButton.tsx
+```
+
+역할:
+
+- `...` trigger 렌더링
+- `삭제` menu item 렌더링
+- 메뉴 open 상태 전달
+- trigger/menu item 이벤트 전파 차단
+
+`BaseNode` 역할:
+
+- hover/open/selected 기반 노출 조건 계산
+- `onRemoveNode(id)` 호출 핸들러 제공
+- 위치 지정
+
+### 3.3 props 계약
+
+```ts
+type NodeMoreMenuButtonProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+};
+```
+
+`canEditNodes`는 `BaseNode`에서 노출 여부로 제어한다. 메뉴 컴포넌트에는 권한 판단을 넣지 않는다.
+
+이유:
+
+- `BaseNode`가 노드 상태와 editor context를 이미 알고 있다.
+- 메뉴 컴포넌트는 표시와 선택 이벤트에 집중한다.
+- 권한 로직 중복을 줄인다.
+
+### 3.4 이벤트 정책
+
+노드 root는 클릭 시 설정 패널을 연다.
+
+```tsx
+<Box onClick={handleOpenPanel}>
+```
+
+따라서 메뉴 trigger는 다음 이벤트를 막아야 한다.
+
+```tsx
+onPointerDown={(event) => event.stopPropagation()}
+onClick={(event) => event.stopPropagation()}
+```
+
+삭제 item 선택도 노드 클릭으로 전파되면 안 된다. Chakra `Menu.Item.onSelect`는 기존 코드에서 단순 handler로 사용하고 있으므로, DOM event 제어는 `Menu.Content` 쪽에서 처리한다.
+
+```tsx
+<Menu.Content
+  onPointerDown={(event) => event.stopPropagation()}
+  onClick={(event) => event.stopPropagation()}
+>
+  <Menu.Item
+    value="delete"
+    onSelect={() => {
+      onOpenChange(false);
+      onDelete();
+    }}
+  >
+    삭제
+  </Menu.Item>
+</Menu.Content>
+```
+
+`Menu.Item`에 직접 DOM event가 필요한 구현으로 바꾸게 된다면, 다음처럼 item의 click 이벤트에서 전파를 막는다.
+
+```tsx
+onClick={(event) => {
+  event.stopPropagation();
+}}
+```
+
+React Flow 노드 내부의 interactive element는 drag/pan gesture와 충돌할 수 있으므로 trigger와 menu content에는 다음 class를 함께 둔다.
+
+```tsx
+className="nodrag nopan"
+```
+
+### 3.5 삭제 확인 정책
+
+V1에서는 삭제 확인 모달을 추가하지 않는다.
+
+이유:
+
+- 기존 동작은 클릭 즉시 삭제였다.
+- 이번 변경은 `...` 열기 후 `삭제` 선택이라는 한 단계 의도 확인을 이미 추가한다.
+- 모달을 추가하면 `Canvas`의 node delete pending, active panel, focus restore까지 설계 범위가 커진다.
+
+추후 요구가 있으면 `NodeDeleteConfirmDialog`를 별도 작업으로 분리한다.
+
+---
+
+## 4. 구현 설계
+
+### 4.0 서버 영향도
+
+이번 작업은 FE UI 변경만 포함한다.
+
+변경 없음:
+
+- `flowify-BE-spring`
+- `flowify-BE`
+- MongoDB schema
+- delete node API contract
+- workflow response contract
+
+이유:
+
+- 노드 삭제 API는 이미 `workflowApi.deleteNode(workflowId, nodeId)`로 연결되어 있다.
+- `Canvas.handleRemoveNode()`가 서버 응답을 받아 `hydrateStore(nextWorkflow)`로 editor store를 갱신한다.
+- 요구사항은 삭제 실행 방식이 아니라 삭제 action 진입 UI를 `...` 메뉴로 바꾸는 것이다.
+
+### 4.1 `NodeMoreMenuButton` 추가
+
+예상 구조:
+
+```tsx
+import { MdDeleteOutline, MdMoreHoriz } from "react-icons/md";
+
+import { Button, Icon, Menu, Portal, Text } from "@chakra-ui/react";
+
+type NodeMoreMenuButtonProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+};
+
+export const NodeMoreMenuButton = ({
+  open,
+  onOpenChange,
+  onDelete,
+}: NodeMoreMenuButtonProps) => (
+  <Menu.Root
+    lazyMount
+    unmountOnExit
+    open={open}
+    onOpenChange={(details) => onOpenChange(details.open)}
+    positioning={{ placement: "bottom-end" }}
+  >
+    <Menu.Trigger asChild>
+      <Button
+        type="button"
+        aria-label="노드 메뉴 열기"
+        title="노드 메뉴"
+        className="nodrag nopan"
+        height="26px"
+        minW="26px"
+        px={0}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Icon as={MdMoreHoriz} boxSize={4} />
+      </Button>
+    </Menu.Trigger>
+
+    <Portal>
+      <Menu.Positioner zIndex={30}>
+        <Menu.Content
+          className="nodrag nopan"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Menu.Item
+            value="delete"
+            onSelect={() => {
+              onOpenChange(false);
+              onDelete();
+            }}
+            color="status.error"
+          >
+            <Icon as={MdDeleteOutline} boxSize={4} />
+            <Text as="span" fontSize="sm">삭제</Text>
+          </Menu.Item>
+        </Menu.Content>
+      </Menu.Positioner>
+    </Portal>
+  </Menu.Root>
+);
+```
+
+스타일은 `WorkflowToolMenuButton`과 최대한 맞춘다.
+
+- `bg="bg.surface"`
+- `borderColor="border.default"`
+- `boxShadow="lg"`
+- trigger hover: `bg="bg.overlay"`
+- delete item color: `status.error`
+
+### 4.2 `BaseNode` 변경
+
+기존 `MdCancel` import와 `handleRemoveNode(event)`를 제거한다.
+
+변경 후:
+
+```tsx
+const [isHovered, setIsHovered] = useState(false);
+const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+const shouldShowNodeMenu =
+  canEditNodes && (isHovered || selected || isMenuOpen);
+
+const handleRemoveNode = () => {
+  setIsMenuOpen(false);
+  onRemoveNode(id);
+};
+```
+
+렌더링:
+
+```tsx
+{shouldShowNodeMenu ? (
+  <Box position="absolute" top={1} right={1}>
+    <NodeMoreMenuButton
+      open={isMenuOpen}
+      onOpenChange={setIsMenuOpen}
+      onDelete={handleRemoveNode}
+    />
+  </Box>
+) : null}
+```
+
+`BaseNodeProps.selected`는 현재 선언되어 있지만 사용하지 않는다. 이번 작업에서 selected를 의미 있게 사용한다.
+
+### 4.3 export 정리
+
+현재 `src/entities/node/ui/index.ts`가 있다면 `NodeMoreMenuButton`을 export한다. 없다면 `BaseNode`에서 상대 경로로 직접 import해도 된다.
+
+권장:
+
+```ts
+export * from "./NodeMoreMenuButton";
+```
+
+단, 외부 계층에서 사용할 계획이 없으면 export는 필수는 아니다. V1에서는 `BaseNode` 내부 전용 컴포넌트로 시작해도 충분하다.
+
+---
+
+## 5. 구현 순서
+
+1. `src/entities/node/ui/NodeMoreMenuButton.tsx` 추가
+2. `BaseNode.tsx`에서 `MdCancel`, `IconButton`, `MouseEvent` 기반 직접 삭제 버튼 제거
+3. `BaseNode.tsx`에 `isMenuOpen`, `shouldShowNodeMenu`, `handleRemoveNode` 추가
+4. hover, selected, menu open 상태에서 메뉴 버튼 유지 확인
+5. `canEditNodes=false`일 때 메뉴가 보이지 않는지 확인
+6. 삭제 메뉴 선택 시 기존 `onRemoveNode(id)`가 호출되는지 확인
+7. `pnpm tsc`, `pnpm test`, 필요 시 `pnpm build` 실행
+
+---
+
+## 6. 테스트 계획
+
+### 6.1 단위 테스트
+
+기존 테스트 인프라상 `BaseNode` 렌더 테스트가 없다면 필수 추가 범위는 아니다. 다만 추가한다면 다음을 검증한다.
+
+- `canEditNodes=false`이면 `노드 메뉴 열기` 버튼이 보이지 않는다.
+- hover 또는 selected이면 `노드 메뉴 열기` 버튼이 보인다.
+- `...` 클릭 시 `삭제` menu item이 보인다.
+- `삭제` 선택 시 `onRemoveNode(id)`가 1회 호출된다.
+- trigger 클릭이 `onOpenPanel(id)`를 호출하지 않는다.
+
+### 6.2 수동 검증
+
+검증 시나리오:
+
+- 노드 hover 시 우측 상단에 `...` 버튼이 노출된다.
+- `...` 클릭 시 삭제 메뉴가 노드 우측 상단 아래에 열린다.
+- 메뉴가 열린 상태에서 포인터가 노드 밖으로 이동해도 메뉴가 닫히거나 trigger가 사라지지 않는다.
+- 삭제 선택 시 노드가 삭제되고 캔버스가 서버 응답 기준으로 갱신된다.
+- 삭제 실패 시 기존 toast가 뜬다.
+- 노드 본문 클릭은 기존처럼 패널을 연다.
+- `...` 클릭은 패널을 열지 않는다.
+- 읽기 전용 워크플로우에서는 `...` 버튼이 보이지 않는다.
+- start/end/middle node 모두 기존 삭제 정책과 동일하게 동작한다.
+
+### 6.3 회귀 검증 명령
+
+```bash
+pnpm tsc
+pnpm test
+pnpm build
+```
+
+---
+
+## 7. 위험 요소와 대응
+
+### 7.1 메뉴 open 중 trigger unmount
+
+위험:
+
+- hover 조건으로만 버튼을 렌더링하면 메뉴 포털로 포인터가 이동할 때 버튼이 사라질 수 있다.
+
+대응:
+
+- `isMenuOpen`을 `BaseNode`가 관리한다.
+- `shouldShowNodeMenu = canEditNodes && (isHovered || selected || isMenuOpen)`로 렌더링한다.
+
+### 7.2 노드 클릭과 메뉴 클릭 충돌
+
+위험:
+
+- `...` 클릭이 노드 root click으로 전파되어 설정 패널이 열릴 수 있다.
+
+대응:
+
+- trigger의 `onPointerDown`, `onClick`에서 `stopPropagation()` 처리한다.
+- menu content의 `onPointerDown`, `onClick`에서 `stopPropagation()` 처리한다.
+- delete item의 `onSelect`는 메뉴 닫기와 삭제 실행만 담당한다.
+
+### 7.3 캔버스 드래그/패닝 충돌
+
+위험:
+
+- React Flow가 pointer event를 받아 노드 drag나 canvas interaction을 시작할 수 있다.
+
+대응:
+
+- trigger에서 pointer event 전파를 막는다.
+- trigger와 menu content에 `className="nodrag nopan"`을 지정한다.
+- menu content는 `Portal`로 띄우고 충분한 `zIndex`를 준다.
+
+### 7.4 삭제 pending 중 중복 선택
+
+위험:
+
+- 현재 `NodeEditorContext`는 delete pending 상태를 제공하지 않는다.
+- 사용자가 빠르게 여러 번 삭제를 선택할 수 있다.
+
+대응:
+
+- V1에서는 기존 직접 삭제 버튼과 동일한 정책을 유지한다.
+- 중복 삭제 문제가 실제로 확인되면 `NodeEditorContext`에 `isDeleteNodePending` 또는 node별 pending state를 추가하는 후속 작업으로 분리한다.
+
+### 7.5 확인 모달 부재
+
+위험:
+
+- 메뉴에서 삭제를 선택하면 바로 삭제된다.
+
+대응:
+
+- 기존은 버튼 클릭 즉시 삭제였고, 이번 변경은 메뉴 선택 단계를 추가한다.
+- 삭제 확인 모달은 요구사항 범위를 넘기 때문에 V1에서 제외한다.
+
+---
+
+## 8. 완료 기준
+
+- 노드 hover 또는 selected 상태에서 `...` 버튼이 노출된다.
+- `...` 버튼 클릭 시 삭제 메뉴가 노출된다.
+- 삭제 메뉴의 `삭제` 선택 시 기존 노드 삭제 API 흐름이 실행된다.
+- `...` 클릭과 삭제 메뉴 클릭이 노드 패널 열기 이벤트를 발생시키지 않는다.
+- 메뉴 open 중 hover가 풀려도 메뉴가 안정적으로 유지된다.
+- 읽기 전용 상태에서는 메뉴가 보이지 않는다.
+- FE 타입 체크와 기존 테스트가 통과한다.
+
+---
+
+## 9. 최종 요약
+
+이번 기능은 서버 계약이나 워크플로우 삭제 도메인을 바꾸는 작업이 아니라, 노드 action UI를 직접 삭제 버튼에서 `...` 메뉴로 바꾸는 얇은 FE 변경이다.
+
+가장 중요한 설계 포인트는 `Menu`가 열린 동안 trigger가 사라지지 않게 `isMenuOpen`을 렌더 조건에 포함하는 것과, `...` 버튼 클릭이 노드 패널 열기/드래그로 전파되지 않게 이벤트를 차단하는 것이다. 삭제 실행은 기존 `Canvas.handleRemoveNode`와 `useDeleteWorkflowNodeMutation` 흐름을 그대로 재사용한다.

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -23,6 +23,56 @@ type Props = {
   onToggle: () => void;
 };
 
+const LATIN_TEXT_PATTERN = /[A-Za-z]/;
+const UNKNOWN_ERROR_DETAIL_MESSAGE = "오류 상세를 확인해 주세요.";
+
+const getLocalizedDashboardIssueMessage = (message: string) => {
+  const trimmedMessage = message.trim();
+
+  if (trimmedMessage.length === 0) {
+    return UNKNOWN_ERROR_DETAIL_MESSAGE;
+  }
+
+  const messageCode = trimmedMessage.toUpperCase();
+  const normalizedMessage = trimmedMessage.toLowerCase();
+
+  if (messageCode === "EXECUTION_FAILED") {
+    return "워크플로우 실행 중 오류가 발생했습니다.";
+  }
+
+  if (messageCode === "WORKFLOW_NOT_EXECUTABLE") {
+    return "워크플로우 실행에 필요한 설정을 확인해 주세요.";
+  }
+
+  if (normalizedMessage.includes("gmail auth failed")) {
+    return "Gmail 인증에 실패했습니다.";
+  }
+
+  if (normalizedMessage.includes("gmail node execution failed")) {
+    return "Gmail 노드 실행 중 오류가 발생했습니다.";
+  }
+
+  if (
+    normalizedMessage.includes("auth") ||
+    normalizedMessage.includes("unauthorized")
+  ) {
+    return "서비스 인증에 실패했습니다. 연결 상태를 다시 확인해 주세요.";
+  }
+
+  if (
+    normalizedMessage.includes("execution failed") ||
+    normalizedMessage.includes("failed")
+  ) {
+    return "워크플로우 실행 중 오류가 발생했습니다.";
+  }
+
+  if (LATIN_TEXT_PATTERN.test(trimmedMessage)) {
+    return UNKNOWN_ERROR_DETAIL_MESSAGE;
+  }
+
+  return trimmedMessage;
+};
+
 export const DashboardErrorCard = ({
   issue,
   isExpanded,
@@ -126,22 +176,37 @@ export const DashboardErrorCard = ({
       {isExpanded ? (
         <VStack id={detailsId} align="stretch" gap={2} mt={4}>
           {hasIssueItems ? (
-            issue.items.map((item) => (
-              <HStack
-                key={item.id}
-                align="center"
-                gap={4}
-                p={3}
-                border="1px solid"
-                borderColor="border.default"
-                borderRadius="4px"
-              >
-                <ServiceBadge type={item.badgeKey} />
-                <Text fontSize="sm" color="text.primary" lineHeight="1.4">
-                  {item.message}
-                </Text>
-              </HStack>
-            ))
+            issue.items.map((item) => {
+              const localizedMessage = getLocalizedDashboardIssueMessage(
+                item.message,
+              );
+
+              return (
+                <HStack
+                  key={item.id}
+                  align="center"
+                  gap={4}
+                  p={3}
+                  border="1px solid"
+                  borderColor="border.default"
+                  borderRadius="4px"
+                >
+                  <ServiceBadge type={item.badgeKey} />
+                  <Text
+                    fontSize="sm"
+                    color="text.primary"
+                    lineHeight="1.4"
+                    title={
+                      localizedMessage === item.message
+                        ? undefined
+                        : item.message
+                    }
+                  >
+                    {localizedMessage}
+                  </Text>
+                </HStack>
+              );
+            })
           ) : (
             <Text fontSize="sm" color="text.secondary">
               표시할 상세 에러 내역이 없습니다.

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -3,6 +3,7 @@ import { MdKeyboardArrowDown, MdKeyboardArrowUp } from "react-icons/md";
 
 import { Box, Flex, HStack, IconButton, Text, VStack } from "@chakra-ui/react";
 
+import { getNodeStatusMissingFieldLabel } from "@/entities/workflow";
 import { ServiceBadge, type ServiceBadgeKey } from "@/shared";
 
 import { type DashboardIssue } from "../model";
@@ -56,6 +57,26 @@ const DASHBOARD_ISSUE_SERVICE_PATTERNS: Array<[RegExp, string]> = [
   [/\bseboard\b|\bse[-_\s]?board\b/, "SE Board"],
 ];
 
+const DASHBOARD_ISSUE_REQUIRED_FIELD_PATTERNS: Array<[RegExp, string]> = [
+  [
+    /\bconfig[._-]?recipient\b|\brecipients?\b|\brecipient_list\b|\bto\b/,
+    "recipient",
+  ],
+  [/\bconfig[._-]?subject\b|\bsubjects?\b|\btitle\b/, "subject"],
+  [
+    /\bconfig[._-]?action\b|\bchoice_action_id\b|\bwrite_mode\b|\baction\b/,
+    "action",
+  ],
+  [/\bconfig[._-]?message\b|\bmessage_template\b|\bbody\b/, "messageTemplate"],
+  [/\bconfig[._-]?channel\b|\bchannel\b/, "channel"],
+  [/\bconfig[._-]?target\b|\btarget\b|\btarget_id\b/, "target"],
+  [/\bconfig[._-]?prompt\b|\bprompt\b/, "prompt"],
+  [/\bspreadsheet_id\b|\bspreadsheetid\b/, "spreadsheet_id"],
+  [/\bsheet_name\b|\bsheetname\b/, "sheet_name"],
+  [/\bcalendar_id\b|\bcalendarid\b/, "calendar_id"],
+  [/\bwebhook_url\b|\bwebhook\b/, "webhook_url"],
+];
+
 const includesAny = (value: string, keywords: string[]) =>
   keywords.some((keyword) => value.includes(keyword));
 
@@ -68,6 +89,14 @@ const getDashboardIssueServiceLabel = (
   );
 
   return matchedService?.[1] ?? DASHBOARD_ISSUE_SERVICE_LABELS[badgeKey];
+};
+
+const getDashboardIssueRequiredFieldLabels = (normalizedMessage: string) => {
+  const labels = DASHBOARD_ISSUE_REQUIRED_FIELD_PATTERNS.filter(([pattern]) =>
+    pattern.test(normalizedMessage),
+  ).map(([, field]) => getNodeStatusMissingFieldLabel(field));
+
+  return Array.from(new Set(labels));
 };
 
 const getLocalizedDashboardIssueMessage = (
@@ -122,6 +151,13 @@ const getLocalizedDashboardIssueMessage = (
       "bad request",
     ])
   ) {
+    const requiredFieldLabels =
+      getDashboardIssueRequiredFieldLabels(normalizedMessage);
+
+    if (requiredFieldLabels.length > 0) {
+      return `${serviceLabel} 필수 설정이 필요합니다. 확인할 항목: ${requiredFieldLabels.join(", ")}`;
+    }
+
     return `${serviceLabel} 노드 설정값을 확인해 주세요.`;
   }
 

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -249,7 +249,6 @@ export const DashboardErrorCard = ({
       title={canOpenWorkflow ? undefined : "연결된 워크플로우 정보가 없습니다."}
       onClick={handleCardClick}
       onKeyDown={handleCardKeyDown}
-      _hover={canOpenWorkflow ? { bg: "bg.muted" } : undefined}
       _focusVisible={{
         outline: "2px solid",
         outlineColor: "neutral.950",

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -44,6 +44,7 @@ export const DashboardErrorCard = ({
   onExecutionAction,
 }: Props) => {
   const detailsId = useId();
+  const hasIssueItems = issue.items.length > 0;
 
   const handleExecutionActionClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -86,7 +87,11 @@ export const DashboardErrorCard = ({
           textAlign="left"
           cursor={canOpenWorkflow ? "pointer" : "default"}
           disabled={!canOpenWorkflow}
+          aria-disabled={!canOpenWorkflow}
           aria-label={`${issue.name} 워크플로우 편집 화면 열기`}
+          title={
+            canOpenWorkflow ? undefined : "연결된 워크플로우 정보가 없습니다."
+          }
           onClick={onOpenWorkflow}
           _hover={canOpenWorkflow ? { bg: "bg.muted" } : undefined}
           _focusVisible={{
@@ -126,6 +131,7 @@ export const DashboardErrorCard = ({
 
         <HStack
           gap={1}
+          flexWrap="nowrap"
           flexShrink={0}
           alignSelf={{ base: "flex-end", md: "center" }}
         >
@@ -161,22 +167,28 @@ export const DashboardErrorCard = ({
 
       {isExpanded ? (
         <VStack id={detailsId} align="stretch" gap={2} mt={4}>
-          {issue.items.map((item) => (
-            <HStack
-              key={item.id}
-              align="center"
-              gap={4}
-              p={3}
-              border="1px solid"
-              borderColor="border.default"
-              borderRadius="4px"
-            >
-              <ServiceBadge type={item.badgeKey} />
-              <Text fontSize="sm" color="text.primary" lineHeight="1.4">
-                {item.message}
-              </Text>
-            </HStack>
-          ))}
+          {hasIssueItems ? (
+            issue.items.map((item) => (
+              <HStack
+                key={item.id}
+                align="center"
+                gap={4}
+                p={3}
+                border="1px solid"
+                borderColor="border.default"
+                borderRadius="4px"
+              >
+                <ServiceBadge type={item.badgeKey} />
+                <Text fontSize="sm" color="text.primary" lineHeight="1.4">
+                  {item.message}
+                </Text>
+              </HStack>
+            ))
+          ) : (
+            <Text fontSize="sm" color="text.secondary">
+              표시할 상세 에러 내역이 없습니다.
+            </Text>
+          )}
         </VStack>
       ) : null}
     </Box>

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -47,12 +47,7 @@ export const DashboardErrorCard = ({
       boxShadow="0 0 4px rgba(239, 61, 61, 0.24)"
       p={4}
     >
-      <Flex
-        align={{ base: "stretch", md: "center" }}
-        justify="space-between"
-        direction={{ base: "column", md: "row" }}
-        gap={3}
-      >
+      <Flex align="center" justify="space-between" gap={3}>
         <Button
           type="button"
           variant="ghost"
@@ -64,6 +59,7 @@ export const DashboardErrorCard = ({
           w="full"
           h="auto"
           p={0}
+          overflow="hidden"
           bg="transparent"
           borderRadius="8px"
           color="inherit"
@@ -95,7 +91,7 @@ export const DashboardErrorCard = ({
             <ServiceBadge type={issue.endBadgeKey} />
           </HStack>
 
-          <Box minW={0}>
+          <Box minW={0} flex={1}>
             <Text
               fontSize="sm"
               fontWeight="medium"
@@ -112,12 +108,7 @@ export const DashboardErrorCard = ({
           </Box>
         </Button>
 
-        <HStack
-          gap={1}
-          flexWrap="nowrap"
-          flexShrink={0}
-          alignSelf={{ base: "flex-end", md: "center" }}
-        >
+        <HStack gap={1} flexWrap="nowrap" flexShrink={0} alignSelf="center">
           <IconButton
             aria-label={isExpanded ? "에러 상세 접기" : "에러 상세 펼치기"}
             aria-expanded={isExpanded}

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -1,10 +1,5 @@
 import { type MouseEvent, useId } from "react";
-import {
-  MdKeyboardArrowDown,
-  MdKeyboardArrowUp,
-  MdPlayArrow,
-  MdStop,
-} from "react-icons/md";
+import { MdKeyboardArrowDown, MdKeyboardArrowUp } from "react-icons/md";
 
 import {
   Box,
@@ -12,7 +7,6 @@ import {
   Flex,
   HStack,
   IconButton,
-  Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -23,34 +17,21 @@ import { type DashboardIssue } from "../model";
 
 type Props = {
   issue: DashboardIssue;
-  executionActionKind: "run" | "stop";
-  executionActionLabel: string;
-  isExecutionActionPending: boolean;
   isExpanded: boolean;
   canOpenWorkflow: boolean;
   onOpenWorkflow: () => void;
   onToggle: () => void;
-  onExecutionAction: () => void;
 };
 
 export const DashboardErrorCard = ({
   issue,
-  executionActionKind,
-  executionActionLabel,
-  isExecutionActionPending,
   isExpanded,
   canOpenWorkflow,
   onOpenWorkflow,
   onToggle,
-  onExecutionAction,
 }: Props) => {
   const detailsId = useId();
   const hasIssueItems = issue.items.length > 0;
-
-  const handleExecutionActionClick = (event: MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    onExecutionAction();
-  };
 
   const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -137,22 +118,6 @@ export const DashboardErrorCard = ({
           flexShrink={0}
           alignSelf={{ base: "flex-end", md: "center" }}
         >
-          <IconButton
-            aria-label={executionActionLabel}
-            variant="ghost"
-            size="sm"
-            flexShrink={0}
-            disabled={isExecutionActionPending}
-            onClick={handleExecutionActionClick}
-          >
-            {isExecutionActionPending ? (
-              <Spinner size="xs" />
-            ) : executionActionKind === "stop" ? (
-              <MdStop />
-            ) : (
-              <MdPlayArrow />
-            )}
-          </IconButton>
           <IconButton
             aria-label={isExpanded ? "에러 상세 접기" : "에러 상세 펼치기"}
             aria-expanded={isExpanded}

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -1,15 +1,7 @@
-import { type MouseEvent, useId } from "react";
+import { type KeyboardEvent, type MouseEvent, useId } from "react";
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from "react-icons/md";
 
-import {
-  Box,
-  Button,
-  Flex,
-  HStack,
-  IconButton,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, IconButton, Text, VStack } from "@chakra-ui/react";
 
 import { ServiceBadge, type ServiceBadgeKey } from "@/shared";
 
@@ -217,6 +209,25 @@ export const DashboardErrorCard = ({
     issue.startBadgeKey,
   );
 
+  const handleCardClick = () => {
+    if (!canOpenWorkflow) {
+      return;
+    }
+
+    onOpenWorkflow();
+  };
+
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!canOpenWorkflow || event.target !== event.currentTarget) {
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpenWorkflow();
+    }
+  };
+
   const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onToggle();
@@ -229,43 +240,31 @@ export const DashboardErrorCard = ({
       borderColor="border.default"
       borderRadius="10px"
       boxShadow="0 0 4px rgba(239, 61, 61, 0.24)"
+      cursor={canOpenWorkflow ? "pointer" : "default"}
       p={4}
+      role={canOpenWorkflow ? "button" : undefined}
+      tabIndex={canOpenWorkflow ? 0 : undefined}
+      aria-disabled={!canOpenWorkflow}
+      aria-label={`${issue.name} 워크플로우 편집 화면 열기`}
+      title={canOpenWorkflow ? undefined : "연결된 워크플로우 정보가 없습니다."}
+      onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
+      _hover={canOpenWorkflow ? { bg: "bg.muted" } : undefined}
+      _focusVisible={{
+        outline: "2px solid",
+        outlineColor: "neutral.950",
+        outlineOffset: "2px",
+      }}
     >
       <Flex align="center" justify="space-between" gap={3}>
-        <Button
-          type="button"
-          variant="ghost"
+        <Flex
           alignItems="center"
           justifyContent="flex-start"
           gap={3}
           minW={0}
           flex={1}
           w="full"
-          h="auto"
-          p={0}
           overflow="hidden"
-          bg="transparent"
-          borderRadius="8px"
-          color="inherit"
-          textAlign="left"
-          cursor={canOpenWorkflow ? "pointer" : "default"}
-          disabled={!canOpenWorkflow}
-          aria-disabled={!canOpenWorkflow}
-          aria-label={`${issue.name} 워크플로우 편집 화면 열기`}
-          title={
-            canOpenWorkflow ? undefined : "연결된 워크플로우 정보가 없습니다."
-          }
-          onClick={onOpenWorkflow}
-          _hover={canOpenWorkflow ? { bg: "bg.muted" } : undefined}
-          _focusVisible={{
-            outline: "2px solid",
-            outlineColor: "neutral.950",
-            outlineOffset: "2px",
-          }}
-          _disabled={{
-            cursor: "default",
-            opacity: 1,
-          }}
         >
           <HStack gap={1.5} flexShrink={0}>
             <ServiceBadge type={issue.startBadgeKey} />
@@ -299,7 +298,7 @@ export const DashboardErrorCard = ({
               </Text>
             </HStack>
           </Box>
-        </Button>
+        </Flex>
 
         <HStack gap={1} flexWrap="nowrap" flexShrink={0} alignSelf="center">
           <IconButton

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -8,6 +8,7 @@ import {
 
 import {
   Box,
+  Button,
   Flex,
   HStack,
   IconButton,
@@ -71,17 +72,18 @@ export const DashboardErrorCard = ({
         direction={{ base: "column", md: "row" }}
         gap={3}
       >
-        <Flex
-          as="button"
+        <Button
           type="button"
-          align="center"
+          variant="ghost"
+          alignItems="center"
+          justifyContent="flex-start"
           gap={3}
           minW={0}
           flex={1}
           w="full"
+          h="auto"
           p={0}
           bg="transparent"
-          border={0}
           borderRadius="8px"
           color="inherit"
           textAlign="left"
@@ -127,7 +129,7 @@ export const DashboardErrorCard = ({
               <Text fontSize="xs">{issue.buildProgressLabel}</Text>
             </HStack>
           </Box>
-        </Flex>
+        </Button>
 
         <HStack
           gap={1}

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -12,6 +12,8 @@ type Props = {
   issue: DashboardIssue;
   isExpanded: boolean;
   canOpenWorkflow: boolean;
+  workflowMissingFieldLabels: string[];
+  missingFieldLabelsByBadgeKey: Partial<Record<ServiceBadgeKey, string[]>>;
   onOpenWorkflow: () => void;
   onToggle: () => void;
 };
@@ -99,9 +101,14 @@ const getDashboardIssueRequiredFieldLabels = (normalizedMessage: string) => {
   return Array.from(new Set(labels));
 };
 
+const mergeFieldLabels = (
+  ...labelGroups: Array<readonly string[] | undefined>
+) => Array.from(new Set(labelGroups.flatMap((labels) => labels ?? [])));
+
 const getLocalizedDashboardIssueMessage = (
   message: string,
   badgeKey: ServiceBadgeKey,
+  missingFieldLabels?: readonly string[],
 ) => {
   const trimmedMessage = message.trim();
 
@@ -151,8 +158,10 @@ const getLocalizedDashboardIssueMessage = (
       "bad request",
     ])
   ) {
-    const requiredFieldLabels =
-      getDashboardIssueRequiredFieldLabels(normalizedMessage);
+    const requiredFieldLabels = mergeFieldLabels(
+      missingFieldLabels,
+      getDashboardIssueRequiredFieldLabels(normalizedMessage),
+    );
 
     if (requiredFieldLabels.length > 0) {
       return `${serviceLabel} 필수 설정이 필요합니다. 확인할 항목: ${requiredFieldLabels.join(", ")}`;
@@ -235,6 +244,8 @@ export const DashboardErrorCard = ({
   issue,
   isExpanded,
   canOpenWorkflow,
+  workflowMissingFieldLabels,
+  missingFieldLabelsByBadgeKey,
   onOpenWorkflow,
   onToggle,
 }: Props) => {
@@ -243,6 +254,7 @@ export const DashboardErrorCard = ({
   const localizedBuildProgressLabel = getLocalizedDashboardIssueMessage(
     issue.buildProgressLabel,
     issue.startBadgeKey,
+    workflowMissingFieldLabels,
   );
 
   const handleCardClick = () => {
@@ -357,6 +369,7 @@ export const DashboardErrorCard = ({
               const localizedMessage = getLocalizedDashboardIssueMessage(
                 item.message,
                 item.badgeKey,
+                missingFieldLabelsByBadgeKey[item.badgeKey],
               );
 
               return (

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -11,7 +11,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
-import { ServiceBadge } from "@/shared";
+import { ServiceBadge, type ServiceBadgeKey } from "@/shared";
 
 import { type DashboardIssue } from "../model";
 
@@ -24,17 +24,76 @@ type Props = {
 };
 
 const LATIN_TEXT_PATTERN = /[A-Za-z]/;
-const UNKNOWN_ERROR_DETAIL_MESSAGE = "오류 상세를 확인해 주세요.";
+const KOREAN_TEXT_PATTERN = /[가-힣]/;
+const EMPTY_ERROR_DETAIL_MESSAGE = "에러 메시지가 비어 있습니다.";
 
-const getLocalizedDashboardIssueMessage = (message: string) => {
+const DASHBOARD_ISSUE_SERVICE_LABELS: Record<ServiceBadgeKey, string> = {
+  calendar: "Google Calendar",
+  "canvas-lms": "Canvas LMS",
+  discord: "Discord",
+  gmail: "Gmail",
+  "google-drive": "Google Drive",
+  "google-sheets": "Google Sheets",
+  github: "GitHub",
+  "naver-news": "Naver News",
+  notion: "Notion",
+  seboard: "SE Board",
+  slack: "Slack",
+  communication: "커뮤니케이션 서비스",
+  storage: "저장소 서비스",
+  spreadsheet: "스프레드시트 서비스",
+  "web-scraping": "웹 수집 서비스",
+  notification: "알림 서비스",
+  llm: "AI 서비스",
+  trigger: "트리거",
+  processing: "처리 노드",
+  unknown: "워크플로우",
+};
+
+const DASHBOARD_ISSUE_SERVICE_PATTERNS: Array<[RegExp, string]> = [
+  [/\bgmail\b/, "Gmail"],
+  [/\bslack\b/, "Slack"],
+  [/\bnotion\b/, "Notion"],
+  [/\bgithub\b/, "GitHub"],
+  [/\bdiscord\b/, "Discord"],
+  [/\bcanvas(?:[-_\s]?lms)?\b/, "Canvas LMS"],
+  [/\bgoogle[-_\s]?drive\b/, "Google Drive"],
+  [/\bgoogle[-_\s]?sheets?\b/, "Google Sheets"],
+  [/\bgoogle[-_\s]?calendar\b|\bcalendar\b/, "Google Calendar"],
+  [/\bnaver(?:[-_\s]?news)?\b/, "Naver News"],
+  [/\bseboard\b|\bse[-_\s]?board\b/, "SE Board"],
+];
+
+const includesAny = (value: string, keywords: string[]) =>
+  keywords.some((keyword) => value.includes(keyword));
+
+const getDashboardIssueServiceLabel = (
+  normalizedMessage: string,
+  badgeKey: ServiceBadgeKey,
+) => {
+  const matchedService = DASHBOARD_ISSUE_SERVICE_PATTERNS.find(([pattern]) =>
+    pattern.test(normalizedMessage),
+  );
+
+  return matchedService?.[1] ?? DASHBOARD_ISSUE_SERVICE_LABELS[badgeKey];
+};
+
+const getLocalizedDashboardIssueMessage = (
+  message: string,
+  badgeKey: ServiceBadgeKey,
+) => {
   const trimmedMessage = message.trim();
 
   if (trimmedMessage.length === 0) {
-    return UNKNOWN_ERROR_DETAIL_MESSAGE;
+    return EMPTY_ERROR_DETAIL_MESSAGE;
   }
 
   const messageCode = trimmedMessage.toUpperCase();
   const normalizedMessage = trimmedMessage.toLowerCase();
+  const serviceLabel = getDashboardIssueServiceLabel(
+    normalizedMessage,
+    badgeKey,
+  );
 
   if (messageCode === "EXECUTION_FAILED") {
     return "워크플로우 실행 중 오류가 발생했습니다.";
@@ -44,30 +103,101 @@ const getLocalizedDashboardIssueMessage = (message: string) => {
     return "워크플로우 실행에 필요한 설정을 확인해 주세요.";
   }
 
-  if (normalizedMessage.includes("gmail auth failed")) {
-    return "Gmail 인증에 실패했습니다.";
-  }
-
-  if (normalizedMessage.includes("gmail node execution failed")) {
-    return "Gmail 노드 실행 중 오류가 발생했습니다.";
+  if (
+    includesAny(normalizedMessage, [
+      "auth",
+      "oauth",
+      "token",
+      "credential",
+      "unauthorized",
+      "forbidden",
+      "permission",
+      "access denied",
+    ])
+  ) {
+    return `${serviceLabel} 인증 또는 권한 확인이 필요합니다.`;
   }
 
   if (
-    normalizedMessage.includes("auth") ||
-    normalizedMessage.includes("unauthorized")
+    includesAny(normalizedMessage, [
+      "not executable",
+      "config",
+      "configuration",
+      "validation",
+      "invalid",
+      "missing",
+      "required",
+      "bad request",
+    ])
   ) {
-    return "서비스 인증에 실패했습니다. 연결 상태를 다시 확인해 주세요.";
+    return `${serviceLabel} 노드 설정값을 확인해 주세요.`;
+  }
+
+  if (includesAny(normalizedMessage, ["rate limit", "quota", "too many"])) {
+    return `${serviceLabel} 요청 한도 초과로 실행에 실패했습니다.`;
+  }
+
+  if (includesAny(normalizedMessage, ["timeout", "timed out"])) {
+    return `${serviceLabel} 응답 시간이 초과되어 실행에 실패했습니다.`;
+  }
+
+  if (includesAny(normalizedMessage, ["not found", "404"])) {
+    return `${serviceLabel}에서 필요한 대상을 찾지 못했습니다.`;
+  }
+
+  if (includesAny(normalizedMessage, ["parse", "json", "format"])) {
+    return `${serviceLabel} 응답 형식을 처리하지 못했습니다.`;
   }
 
   if (
-    normalizedMessage.includes("execution failed") ||
-    normalizedMessage.includes("failed")
+    includesAny(normalizedMessage, [
+      "fetch",
+      "load",
+      "read",
+      "get ",
+      "list",
+      "retrieve",
+      "message",
+    ])
   ) {
-    return "워크플로우 실행 중 오류가 발생했습니다.";
+    return `${serviceLabel} 데이터를 가져오는 중 오류가 발생했습니다.`;
+  }
+
+  if (
+    includesAny(normalizedMessage, [
+      "send",
+      "post",
+      "create",
+      "upload",
+      "write",
+      "publish",
+    ])
+  ) {
+    return `${serviceLabel}로 데이터를 보내는 중 오류가 발생했습니다.`;
+  }
+
+  if (includesAny(normalizedMessage, ["network", "connect", "request"])) {
+    return `${serviceLabel} 연결 요청 중 오류가 발생했습니다.`;
+  }
+
+  if (
+    includesAny(normalizedMessage, [
+      "node execution failed",
+      "execution failed",
+      "failed",
+      "error",
+      "exception",
+    ])
+  ) {
+    return `${serviceLabel} 노드 실행 중 오류가 발생했습니다.`;
+  }
+
+  if (KOREAN_TEXT_PATTERN.test(trimmedMessage)) {
+    return trimmedMessage;
   }
 
   if (LATIN_TEXT_PATTERN.test(trimmedMessage)) {
-    return UNKNOWN_ERROR_DETAIL_MESSAGE;
+    return `${serviceLabel} 처리 중 오류가 발생했습니다.`;
   }
 
   return trimmedMessage;
@@ -82,6 +212,10 @@ export const DashboardErrorCard = ({
 }: Props) => {
   const detailsId = useId();
   const hasIssueItems = issue.items.length > 0;
+  const localizedBuildProgressLabel = getLocalizedDashboardIssueMessage(
+    issue.buildProgressLabel,
+    issue.startBadgeKey,
+  );
 
   const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -153,7 +287,16 @@ export const DashboardErrorCard = ({
             <HStack gap={2} mt={0.5} color="text.secondary" flexWrap="wrap">
               <Text fontSize="xs">{issue.relativeUpdateLabel}</Text>
               <Box w="1px" h="10px" bg="text.secondary" flexShrink={0} />
-              <Text fontSize="xs">{issue.buildProgressLabel}</Text>
+              <Text
+                fontSize="xs"
+                title={
+                  localizedBuildProgressLabel === issue.buildProgressLabel
+                    ? undefined
+                    : issue.buildProgressLabel
+                }
+              >
+                {localizedBuildProgressLabel}
+              </Text>
             </HStack>
           </Box>
         </Button>
@@ -179,6 +322,7 @@ export const DashboardErrorCard = ({
             issue.items.map((item) => {
               const localizedMessage = getLocalizedDashboardIssueMessage(
                 item.message,
+                item.badgeKey,
               );
 
               return (

--- a/src/pages/dashboard/ui/DashboardErrorCard.tsx
+++ b/src/pages/dashboard/ui/DashboardErrorCard.tsx
@@ -1,5 +1,10 @@
-import { type KeyboardEvent, type MouseEvent } from "react";
-import { MdPlayArrow, MdStop } from "react-icons/md";
+import { type MouseEvent, useId } from "react";
+import {
+  MdKeyboardArrowDown,
+  MdKeyboardArrowUp,
+  MdPlayArrow,
+  MdStop,
+} from "react-icons/md";
 
 import {
   Box,
@@ -21,6 +26,8 @@ type Props = {
   executionActionLabel: string;
   isExecutionActionPending: boolean;
   isExpanded: boolean;
+  canOpenWorkflow: boolean;
+  onOpenWorkflow: () => void;
   onToggle: () => void;
   onExecutionAction: () => void;
 };
@@ -31,19 +38,21 @@ export const DashboardErrorCard = ({
   executionActionLabel,
   isExecutionActionPending,
   isExpanded,
+  canOpenWorkflow,
+  onOpenWorkflow,
   onToggle,
   onExecutionAction,
 }: Props) => {
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onToggle();
-    }
-  };
+  const detailsId = useId();
 
   const handleExecutionActionClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onExecutionAction();
+  };
+
+  const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onToggle();
   };
 
   return (
@@ -54,20 +63,42 @@ export const DashboardErrorCard = ({
       borderRadius="10px"
       boxShadow="0 0 4px rgba(239, 61, 61, 0.24)"
       p={4}
-      cursor="pointer"
-      onClick={onToggle}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
-      aria-expanded={isExpanded}
     >
       <Flex
-        align={{ base: "flex-start", md: "center" }}
+        align={{ base: "stretch", md: "center" }}
         justify="space-between"
         direction={{ base: "column", md: "row" }}
         gap={3}
       >
-        <HStack gap={3} minW={0} flex={1} align="center">
+        <Flex
+          as="button"
+          type="button"
+          align="center"
+          gap={3}
+          minW={0}
+          flex={1}
+          w="full"
+          p={0}
+          bg="transparent"
+          border={0}
+          borderRadius="8px"
+          color="inherit"
+          textAlign="left"
+          cursor={canOpenWorkflow ? "pointer" : "default"}
+          disabled={!canOpenWorkflow}
+          aria-label={`${issue.name} 워크플로우 편집 화면 열기`}
+          onClick={onOpenWorkflow}
+          _hover={canOpenWorkflow ? { bg: "bg.muted" } : undefined}
+          _focusVisible={{
+            outline: "2px solid",
+            outlineColor: "neutral.950",
+            outlineOffset: "2px",
+          }}
+          _disabled={{
+            cursor: "default",
+            opacity: 1,
+          }}
+        >
           <HStack gap={1.5} flexShrink={0}>
             <ServiceBadge type={issue.startBadgeKey} />
             <Text fontSize="sm" fontWeight="bold" color="text.primary">
@@ -91,28 +122,45 @@ export const DashboardErrorCard = ({
               <Text fontSize="xs">{issue.buildProgressLabel}</Text>
             </HStack>
           </Box>
-        </HStack>
+        </Flex>
 
-        <IconButton
-          aria-label={executionActionLabel}
-          variant="ghost"
-          size="sm"
+        <HStack
+          gap={1}
           flexShrink={0}
-          disabled={isExecutionActionPending}
-          onClick={handleExecutionActionClick}
+          alignSelf={{ base: "flex-end", md: "center" }}
         >
-          {isExecutionActionPending ? (
-            <Spinner size="xs" />
-          ) : executionActionKind === "stop" ? (
-            <MdStop />
-          ) : (
-            <MdPlayArrow />
-          )}
-        </IconButton>
+          <IconButton
+            aria-label={executionActionLabel}
+            variant="ghost"
+            size="sm"
+            flexShrink={0}
+            disabled={isExecutionActionPending}
+            onClick={handleExecutionActionClick}
+          >
+            {isExecutionActionPending ? (
+              <Spinner size="xs" />
+            ) : executionActionKind === "stop" ? (
+              <MdStop />
+            ) : (
+              <MdPlayArrow />
+            )}
+          </IconButton>
+          <IconButton
+            aria-label={isExpanded ? "에러 상세 접기" : "에러 상세 펼치기"}
+            aria-expanded={isExpanded}
+            aria-controls={detailsId}
+            variant="ghost"
+            size="sm"
+            flexShrink={0}
+            onClick={handleToggleClick}
+          >
+            {isExpanded ? <MdKeyboardArrowUp /> : <MdKeyboardArrowDown />}
+          </IconButton>
+        </HStack>
       </Flex>
 
       {isExpanded ? (
-        <VStack align="stretch" gap={2} mt={4}>
+        <VStack id={detailsId} align="stretch" gap={2} mt={4}>
           {issue.items.map((item) => (
             <HStack
               key={item.id}

--- a/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
+++ b/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
@@ -1,6 +1,17 @@
+import { useMemo } from "react";
 import { useNavigate } from "react-router";
 
-import { buildPath } from "@/shared";
+import {
+  type WorkflowResponse,
+  getNodeStatusMissingFieldLabel,
+  useWorkflowQuery,
+} from "@/entities/workflow";
+import {
+  type ServiceBadgeKey,
+  buildPath,
+  getServiceBadgeKeyFromNodeConfig,
+  getServiceBadgeKeyFromService,
+} from "@/shared";
 
 import { type DashboardIssue } from "../model";
 
@@ -12,6 +23,96 @@ type Props = {
   onToggle: () => void;
 };
 
+type MissingFieldLookup = {
+  workflowMissingFieldLabels: string[];
+  missingFieldLabelsByBadgeKey: Partial<Record<ServiceBadgeKey, string[]>>;
+};
+
+const getStringConfigValue = (
+  config: Record<string, unknown>,
+  keys: string[],
+) => {
+  const value = keys
+    .map((key) => config[key])
+    .find((candidate) => typeof candidate === "string");
+
+  return typeof value === "string" ? value : null;
+};
+
+const getWorkflowNodeBadgeKey = (
+  node: WorkflowResponse["nodes"][number],
+): ServiceBadgeKey => {
+  const service = getStringConfigValue(node.config, [
+    "service",
+    "serviceKey",
+    "eventService",
+    "source_service",
+    "sourceService",
+  ]);
+  const sourceMode = getStringConfigValue(node.config, [
+    "source_mode",
+    "sourceMode",
+  ]);
+  const configBadgeKey = getServiceBadgeKeyFromNodeConfig(service, sourceMode);
+
+  if (configBadgeKey !== "unknown") {
+    return configBadgeKey;
+  }
+
+  const typeBadgeKey = getServiceBadgeKeyFromService(node.type);
+
+  if (typeBadgeKey !== "unknown") {
+    return typeBadgeKey;
+  }
+
+  return getServiceBadgeKeyFromService(node.category);
+};
+
+const getUniqueMissingFieldLabels = (missingFields: string[] | null) =>
+  Array.from(
+    new Set((missingFields ?? []).map(getNodeStatusMissingFieldLabel)),
+  );
+
+const getWorkflowMissingFieldLookup = (
+  workflow: WorkflowResponse | undefined,
+): MissingFieldLookup => {
+  const missingFieldLabelsByBadgeKey: Partial<
+    Record<ServiceBadgeKey, string[]>
+  > = {};
+  const workflowMissingFieldLabels: string[] = [];
+  const nodeStatusesById = new Map(
+    (workflow?.nodeStatuses ?? []).map((nodeStatus) => [
+      nodeStatus.nodeId,
+      nodeStatus,
+    ]),
+  );
+
+  for (const node of workflow?.nodes ?? []) {
+    const nodeStatus = nodeStatusesById.get(node.id);
+    const missingFieldLabels = getUniqueMissingFieldLabels(
+      nodeStatus?.missingFields ?? null,
+    );
+
+    if (missingFieldLabels.length === 0) {
+      continue;
+    }
+
+    const badgeKey = getWorkflowNodeBadgeKey(node);
+    const currentLabels = missingFieldLabelsByBadgeKey[badgeKey] ?? [];
+    const nextLabels = Array.from(
+      new Set([...currentLabels, ...missingFieldLabels]),
+    );
+
+    missingFieldLabelsByBadgeKey[badgeKey] = nextLabels;
+    workflowMissingFieldLabels.push(...missingFieldLabels);
+  }
+
+  return {
+    workflowMissingFieldLabels: Array.from(new Set(workflowMissingFieldLabels)),
+    missingFieldLabelsByBadgeKey,
+  };
+};
+
 export const DashboardIssueCardItem = ({
   issue,
   isExpanded,
@@ -21,6 +122,17 @@ export const DashboardIssueCardItem = ({
   const workflowId =
     typeof issue.workflowId === "string" ? issue.workflowId.trim() : "";
   const canOpenWorkflow = workflowId.length > 0;
+  const { data: workflow } = useWorkflowQuery(
+    canOpenWorkflow ? workflowId : undefined,
+    {
+      enabled: canOpenWorkflow,
+      staleTime: 30_000,
+    },
+  );
+  const { workflowMissingFieldLabels, missingFieldLabelsByBadgeKey } = useMemo(
+    () => getWorkflowMissingFieldLookup(workflow),
+    [workflow],
+  );
 
   const handleOpenWorkflow = () => {
     if (!canOpenWorkflow) {
@@ -35,6 +147,8 @@ export const DashboardIssueCardItem = ({
       issue={issue}
       isExpanded={isExpanded}
       canOpenWorkflow={canOpenWorkflow}
+      workflowMissingFieldLabels={workflowMissingFieldLabels}
+      missingFieldLabelsByBadgeKey={missingFieldLabelsByBadgeKey}
       onOpenWorkflow={handleOpenWorkflow}
       onToggle={onToggle}
     />

--- a/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
+++ b/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from "react-router";
+
 import { useWorkflowExecutionAction } from "@/features/workflow-execution";
+import { buildPath } from "@/shared";
 
 import { type DashboardIssue } from "../model";
 
@@ -15,8 +18,20 @@ export const DashboardIssueCardItem = ({
   isExpanded,
   onToggle,
 }: Props) => {
+  const navigate = useNavigate();
   const { actionKind, actionLabel, isActionPending, handleAction } =
     useWorkflowExecutionAction(issue.workflowId);
+  const workflowId =
+    typeof issue.workflowId === "string" ? issue.workflowId.trim() : "";
+  const canOpenWorkflow = workflowId.length > 0;
+
+  const handleOpenWorkflow = () => {
+    if (!canOpenWorkflow) {
+      return;
+    }
+
+    navigate(buildPath.workflowEditor(workflowId));
+  };
 
   return (
     <DashboardErrorCard
@@ -25,6 +40,8 @@ export const DashboardIssueCardItem = ({
       executionActionLabel={actionLabel}
       isExecutionActionPending={isActionPending}
       isExpanded={isExpanded}
+      canOpenWorkflow={canOpenWorkflow}
+      onOpenWorkflow={handleOpenWorkflow}
       onToggle={onToggle}
       onExecutionAction={() => void handleAction()}
     />

--- a/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
+++ b/src/pages/dashboard/ui/DashboardIssueCardItem.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router";
 
-import { useWorkflowExecutionAction } from "@/features/workflow-execution";
 import { buildPath } from "@/shared";
 
 import { type DashboardIssue } from "../model";
@@ -19,8 +18,6 @@ export const DashboardIssueCardItem = ({
   onToggle,
 }: Props) => {
   const navigate = useNavigate();
-  const { actionKind, actionLabel, isActionPending, handleAction } =
-    useWorkflowExecutionAction(issue.workflowId);
   const workflowId =
     typeof issue.workflowId === "string" ? issue.workflowId.trim() : "";
   const canOpenWorkflow = workflowId.length > 0;
@@ -36,14 +33,10 @@ export const DashboardIssueCardItem = ({
   return (
     <DashboardErrorCard
       issue={issue}
-      executionActionKind={actionKind}
-      executionActionLabel={actionLabel}
-      isExecutionActionPending={isActionPending}
       isExpanded={isExpanded}
       canOpenWorkflow={canOpenWorkflow}
       onOpenWorkflow={handleOpenWorkflow}
       onToggle={onToggle}
-      onExecutionAction={() => void handleAction()}
     />
   );
 };

--- a/src/shared/ui/ServiceBadge.tsx
+++ b/src/shared/ui/ServiceBadge.tsx
@@ -74,7 +74,6 @@ export const ServiceBadge = ({ type }: Props) => {
             boxSize="30px"
             align="center"
             justify="center"
-            bg="bg.overlay"
             borderRadius="lg"
           >
             <Icon as={fallbackIcon} boxSize={4.5} color="text.primary" />


### PR DESCRIPTION
## Summary
- 대시보드 「오늘 발생한 에러」 카드에서 실행/중지 버튼을 제거했습니다.
- 우측 상세 토글 버튼을 제외한 카드 영역 클릭 시 workflow editor(`/workflows/:workflowId`)로 이동하도록 정리했습니다.
- 우측 상세 토글은 기존처럼 펼침/접힘만 수행하며, 카드 이동 이벤트와 충돌하지 않도록 `stopPropagation`을 유지했습니다.
- 에러명/상세 메시지는 영문 원문을 그대로 노출하지 않고 서비스/원인 기반 한글 메시지로 표시하도록 개선했습니다.
- unknown/fallback 서비스 배지의 회색 배경을 제거했습니다.
- 카드 hover 시 우측 상세 버튼 외 영역은 배경색이 변하지 않도록 조정했습니다.

## Changes
- `DashboardIssueCardItem`에서 workflowId runtime guard와 editor 이동 handler를 유지합니다.
- `DashboardErrorCard`에서 카드 root 클릭 이동, 우측 상세 버튼 예외 처리, 키보드 Enter/Space 이동 접근성을 정리했습니다.
- 에러 메시지 표시 helper로 인증/권한, 설정값, 요청 한도, timeout, not found, 응답 파싱, fetch/send, network, node execution 실패 메시지를 한글화했습니다.
- `ServiceBadge` fallback branch에서 `bg.overlay` 배경만 제거했습니다.

## Validation
- `pnpm tsc` passed
- `pnpm test` passed: 21 files / 87 tests
- `pnpm lint` passed
- `pnpm build` passed
  - Vite chunk size warning은 기존 번들 크기 경고이며 build 실패는 아닙니다.

## Not Changed
- Spring BE, FastAPI BE, DB, Docker/env/secret 파일 변경 없음
- dashboard summary API, workflow API 변경 없음
- dashboard mapper/type 구조 변경 없음
- `useWorkflowExecutionAction.ts` 변경 없음

## Manual Check Points
- 우측 상세 버튼 외 카드 영역 클릭 시 workflow editor로 이동하는지 확인
- 우측 상세 버튼 클릭 시 이동하지 않고 상세만 펼침/접힘 되는지 확인
- hover 시 우측 상세 버튼 외 카드 배경색이 변하지 않는지 확인
- 영문 에러가 한글 에러명으로 표시되는지 확인
- unknown/fallback 톱니바퀴 아이콘에 회색 배경이 없는지 확인
