### PR TITLE
feat: support document content OCR vision handoff

### DIFF
--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_GMAIL_OCR_VISION_FOLLOWUP_PLAN.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_GMAIL_OCR_VISION_FOLLOWUP_PLAN.md
@@ -1,0 +1,353 @@
+# Gmail attachment/OCR/Vision 문서 본문 런타임 후속 계획
+
+> 작성일: 2026-05-17
+> 목적: 기존 문서 본문 런타임 계약 위에 아직 남아 있는 Gmail attachment 본문 추출, scan PDF OCR, image OCR/vision 처리를 구현 가능한 단위로 분해한다.
+> 기준 문서:
+> - `docs/DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_BACKEND_IMPLEMENTATION_HANDOFF.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_FINAL_IMPLEMENTATION_REVIEW.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_FRONTEND_INTEGRATION_REVIEW.md`
+> - `docs/backend/DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`
+> - `docs/GMAIL_NODE_OPTION_C_IMPLEMENTATION_PLAN.md`
+> - `docs/WORKFLOW_FILE_TYPE_BRANCH_FRONTEND_DESIGN.md`
+> - `docs/WORKFLOW_NODE_PREVIEW_DRY_RUN_DESIGN.md`
+> - `docs/FOLDER_DOCUMENT_SUMMARY_TEMPLATE_DESIGN.md`
+> - `docs/FILE_UPLOAD_AUTO_SHARE_TEMPLATE_DESIGN.md`
+
+---
+
+## 1. 현재 판단
+
+문서 본문 런타임의 계약/경로 안정화와 Google Drive 기반 주요 문서 extractor는 완료된 것으로 본다. 현재 완료 범위에는 `SINGLE_FILE`, `FILE_LIST.items[]`, Gmail attachment 공통 content 상태 필드, `DOCUMENT_CONTENT_*` error contract, TXT/CSV/TSV/PDF text/DOCX/PPTX/HWPX/Google Workspace 추출 경로가 포함된다.
+
+남은 항목은 기능 자체의 부재다.
+
+| 항목 | 현재 상태 | 사용자 영향 |
+|------|-----------|-------------|
+| Gmail attachment 본문 추출 | attachment metadata와 content status field는 있으나 attachment download + extractor 연결이 없음 | Gmail 첨부 문서 요약이 파일명/상태 표시에서 멈춤 |
+| scan PDF OCR | 텍스트 레이어 없는 PDF는 OCR 미지원 `unsupported`로 명확히 실패 | 스캔본 강의자료/영수증/계약서 PDF를 요약할 수 없음 |
+| image OCR/vision | image file은 상태 표시 가능하지만 OCR/vision extractor 없음 | 이미지 branch 뒤의 `ocr`, `describe_image` action이 실제 본문/설명을 만들지 못함 |
+
+따라서 후속 작업의 목표는 새 payload 계약을 다시 만드는 것이 아니라, 이미 합의된 `content`, `content_status`, `content_error`, `content_metadata` 계약에 실제 추출기를 연결하는 것이다.
+
+---
+
+## 2. 관련 문서에서 확인한 공백
+
+### 2.1 Gmail attachment
+
+`GMAIL_NODE_OPTION_C_IMPLEMENTATION_PLAN.md`는 Gmail source/sink/OAuth 진입을 열어두되, `attachment content download/전달`을 후속 범위로 명시한다.
+
+`DOCUMENT_CONTENT_RUNTIME_BACKEND_IMPLEMENTATION_HANDOFF.md`는 Gmail attachment가 파일 카드 helper로 처리될 수 있도록 `content_status`, `content_error`, `content_metadata`를 가진다고 정리했지만, 현재 1차 구현은 attachment download와 공통 extractor 연결을 포함하지 않는다.
+
+필요한 보강:
+
+- Gmail API에서 attachment bytes를 가져오는 downloader.
+- `messageId`, `attachmentId`, `filename`, `mime_type`, `size`를 common file extraction input으로 변환하는 adapter.
+- Gmail attachment를 기존 Drive file extractor와 같은 registry로 보내는 경로.
+- attachment content가 필요한 action에서 `not_requested`를 빈 성공으로 넘기지 않는 실패 처리.
+- Gmail readonly scope 부족, attachment 없음, inline image, 대용량 attachment, base64url decode 실패에 대한 error mapping.
+
+### 2.2 Scan PDF OCR
+
+`DOCUMENT_CONTENT_RUNTIME_IMPLEMENTATION_REPORT.md`와 `DOCUMENT_CONTENT_RUNTIME_FINAL_IMPLEMENTATION_REVIEW.md`는 PDF text layer 추출은 완료됐지만, 텍스트 레이어 없는 PDF는 OCR 미지원 `unsupported`로 반환한다고 정리한다.
+
+필요한 보강:
+
+- PDF text extraction 결과가 비어 있거나 너무 적은 경우 scan PDF로 판별하는 기준.
+- PDF page를 이미지로 렌더링하는 단계.
+- OCR provider 연결.
+- page count, render DPI, max image pixels, max OCR pages 같은 제한값.
+- OCR 결과를 page 순서대로 합쳐 `content_kind=ocr_text` 또는 `mixed`로 반환하는 정규화.
+
+### 2.3 Image OCR/Vision
+
+`WORKFLOW_FILE_TYPE_BRANCH_FRONTEND_DESIGN.md`는 PDF/image/other 분기와 image branch 뒤의 AI 설명 생성 흐름을 전제로 한다. `DOCUMENT_CONTENT_RUNTIME_REQUIREMENTS.md`도 image common file을 OCR 또는 vision 모델 기반 text/description 추출의 조건부 지원군으로 둔다.
+
+필요한 보강:
+
+- 이미지 파일 판별과 안전한 decode/normalize.
+- `ocr` action과 `describe_image` action의 결과 의미 분리.
+- OCR 텍스트는 `content_kind=ocr_text`, vision 설명은 `content_kind=image_description`, 둘을 합치면 `mixed`.
+- animated GIF/HEIC/TIFF multi-page 같은 확장 형식의 1차 지원 여부 결정.
+- vision description을 OCR 결과처럼 확정 텍스트로 오해하지 않도록 metadata에 extraction source를 남김.
+
+---
+
+## 3. 목표 계약
+
+기존 canonical field는 유지한다.
+
+```json
+{
+  "content": "추출 텍스트 또는 이미지 설명",
+  "content_status": "available|empty|unsupported|too_large|failed|not_requested",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "pdf_text|docx_xml|pptx_xml|hwpx_xml|plain_text|csv_parse|ocr|vision|none",
+    "content_kind": "plain_text|ocr_text|image_description|mixed|none",
+    "truncated": false,
+    "char_count": 0,
+    "original_char_count": 0,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 60000,
+      "max_llm_input_chars": 60000
+    }
+  }
+}
+```
+
+후속 구현에서는 아래 metadata를 추가할 수 있다. FE는 표시 필수값으로 보지 않고 디버깅/상태 설명용으로만 사용한다.
+
+```json
+{
+  "content_metadata": {
+    "source_service": "gmail",
+    "message_id": "msg-1",
+    "attachment_id": "att-1",
+    "page_count": 3,
+    "ocr_page_count": 3,
+    "image_width": 1200,
+    "image_height": 800,
+    "provider": "configured_ocr_provider",
+    "confidence": 0.92
+  }
+}
+```
+
+주의:
+
+- `content`는 계속 LLM/UI용 canonical text representation이다.
+- 원본 attachment bytes나 base64는 `content`에 넣지 않는다.
+- Gmail attachment 여부는 `extraction_method`가 아니라 `source_service=gmail`, `message_id`, `attachment_id`로 표현한다. `extraction_method`는 실제 본문을 만든 parser/provider를 기록한다.
+- preview 기본값은 계속 metadata-only이며, `include_content=true` 또는 `requires_content=true` 실행 경로에서만 실제 추출을 수행한다.
+
+---
+
+## 4. 구현 순서
+
+### Phase 0. 계약/설정 정리
+
+목표: 기능을 붙이기 전에 provider, limit, fixture, error behavior를 고정한다.
+
+작업:
+
+1. FastAPI document content 설정에 OCR/vision 관련 flag를 추가한다.
+   - `enable_gmail_attachment_extraction`
+   - `enable_pdf_ocr`
+   - `enable_image_ocr`
+   - `enable_image_vision`
+   - `max_ocr_pages`
+   - `max_image_pixels`
+2. `content_metadata.limits`에 OCR/image 관련 제한값을 optional로 추가한다.
+3. `DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json`에 아래 fixture를 추가한다.
+   - Gmail attachment available
+   - Gmail attachment too_large
+   - scan PDF OCR available
+   - image OCR available
+   - image vision available
+   - image OCR/vision unsupported
+4. error code는 기존 `DOCUMENT_CONTENT_*`를 우선 재사용한다.
+5. provider가 꺼져 있으면 `content_status=unsupported`, 사용자 문구는 “현재 OCR/이미지 분석을 지원하지 않습니다.” 계열로 통일한다.
+
+완료 기준:
+
+- 설정값이 없어도 기존 문서 본문 런타임이 깨지지 않는다.
+- 기능 비활성 상태에서 status/error가 기존 FE 표시 계약으로 자연스럽게 내려간다.
+
+### Phase 1. Gmail attachment download + common extractor 연결
+
+목표: Gmail 첨부파일을 Drive 파일과 같은 extractor registry로 보낸다.
+
+작업:
+
+1. Gmail message part traversal을 구현한다.
+   - nested `parts`에서 filename이 있고 attachment id가 있는 part 수집.
+   - inline image와 일반 attachment를 구분하되 1차는 일반 attachment만 본문 추출 대상으로 둔다.
+2. Gmail attachment downloader를 구현한다.
+   - `messageId`, `attachmentId`로 attachment body 조회.
+   - base64url decode.
+   - 다운로드 전후 size limit 검증.
+3. attachment file object를 common extractor input으로 변환한다.
+   - `source_service=gmail`
+   - `message_id`
+   - `attachment_id`
+   - `filename`
+   - `mime_type`
+   - `size`
+   - `bytes`
+4. 기존 TXT/CSV/PDF text/DOCX/PPTX/HWPX extractor를 attachment에도 적용한다.
+5. `attachment_email` source의 `FILE_LIST.items[]`와 `SINGLE_EMAIL.email.attachments[]` shape를 같은 content contract로 맞춘다.
+6. `requires_content=true`이고 attachment extraction이 실패하면 `DOCUMENT_CONTENT_*` error context에 filename/messageId/attachmentId를 포함한다.
+
+완료 기준:
+
+- Gmail attachment PDF text/DOCX/TXT/CSV가 `content_status=available`로 내려온다.
+- metadata-only preview에서는 `not_requested`가 유지된다.
+- content 요청 또는 실행 경로에서는 attachment body를 다운로드해 extractor를 수행한다.
+- Gmail 첨부 요약이 attachment filename 요약이 아니라 본문 기반 요약이 된다.
+
+### Phase 2. Image OCR/Vision core
+
+목표: 이미지 단일 파일을 텍스트 또는 설명으로 변환하는 공통 엔진을 만든다. Scan PDF OCR도 이 엔진을 재사용한다.
+
+작업:
+
+1. image extractor registry를 추가한다.
+   - 1차 대상: `png`, `jpg`, `jpeg`, `webp`, `bmp`, `tif`, `tiff`.
+   - `gif`, `heic`은 1차에서 `unsupported`로 둘 수 있다.
+2. 이미지 decode/normalize 단계를 만든다.
+   - EXIF orientation 반영.
+   - 최대 pixel 제한.
+   - 필요 시 RGB 변환.
+3. action별 처리 정책을 분리한다.
+   - `ocr`: OCR provider 호출, `content_kind=ocr_text`, `extraction_method=ocr`.
+   - `describe_image`: vision provider 호출, `content_kind=image_description`, `extraction_method=vision`.
+   - `summarize`/`ai_analyze`: OCR 우선, OCR 결과가 없고 vision enabled이면 description fallback 또는 `mixed`.
+4. provider disabled/timeout/rate limit을 `unsupported` 또는 `failed`로 정규화한다.
+5. OCR 결과가 빈 문자열이면 `empty`로 처리한다.
+
+완료 기준:
+
+- image branch 뒤 `ocr` action은 이미지 안의 텍스트를 LLM input으로 전달한다.
+- image branch 뒤 `describe_image` action은 이미지 설명을 LLM input으로 전달한다.
+- OCR과 vision 결과가 metadata에서 구분된다.
+- provider 미설정 환경에서도 기존 runtime은 실패하지 않고 명확한 `unsupported`를 반환한다.
+
+### Phase 3. Scan PDF OCR fallback
+
+목표: 텍스트 레이어가 없는 PDF를 page image OCR로 처리한다.
+
+작업:
+
+1. PDF text extraction 후 scan 판별 기준을 추가한다.
+   - text char count가 0이거나 page 대비 너무 적으면 OCR fallback 대상.
+   - 파일이 image-only PDF인지 metadata에 기록.
+2. PDF page render 단계를 추가한다.
+   - max page count 제한.
+   - render DPI 제한.
+   - page별 image size 제한.
+3. Phase 2의 OCR core를 page별로 호출한다.
+4. page 순서와 page separator를 유지해 content를 합친다.
+5. 일부 page OCR 실패 시 정책을 정한다.
+   - 모든 page 실패: `failed` 또는 `empty`.
+   - 일부 성공: `available`, `content_metadata.partial=true` optional.
+6. 텍스트 레이어와 OCR 결과가 섞인 PDF는 `content_kind=mixed`로 둘 수 있다.
+
+완료 기준:
+
+- 텍스트 레이어 없는 scan PDF가 OCR provider 활성 상태에서 `content_status=available`이 된다.
+- OCR 비활성 상태에서는 기존처럼 `unsupported`가 유지된다.
+- 너무 큰 PDF나 page 제한 초과는 `too_large`로 실패한다.
+- page 순서가 LLM input에서 보존된다.
+
+### Phase 4. 통합 검증과 문구 정리
+
+목표: 새 기능이 문서/파일 템플릿, Gmail source, 파일 종류 분기 UX와 모순 없이 동작하는지 확인한다.
+
+작업:
+
+1. FastAPI unit test 추가.
+   - Gmail attachment download/decode.
+   - attachment -> common extractor.
+   - image OCR/vision success/empty/unsupported/failed.
+   - scan PDF OCR success/too_large/unsupported.
+2. LLM integration-like test 추가.
+   - Gmail attachment PDF -> AI summarize.
+   - Image -> OCR -> AI summarize.
+   - Image -> describe_image.
+   - Scan PDF -> AI summarize.
+3. Spring contract test 확인.
+   - 기존 `DOCUMENT_CONTENT_*` mapping이 신규 OCR/Gmail context를 보존하는지 확인.
+   - 필요 시 `content_metadata` nested field 보존 fixture 추가.
+4. FE fixture/rendering test 확장.
+   - `DOCUMENT_CONTENT_RUNTIME_SAMPLE_PAYLOADS.json` 신규 fixture 기준.
+   - Gmail attachment card에서 available/too_large/unsupported 표시.
+   - image/PDF OCR 결과가 “본문 일부만 표시” 정책과 충돌하지 않는지 확인.
+5. 템플릿/도움말 문구 갱신.
+   - OCR/vision이 켜진 경우와 꺼진 경우의 지원 범위를 과장하지 않는다.
+
+완료 기준:
+
+- 세 기능 모두 sample payload, unit test, integration-like test가 있다.
+- 사용자는 미지원/비활성 상태를 빈 요약 성공으로 보지 않는다.
+- 문서 요약 템플릿과 파일 종류 분기 흐름에서 PDF/image branch가 실제 extractor 결과를 downstream으로 전달한다.
+
+---
+
+## 5. 우선순위
+
+권장 순서는 다음과 같다.
+
+1. **Gmail attachment download + common extractor 연결**
+   - 새 OCR provider 없이도 기존 DOCX/PPTX/HWPX/PDF text/TXT/CSV extractor를 즉시 재사용할 수 있다.
+   - Gmail 첨부 문서 요약이라는 사용자 흐름을 가장 빨리 복구한다.
+2. **Image OCR/Vision core**
+   - scan PDF OCR이 page image OCR을 재사용할 수 있으므로 먼저 공통 이미지 처리 계층을 만든다.
+3. **Scan PDF OCR fallback**
+   - PDF render와 page orchestration이 추가로 필요하므로 image OCR core 이후가 안전하다.
+4. **Cross-service E2E와 FE fixture 확장**
+   - 기능별 extractor가 붙은 뒤 Spring/FastAPI/FE 계약 회귀를 고정한다.
+
+---
+
+## 6. 수용 기준
+
+### 6.1 Gmail attachment
+
+- `attachment_email` source가 attachment metadata-only preview와 content-included execution을 구분한다.
+- 지원 파일 attachment는 `content_status=available`과 추출된 `content`를 가진다.
+- 미지원/대용량/권한 부족/다운로드 실패는 `DOCUMENT_CONTENT_*` 또는 OAuth error로 구분된다.
+- `messageId:attachmentId` 기준으로 error context와 debug trace를 추적할 수 있다.
+
+### 6.2 Scan PDF OCR
+
+- text layer PDF는 기존 `pdf_text` 경로를 유지한다.
+- scan PDF는 OCR enabled일 때 `ocr` 경로로 fallback한다.
+- OCR disabled일 때는 `unsupported`와 사용자 표시 가능한 사유를 반환한다.
+- page limit, render limit, char limit이 metadata에 남는다.
+
+### 6.3 Image OCR/Vision
+
+- `ocr` action은 OCR 텍스트를 생성한다.
+- `describe_image` action은 이미지 설명을 생성한다.
+- `summarize`/`ai_analyze`는 image content를 사용할 때 OCR/vision 결과의 출처를 metadata에 남긴다.
+- image branch 결과가 `FILE_LIST -> LOOP -> AI` 경로에서 손실되지 않는다.
+
+---
+
+## 7. PR/릴리즈 표현
+
+기능 완료 전까지 피해야 할 표현:
+
+- “Gmail 첨부파일 본문 추출 완료”
+- “스캔 PDF OCR 완료”
+- “이미지 OCR/vision 완료”
+- “모든 파일 완전 호환”
+
+기능별 완료 후 사용할 수 있는 표현:
+
+- “Gmail attachment를 공통 문서 extractor에 연결했습니다.”
+- “텍스트 레이어 없는 PDF에 OCR fallback을 추가했습니다.”
+- “이미지 파일의 OCR/vision 기반 content extraction을 추가했습니다.”
+- “OCR/vision 비활성 또는 미지원 상태를 `DOCUMENT_CONTENT_*` contract로 명확히 반환합니다.”
+
+---
+
+## 8. 남은 결정 사항
+
+1. OCR/vision provider를 무엇으로 둘지 결정해야 한다.
+   - 자체 OCR, cloud OCR, LLM vision 등 provider를 바꿀 수 있도록 interface를 먼저 둔다.
+2. Korean/English OCR 언어 설정을 기본 지원 범위에 포함할지 결정해야 한다.
+3. scan PDF OCR의 page limit 기본값을 정해야 한다.
+4. image `summarize`에서 OCR만 사용할지, OCR + vision mixed를 기본으로 할지 결정해야 한다.
+5. Gmail inline image를 attachment extraction 범위에 포함할지 결정해야 한다.
+6. OCR/vision 결과를 실행 로그에 얼마나 저장할지, 기존 4,000자 truncate 정책으로 충분한지 확인해야 한다.
+
+---
+
+## 9. 한 줄 결론
+
+현재 남은 작업은 계약 재설계가 아니라 extractor 확장이다. Gmail attachment는 기존 extractor를 재사용하는 downloader/adapter 작업으로 먼저 처리하고, image OCR/vision core를 만든 뒤 그 위에 scan PDF OCR fallback을 얹는 순서가 가장 안전하다.

--- a/docs/backend/DOCUMENT_CONTENT_RUNTIME_GMAIL_OCR_VISION_IMPLEMENTATION_HANDOFF.md
+++ b/docs/backend/DOCUMENT_CONTENT_RUNTIME_GMAIL_OCR_VISION_IMPLEMENTATION_HANDOFF.md
@@ -1,0 +1,351 @@
+# Gmail attachment/OCR/Vision 구현 전달 문서
+
+> 작성일: 2026-05-17
+> 전달 대상: Frontend 팀, Spring Boot 팀
+> 기준 브랜치: `feat/26-runtime-document`
+> 목적: Gmail attachment 본문 추출, scan PDF OCR, image OCR/vision 후속 작업의 실제 구현 방식과 연동 시 주의사항을 공유한다.
+
+---
+
+## 1. 구현 요약
+
+기존 문서 본문 런타임 계약은 유지했다.
+
+- 기존 top-level 필드인 `content`, `content_status`, `content_error`, `content_metadata`를 그대로 사용한다.
+- Gmail attachment, image, scan PDF는 새 payload 계약을 만들지 않고 기존 file content contract에 metadata를 추가하는 방식으로 연결했다.
+- 기능 플래그는 모두 기본 `false`다. 운영에서 명시적으로 켜기 전에는 기존 동작을 깨지 않고 `unsupported` 상태를 반환한다.
+- OCR/vision provider는 1차 구현에서 기존 LLM 연동을 재사용하는 `openai_vision`만 지원한다.
+- 원본 파일 bytes/base64는 응답 payload나 log에 저장하지 않는다.
+
+검토 결과, 현재 변경분에서 차단급 이슈는 발견하지 못했다. 비용과 latency가 큰 기능이라 기본 off 정책, size/page/pixel limit, `unsupported` 정규화가 핵심 안전장치다.
+
+---
+
+## 2. 변경 파일
+
+주요 구현 파일:
+
+- `app/config.py`: OCR/vision/Gmail attachment feature flag와 limit 설정 추가.
+- `app/core/document_content.py`: `content_metadata`에 service-specific metadata를 병합할 수 있도록 확장.
+- `app/services/integrations/gmail.py`: Gmail attachment metadata 보강, attachment download, 공통 extractor adapter 추가.
+- `app/services/integrations/google_drive.py`: byte 기반 공통 extractor, image OCR/vision, scan PDF OCR fallback 추가.
+- `app/services/llm_service.py`: vision-capable model 호출용 `analyze_image()` 추가.
+- `app/core/nodes/llm_node.py`: LLM 실행 직전 Gmail/Drive file content lazy extraction 연결.
+- `app/core/engine/preview_executor.py`: `include_content=true` preview에서 Gmail attachment content 추출 연결.
+- `app/core/nodes/input_node.py`: Gmail attachment alias field 보존.
+
+테스트 파일:
+
+- `tests/test_integrations/test_google_drive.py`
+- `tests/test_integrations/test_gmail.py`
+- `tests/test_input_node.py`
+- `tests/test_llm_node.py`
+- `tests/test_preview_executor.py`
+
+의존성:
+
+- `PyMuPDF>=1.24.0` 추가. scan PDF를 page image로 렌더링할 때 사용한다.
+
+---
+
+## 3. 설정값
+
+FastAPI 설정에 아래 값이 추가됐다.
+
+```text
+ENABLE_GMAIL_ATTACHMENT_EXTRACTION=false
+ENABLE_PDF_OCR=false
+ENABLE_IMAGE_OCR=false
+ENABLE_IMAGE_VISION=false
+OCR_PROVIDER=openai_vision
+VISION_PROVIDER=openai_vision
+VISION_MODEL_NAME=
+OCR_LANGUAGES=ko,en
+MAX_OCR_PAGES=10
+MAX_IMAGE_PIXELS=12000000
+```
+
+운영 의미:
+
+- Gmail attachment 본문 추출은 `ENABLE_GMAIL_ATTACHMENT_EXTRACTION=true`일 때만 attachment bytes를 다운로드한다.
+- scan PDF OCR은 `ENABLE_PDF_OCR=true`, `ENABLE_IMAGE_OCR=true`, `OCR_PROVIDER=openai_vision`, `LLM_API_KEY`가 모두 준비되어야 실제 OCR을 수행한다.
+- image OCR은 `ENABLE_IMAGE_OCR=true`일 때만 수행한다.
+- image description/vision은 `ENABLE_IMAGE_VISION=true`일 때만 수행한다.
+- `VISION_MODEL_NAME`이 비어 있으면 기존 `LLM_MODEL_NAME`을 사용한다.
+
+Spring Boot나 Frontend가 provider API key, provider 이름, page render 설정을 runtime payload로 넘길 필요는 없다. 이 값들은 FastAPI 서버 설정이다.
+
+---
+
+## 4. 공통 응답 계약
+
+기존 file content contract를 유지한다.
+
+```json
+{
+  "content": "추출된 텍스트 또는 이미지 설명",
+  "content_status": "available",
+  "content_error": null,
+  "content_metadata": {
+    "extraction_method": "pdf_text",
+    "content_kind": "plain_text",
+    "truncated": false,
+    "char_count": 1234,
+    "original_char_count": 1234,
+    "limits": {
+      "max_download_bytes": 10485760,
+      "max_extracted_chars": 60000,
+      "max_llm_input_chars": 60000,
+      "max_ocr_pages": 10,
+      "max_image_pixels": 12000000
+    }
+  }
+}
+```
+
+신규 metadata는 optional이다.
+
+| 필드 | 의미 |
+|------|------|
+| `source_service` | `gmail`, `google_drive` 등 원천 서비스 |
+| `message_id` | Gmail message id |
+| `attachment_id` | Gmail attachment id |
+| `inline` | Gmail inline image 여부 |
+| `provider` | OCR/vision provider 이름. 현재는 `openai_vision` |
+| `languages` | OCR language hint. 기본 `["ko", "en"]` |
+| `page_count` | PDF page 수 |
+| `ocr_page_count` | OCR 결과가 나온 page 수 |
+| `image_only_pdf` | PDF text layer가 없어 OCR fallback 대상인지 여부 |
+| `partial` | 일부 page만 OCR 성공했는지 여부 |
+| `image_width`, `image_height` | 확인 가능한 이미지 pixel size |
+
+`extraction_method`는 파일 출처가 아니라 본문 생성 방식을 의미한다. Gmail attachment라도 `extraction_method`는 `pdf_text`, `docx_xml`, `csv_parse`, `ocr`, `vision`, `mixed`처럼 기록된다.
+
+---
+
+## 5. Gmail Attachment 구현
+
+Gmail message parsing 단계에서 attachment item에 아래 alias를 모두 실어 보낸다.
+
+- `messageId`, `message_id`
+- `attachmentId`, `attachment_id`
+- `mimeType`, `mime_type`
+- `source`, `source_service`
+- `inline`
+
+본문 추출 흐름:
+
+1. Gmail source가 attachment metadata를 만든다.
+2. 기본 preview 또는 metadata-only 경로에서는 `content_status=not_requested`가 유지된다.
+3. `include_content=true` preview 또는 LLM node에서 content-dependent action이 실행되면 attachment download를 시도한다.
+4. Gmail API attachment body의 `data`를 base64url decode한다.
+5. decode된 bytes를 Google Drive byte extractor와 같은 공통 extractor에 넘긴다.
+6. TXT/CSV/PDF text/DOCX/PPTX/HWPX/image/scan PDF 처리는 모두 같은 결과 계약으로 반환된다.
+
+inline image 정책:
+
+- 1차 구현에서는 Gmail inline image를 attachment 본문 추출 대상에서 제외했다.
+- 이유는 서명 이미지, 로고, tracking pixel이 많이 섞여 LLM 입력 품질과 비용을 해칠 수 있기 때문이다.
+- inline이면 `content_status=unsupported`, `content_metadata.inline=true`가 내려갈 수 있다.
+
+대용량 정책:
+
+- Gmail attachment는 다운로드 전에 Gmail metadata의 `size`가 `MAX_DOWNLOAD_BYTES`를 넘으면 다운로드하지 않고 `too_large`로 반환한다.
+- 다운로드 후 실제 bytes 크기도 다시 검사한다.
+
+---
+
+## 6. Image OCR/Vision 구현
+
+이미지 판별:
+
+- MIME이 `image/*`이거나 확장자가 `.png`, `.jpg`, `.jpeg`, `.webp`, `.bmp`, `.tif`, `.tiff`이면 image extractor 대상으로 본다.
+- 현재 pixel size 직접 확인은 PNG/BMP/JPEG에 우선 적용된다. size를 읽을 수 없는 형식은 bytes size limit과 provider limit에 맡긴다.
+
+action별 동작:
+
+| action | provider mode | `extraction_method` | `content_kind` |
+|--------|---------------|---------------------|----------------|
+| `ocr` | OCR only | `ocr` | `ocr_text` |
+| `describe_image` | Vision only | `vision` | `image_description` |
+| `summarize`, `ai_analyze` | OCR + Vision mixed | `mixed` 또는 단일 성공 method | `mixed` 또는 단일 성공 kind |
+
+`summarize`/`ai_analyze`를 mixed로 둔 이유:
+
+- 캡처 이미지나 영수증처럼 텍스트가 중요한 경우 OCR이 필요하다.
+- 차트, 사진, UI screenshot처럼 시각적 맥락이 중요한 경우 vision description이 필요하다.
+- 둘 중 하나만 쓰면 결과 품질이 크게 흔들릴 수 있어 기본은 mixed로 결정했다.
+
+provider disabled/key missing:
+
+- 기능 플래그가 꺼져 있거나 `LLM_API_KEY`가 없으면 external API를 호출하지 않는다.
+- 이 경우 `content_status=unsupported`로 반환한다.
+
+---
+
+## 7. Scan PDF OCR 구현
+
+PDF 처리 순서:
+
+1. 기존 `pypdf` text layer extraction을 먼저 실행한다.
+2. 텍스트가 있으면 기존처럼 `extraction_method=pdf_text`로 성공 반환한다.
+3. 텍스트가 없으면 scan PDF로 보고 OCR fallback을 검토한다.
+4. `ENABLE_PDF_OCR=false`이면 기존과 동일하게 `unsupported` 반환.
+5. `page_count > MAX_OCR_PAGES`이면 `too_large` 반환.
+6. PyMuPDF로 page를 PNG image로 렌더링한다.
+7. 각 page image를 image OCR provider에 넘긴다.
+8. 성공한 page text를 `[Page N]` 구분자로 합쳐 반환한다.
+
+중요한 운영 조건:
+
+- scan PDF OCR은 PDF OCR flag만 켠다고 동작하지 않는다. image OCR provider도 켜져 있어야 한다.
+- PyMuPDF가 설치되지 않은 환경에서는 page rendering을 할 수 없으므로 `unsupported`가 반환된다.
+- 일부 page만 성공하면 `content_metadata.partial=true`가 붙을 수 있다.
+
+---
+
+## 8. LLM/Preview 연결
+
+LLM node:
+
+- `SINGLE_FILE` 또는 `FILE_LIST.items[]`에 `content`가 이미 있으면 그대로 사용한다.
+- `content_status`가 `not_requested`이거나 없고, content-dependent action이면 lazy extraction을 수행한다.
+- Google Drive file은 `GoogleDriveService.extract_file_text()`를 호출한다.
+- Gmail attachment는 `GmailService.extract_attachment_text()`를 호출한다.
+- `requires_content=true`인데 추출 실패 상태라면 기존 `DOCUMENT_CONTENT_*` error로 raise한다.
+- error context에는 `filename`, `message_id`, `attachment_id`, `content_status`, `content_error`가 포함된다.
+
+Preview:
+
+- Google Drive single file preview는 기존처럼 `include_content=true`일 때만 본문 추출을 수행한다.
+- Gmail `single_email`, `new_email`, `sender_email`, `starred_email`은 `include_content=true`일 때 해당 email의 attachment content 추출을 시도한다.
+- Gmail `attachment_email`은 `FILE_LIST.items[]`에 attachment를 담고, `include_content=true`일 때 각 item에 content 결과를 붙인다.
+- Gmail `label_emails`는 email list 중심 preview라 attachment 본문 추출을 자동 수행하지 않는다.
+
+---
+
+## 9. Frontend 팀 연동 가이드
+
+Frontend는 기존 file card/content helper를 계속 재사용하면 된다.
+
+필수 표시 기준:
+
+- `content_status=available`: `content`를 본문 미리보기 또는 LLM 입력용 추출 결과로 표시한다.
+- `content_status=not_requested`: 아직 본문을 요청하지 않은 상태로 표시한다.
+- `content_status=unsupported`: 지원하지 않거나 feature flag/provider가 꺼진 상태로 안내한다.
+- `content_status=too_large`: 크기/page/pixel 제한 초과로 안내한다.
+- `content_status=empty`: 추출은 성공했지만 읽을 수 있는 텍스트가 없다고 안내한다.
+- `content_status=failed`: provider/API/parsing 실패로 안내한다.
+
+UI 주의사항:
+
+- `content`는 전체 원문이 아니라 제한된 추출 본문 또는 미리보기일 수 있다.
+- `content_error` 문구는 provider/정규화 경로에 따라 일반화될 수 있으므로, 화면 로직은 exact string이 아니라 `content_status` 중심으로 분기한다.
+- Gmail attachment는 snake_case와 camelCase alias가 함께 올 수 있다. `message_id`/`messageId`, `attachment_id`/`attachmentId`, `mime_type`/`mimeType`를 모두 허용한다.
+- `inline=true`인 Gmail image는 1차에서 추출 대상이 아니므로 attachment card에는 "inline image는 본문 추출 제외" 계열로 표시하면 된다.
+- `content_metadata.content_kind=mixed`인 image 결과는 OCR 텍스트와 이미지 설명이 합쳐진 일반 텍스트로 표시하면 된다.
+- provider 세부값은 사용자에게 직접 노출하기보다 debug/detail 영역에 두는 것을 권장한다.
+
+권장 상태 문구:
+
+| 상태 | 사용자 문구 예시 |
+|------|------------------|
+| `not_requested` | 본문은 아직 불러오지 않았습니다. |
+| `unsupported` | 현재 이 파일의 본문 추출을 지원하지 않습니다. |
+| `too_large` | 파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다. |
+| `empty` | 읽을 수 있는 텍스트를 찾지 못했습니다. |
+| `failed` | 본문을 추출하는 중 문제가 발생했습니다. |
+
+---
+
+## 10. Spring Boot 팀 연동 가이드
+
+Spring Boot는 이번 기능의 provider 세부 구현을 알 필요가 없다. 핵심은 FastAPI에서 내려온 canonical payload와 error context를 손실 없이 보존하는 것이다.
+
+보존해야 하는 필드:
+
+- `content`
+- `content_status`
+- `content_error`
+- `content_metadata`
+- `content_metadata.limits.*`
+- `nodeLogs[].error.code`
+- `nodeLogs[].error.context`
+
+Spring Boot에서 확인할 부분:
+
+- public DTO에서 camelCase 대표 필드를 만들더라도 raw `content_metadata` map은 제거하지 않는다.
+- unknown nested metadata field를 whitelist로 잘라내지 않는다.
+- `message_id`, `attachment_id`, `page_count`, `ocr_page_count`, `provider`, `languages`, `image_width`, `image_height`를 그대로 저장/조회한다.
+- `runtime_config.requires_content=true` 정책은 기존 content-dependent action 기준을 유지한다.
+- OCR/vision provider 설정값이나 provider API key를 Spring runtime payload에 넣지 않는다.
+- execution log/callback/public detail에서 `content`가 truncate될 수 있다는 기존 정책을 유지한다.
+
+권장 테스트 fixture:
+
+- Gmail attachment 추출 성공: `source_service=gmail`, `message_id`, `attachment_id`, `extraction_method=pdf_text` 보존.
+- Gmail attachment 추출 실패: `nodeLogs[].error.context.message_id`, `attachment_id`, `filename` 보존.
+- scan PDF page limit 초과: `content_status=too_large`, `limits.max_ocr_pages`, `page_count` 보존.
+- image mixed 결과: `content_kind=mixed`, `provider`, `languages` 보존.
+- provider disabled: `content_status=unsupported`를 실패 실행으로 과도하게 재분류하지 않는지 확인.
+
+---
+
+## 11. Error/Status Mapping
+
+| 상황 | `content_status` | 비고 |
+|------|------------------|------|
+| feature flag off | `unsupported` | 다운로드/provider 호출 없음 |
+| provider key missing | `unsupported` | OCR/vision provider 호출 없음 |
+| unsupported file type | `unsupported` | 기존 정책 유지 |
+| Gmail inline image | `unsupported` | 1차 범위 제외 |
+| download bytes 초과 | `too_large` | `observed_size_bytes` 기록 |
+| PDF OCR page 초과 | `too_large` | `observed_page_count`, `max_ocr_pages` 기록 |
+| image pixel 초과 | `too_large` | `observed_image_pixels`, `max_image_pixels` 기록 |
+| OCR 결과 없음 | `empty` | 추출은 실행됐지만 읽을 텍스트 없음 |
+| provider/API/parsing 예외 | `failed` | error context 보존 |
+| PDF text layer 존재 | `available` | OCR fallback 없이 `pdf_text` |
+
+---
+
+## 12. 검증 결과
+
+변경 관련 테스트:
+
+```text
+python3 -m pytest tests/test_integrations/test_google_drive.py tests/test_integrations/test_gmail.py tests/test_input_node.py tests/test_llm_node.py tests/test_preview_executor.py
+=> 93 passed
+```
+
+Scoped lint:
+
+```text
+python3 -m ruff check app/config.py app/core/document_content.py app/core/engine/preview_executor.py app/core/nodes/input_node.py app/core/nodes/llm_node.py app/services/integrations/gmail.py app/services/integrations/google_drive.py app/services/llm_service.py tests/test_input_node.py tests/test_integrations/test_gmail.py tests/test_integrations/test_google_drive.py tests/test_llm_node.py tests/test_preview_executor.py
+=> All checks passed
+```
+
+Whitespace check:
+
+```text
+git diff --check
+=> passed
+```
+
+전체 회귀:
+
+```text
+python3 -m pytest --ignore=tests/test_trigger_api.py
+=> 403 passed, 17 warnings
+```
+
+`tests/test_trigger_api.py`는 로컬 sandbox에서 MongoDB SRV DNS/network 접근이 막히는 환경 이슈가 있어 별도 네트워크 가능 환경에서 확인이 필요하다.
+
+---
+
+## 13. 잔여 리스크
+
+- OCR/vision은 비용과 latency가 크므로 운영 feature flag를 켤 때 rate limit과 timeout 관찰이 필요하다.
+- `openai_vision` provider는 confidence score를 제공하지 않으므로 `confidence`는 비어 있을 수 있다.
+- `GoogleDriveService`가 현재 공통 byte extractor 역할까지 맡고 있어 파일이 커졌다. 동작 안정화 후 별도 extractor module로 분리할 수 있다.
+- Gmail `include_content=true` preview는 대상 email의 attachment를 순차 추출한다. attachment가 많은 email에서는 preview latency가 늘 수 있다.
+- GIF/HEIC, multi-page TIFF 같은 확장 이미지 형식은 1차에서 provider/format 지원에 따라 `unsupported` 또는 provider 실패가 될 수 있다.

--- a/src/entities/execution/api/types.ts
+++ b/src/entities/execution/api/types.ts
@@ -6,6 +6,7 @@ export interface ExecutionErrorDetail {
   code: string | null;
   message: string | null;
   stackTrace: string | null;
+  context?: Record<string, unknown> | null;
 }
 
 export interface ExecutionSnapshot {

--- a/src/entities/execution/model/nodeRuntimeIssue.test.ts
+++ b/src/entities/execution/model/nodeRuntimeIssue.test.ts
@@ -104,7 +104,7 @@ describe("node runtime issue", () => {
         message: "max_download_bytes exceeded",
         stackTrace: null,
       }),
-    ).toBe("파일이 현재 처리 가능한 크기 제한을 초과했습니다.");
+    ).toBe("파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다.");
 
     expect(
       getExecutionErrorDisplayMessage({
@@ -113,5 +113,19 @@ describe("node runtime issue", () => {
         stackTrace: null,
       }),
     ).toBe("본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다.");
+  });
+
+  it("prefers document content status in error context", () => {
+    expect(
+      getExecutionErrorDisplayMessage({
+        code: "DOCUMENT_CONTENT_EXTRACTION_FAILED",
+        message: "provider returned a custom error",
+        stackTrace: null,
+        context: {
+          content_status: "unsupported",
+          content_error: "provider disabled",
+        },
+      }),
+    ).toBe("현재 이 파일의 본문 추출을 지원하지 않습니다.");
   });
 });

--- a/src/entities/execution/model/nodeRuntimeIssue.ts
+++ b/src/entities/execution/model/nodeRuntimeIssue.ts
@@ -7,9 +7,53 @@ const DEFAULT_RUNTIME_ISSUE_MESSAGE = "이 단계 실행 중 문제가 발생했
 const includesAny = (value: string, keywords: string[]) =>
   keywords.some((keyword) => value.includes(keyword));
 
+const getContextString = (
+  context: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+) => {
+  if (!context) {
+    return "";
+  }
+
+  for (const key of keys) {
+    const value = context[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim().toLowerCase();
+    }
+  }
+
+  return "";
+};
+
+const getDocumentContentStatusMessage = (status: string) => {
+  switch (status) {
+    case "empty":
+      return "읽을 수 있는 텍스트를 찾지 못했습니다.";
+    case "unsupported":
+      return "현재 이 파일의 본문 추출을 지원하지 않습니다.";
+    case "too_large":
+      return "파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다.";
+    case "failed":
+      return "본문을 추출하는 중 문제가 발생했습니다.";
+    case "not_requested":
+      return "본문이 필요한 작업이지만 본문 추출이 수행되지 않았습니다.";
+    default:
+      return "";
+  }
+};
+
 export const getExecutionErrorDisplayMessage = (
   error: ExecutionErrorDetail | null | undefined,
 ) => {
+  const contentStatus = getContextString(error?.context, [
+    "content_status",
+    "contentStatus",
+  ]);
+  const contentStatusMessage = getDocumentContentStatusMessage(contentStatus);
+  if (contentStatusMessage) {
+    return contentStatusMessage;
+  }
+
   const code = error?.code?.toLowerCase() ?? "";
   const message = error?.message?.toLowerCase() ?? "";
   const text = `${code} ${message}`;
@@ -23,7 +67,7 @@ export const getExecutionErrorDisplayMessage = (
       "본문 없음",
     ])
   ) {
-    return "파일에서 읽을 수 있는 본문을 찾지 못했습니다.";
+    return "읽을 수 있는 텍스트를 찾지 못했습니다.";
   }
 
   if (
@@ -36,7 +80,7 @@ export const getExecutionErrorDisplayMessage = (
       "지원하지 않는 형식",
     ])
   ) {
-    return "현재 지원하지 않는 파일 형식입니다.";
+    return "현재 이 파일의 본문 추출을 지원하지 않습니다.";
   }
 
   if (
@@ -46,11 +90,16 @@ export const getExecutionErrorDisplayMessage = (
       "content_too_large",
       "max_download_bytes",
       "max_extracted_chars",
+      "max_ocr_pages",
+      "max_image_pixels",
+      "page limit",
+      "pixel limit",
       "크기 제한",
       "용량 제한",
+      "페이지 수",
     ])
   ) {
-    return "파일이 현재 처리 가능한 크기 제한을 초과했습니다.";
+    return "파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다.";
   }
 
   if (
@@ -76,7 +125,7 @@ export const getExecutionErrorDisplayMessage = (
       "본문 읽기 실패",
     ])
   ) {
-    return "파일 본문을 읽는 중 문제가 발생했습니다.";
+    return "본문을 추출하는 중 문제가 발생했습니다.";
   }
 
   if (

--- a/src/widgets/node-data-panel/model/document-content.test.ts
+++ b/src/widgets/node-data-panel/model/document-content.test.ts
@@ -19,6 +19,15 @@ describe("document content helpers", () => {
       content_metadata: {
         extraction_method: "pdf_text",
         content_kind: "plain_text",
+        source_service: "gmail",
+        message_id: "msg-1",
+        attachment_id: "att-1",
+        mime_type: "application/pdf",
+        inline: "false",
+        page_count: "3",
+        ocr_page_count: 2,
+        image_width: 1200,
+        image_height: "800",
         truncated: true,
         char_count: "1200",
         original_char_count: 2400,
@@ -28,6 +37,8 @@ describe("document content helpers", () => {
           max_download_bytes: 100,
           max_extracted_chars: "2000",
           max_llm_input_chars: 3000,
+          max_ocr_pages: "10",
+          max_image_pixels: 12000000,
         },
       },
     };
@@ -42,10 +53,21 @@ describe("document content helpers", () => {
       originalCharCount: 2400,
       storedContentTruncated: true,
       storedCharCount: 1000,
+      sourceService: "gmail",
+      messageId: "msg-1",
+      attachmentId: "att-1",
+      mimeType: "application/pdf",
+      inline: false,
+      pageCount: 3,
+      ocrPageCount: 2,
+      imageWidth: 1200,
+      imageHeight: 800,
       limits: {
         maxDownloadBytes: 100,
         maxExtractedChars: 2000,
         maxLlmInputChars: 3000,
+        maxOcrPages: 10,
+        maxImagePixels: 12000000,
       },
     });
   });
@@ -63,12 +85,35 @@ describe("document content helpers", () => {
           maxDownloadBytes: 2048,
           maxExtractedChars: 4000,
           maxLlmInputChars: 3000,
+          maxOcrPages: 8,
+          maxImagePixels: 1000000,
         },
       },
     };
 
     expect(getDocumentContentStatus(data)).toBe("too_large");
     expect(getDocumentContentMetadata(data).limits.maxDownloadBytes).toBe(2048);
+    expect(getDocumentContentMetadata(data).limits.maxOcrPages).toBe(8);
+  });
+
+  it("reads Gmail attachment aliases from top-level payload", () => {
+    const metadata = getDocumentContentMetadata({
+      messageId: "camel-message",
+      attachment_id: "snake-attachment",
+      mimeType: "image/png",
+      source: "gmail",
+      inline: true,
+      content_metadata: {
+        content_kind: "mixed",
+      },
+    });
+
+    expect(metadata.sourceService).toBe("gmail");
+    expect(metadata.messageId).toBe("camel-message");
+    expect(metadata.attachmentId).toBe("snake-attachment");
+    expect(metadata.mimeType).toBe("image/png");
+    expect(metadata.inline).toBe(true);
+    expect(metadata.contentKind).toBe("mixed");
   });
 
   it("falls back to legacy extracted text", () => {
@@ -88,12 +133,23 @@ describe("document content helpers", () => {
           charCount: null,
           contentKind: null,
           extractionMethod: null,
+          imageHeight: null,
+          imageWidth: null,
+          inline: false,
           limits: {
             maxDownloadBytes: null,
             maxExtractedChars: null,
             maxLlmInputChars: null,
+            maxImagePixels: null,
+            maxOcrPages: null,
           },
+          messageId: null,
+          attachmentId: null,
+          mimeType: null,
+          ocrPageCount: null,
           originalCharCount: null,
+          pageCount: null,
+          sourceService: null,
           storedCharCount: null,
           storedContentTruncated: true,
           truncated: false,
@@ -101,6 +157,32 @@ describe("document content helpers", () => {
         status: "available",
       }),
     ).toBe("실행 로그에는 일부 본문만 저장되었습니다.");
+  });
+
+  it("uses status-based document content descriptions", () => {
+    const baseMetadata = getDocumentContentMetadata({});
+
+    expect(
+      getDocumentContentStatusDescription({
+        error: "raw backend text",
+        metadata: baseMetadata,
+        status: "not_requested",
+      }),
+    ).toBe("본문은 아직 불러오지 않았습니다.");
+    expect(
+      getDocumentContentStatusDescription({
+        error: "different raw backend text",
+        metadata: baseMetadata,
+        status: "too_large",
+      }),
+    ).toBe("파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다.");
+    expect(
+      getDocumentContentStatusDescription({
+        error: "",
+        metadata: getDocumentContentMetadata({ inline: true }),
+        status: "unsupported",
+      }),
+    ).toBe("inline image는 본문 추출 대상이 아닙니다.");
   });
 
   it("reads preview content policy metadata", () => {

--- a/src/widgets/node-data-panel/model/document-content.ts
+++ b/src/widgets/node-data-panel/model/document-content.ts
@@ -25,10 +25,21 @@ export type DocumentContentMetadata = {
   originalCharCount: number | null;
   storedContentTruncated: boolean;
   storedCharCount: number | null;
+  sourceService: string | null;
+  messageId: string | null;
+  attachmentId: string | null;
+  mimeType: string | null;
+  inline: boolean;
+  pageCount: number | null;
+  ocrPageCount: number | null;
+  imageWidth: number | null;
+  imageHeight: number | null;
   limits: {
     maxDownloadBytes: number | null;
     maxExtractedChars: number | null;
     maxLlmInputChars: number | null;
+    maxOcrPages: number | null;
+    maxImagePixels: number | null;
   };
 };
 
@@ -81,8 +92,23 @@ const getNestedRecord = (record: DataRecord, ...keys: string[]) => {
 const getString = (value: unknown) =>
   typeof value === "string" && value.trim().length > 0 ? value.trim() : "";
 
-const getBoolean = (value: unknown) =>
-  typeof value === "boolean" ? value : null;
+const getBoolean = (value: unknown) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalizedValue = value.trim().toLowerCase();
+    if (normalizedValue === "true") {
+      return true;
+    }
+    if (normalizedValue === "false") {
+      return false;
+    }
+  }
+
+  return null;
+};
 
 const getNumber = (value: unknown) => {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -163,6 +189,7 @@ export const getDocumentContentText = (value: unknown) => {
 export const getDocumentContentMetadata = (
   value: unknown,
 ): DocumentContentMetadata => {
+  const source = isRecord(value) ? value : {};
   const metadata = isRecord(value)
     ? (getNestedRecord(value, "content_metadata", "contentMetadata") ?? {})
     : {};
@@ -188,6 +215,29 @@ export const getDocumentContentMetadata = (
       "stored_char_count",
       "storedCharCount",
     ]),
+    sourceService:
+      getFirstString(metadata, ["source_service", "sourceService"]) ||
+      getFirstString(source, ["source_service", "sourceService", "source"]) ||
+      null,
+    messageId:
+      getFirstString(metadata, ["message_id", "messageId"]) ||
+      getFirstString(source, ["message_id", "messageId"]) ||
+      null,
+    attachmentId:
+      getFirstString(metadata, ["attachment_id", "attachmentId"]) ||
+      getFirstString(source, ["attachment_id", "attachmentId"]) ||
+      null,
+    mimeType:
+      getFirstString(metadata, ["mime_type", "mimeType"]) ||
+      getFirstString(source, ["mime_type", "mimeType"]) ||
+      null,
+    inline:
+      getFirstBoolean(metadata, ["inline"]) ||
+      getFirstBoolean(source, ["inline"]),
+    pageCount: getFirstNumber(metadata, ["page_count", "pageCount"]),
+    ocrPageCount: getFirstNumber(metadata, ["ocr_page_count", "ocrPageCount"]),
+    imageWidth: getFirstNumber(metadata, ["image_width", "imageWidth"]),
+    imageHeight: getFirstNumber(metadata, ["image_height", "imageHeight"]),
     limits: {
       maxDownloadBytes: getFirstNumber(limits, [
         "max_download_bytes",
@@ -201,6 +251,11 @@ export const getDocumentContentMetadata = (
         "max_llm_input_chars",
         "maxLlmInputChars",
       ]),
+      maxOcrPages: getFirstNumber(limits, ["max_ocr_pages", "maxOcrPages"]),
+      maxImagePixels: getFirstNumber(limits, [
+        "max_image_pixels",
+        "maxImagePixels",
+      ]),
     },
   };
 };
@@ -210,17 +265,17 @@ export const getDocumentContentStatusLabel = (
 ) => {
   switch (status) {
     case "available":
-      return "본문 읽기 완료";
+      return "본문 추출 성공";
     case "empty":
-      return "읽을 수 있는 본문 없음";
+      return "텍스트 없음";
     case "unsupported":
-      return "지원하지 않는 파일 형식";
+      return "본문 추출 미지원";
     case "too_large":
-      return "파일 크기 제한 초과";
+      return "처리 제한 초과";
     case "failed":
-      return "본문 읽기 실패";
+      return "본문 추출 실패";
     case "not_requested":
-      return "본문 미포함";
+      return "본문 미요청";
     default:
       return "";
   }
@@ -235,23 +290,32 @@ export const getDocumentContentStatusDescription = ({
   metadata: DocumentContentMetadata;
   status: DocumentContentStatus | null;
 }) => {
-  if (error) {
-    return error;
-  }
+  switch (status) {
+    case "available":
+      if (metadata.storedContentTruncated) {
+        return "실행 로그에는 일부 본문만 저장되었습니다.";
+      }
 
-  if (status === "too_large") {
-    return "현재 처리 가능한 크기를 초과했습니다.";
-  }
+      if (metadata.truncated) {
+        return "본문 일부만 표시됩니다.";
+      }
 
-  if (metadata.storedContentTruncated) {
-    return "실행 로그에는 일부 본문만 저장되었습니다.";
+      return "";
+    case "not_requested":
+      return "본문은 아직 불러오지 않았습니다.";
+    case "unsupported":
+      return metadata.inline
+        ? "inline image는 본문 추출 대상이 아닙니다."
+        : "현재 이 파일의 본문 추출을 지원하지 않습니다.";
+    case "too_large":
+      return "파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다.";
+    case "empty":
+      return "읽을 수 있는 텍스트를 찾지 못했습니다.";
+    case "failed":
+      return "본문을 추출하는 중 문제가 발생했습니다.";
+    default:
+      return error ?? "";
   }
-
-  if (metadata.truncated) {
-    return "본문 일부만 표시됩니다.";
-  }
-
-  return "";
 };
 
 export const isDocumentContentProblem = (

--- a/src/widgets/node-data-panel/ui/DataPreviewBlock.test.tsx
+++ b/src/widgets/node-data-panel/ui/DataPreviewBlock.test.tsx
@@ -46,9 +46,47 @@ describe("DataPreviewBlock", () => {
 
     expect(html).toContain("본문 포함 미리보기");
     expect(html).toContain("다음 단계에서 본문 필요");
-    expect(html).toContain("본문 읽기 완료 1개");
-    expect(html).toContain("파일 크기 제한 초과 1개");
-    expect(html).toContain("본문: 요약 가능한 본문입니다.");
-    expect(html).toContain("limit exceeded");
+    expect(html).toContain("본문 추출 성공 1개");
+    expect(html).toContain("처리 제한 초과 1개");
+    expect(html).toContain("본문 미리보기: 요약 가능한 본문입니다.");
+    expect(html).toContain(
+      "파일이 현재 처리 가능한 크기나 페이지 수를 초과했습니다.",
+    );
+    expect(html).not.toContain("limit exceeded");
+  });
+
+  it("shows Gmail inline image and mixed image extraction results safely", () => {
+    const html = renderDataPreviewBlock({
+      data: {
+        type: "SINGLE_EMAIL",
+        email: {
+          subject: "첨부 메일",
+          attachments: [
+            {
+              filename: "signature.png",
+              mimeType: "image/png",
+              messageId: "msg-1",
+              attachment_id: "att-1",
+              inline: true,
+              content_status: "unsupported",
+            },
+            {
+              filename: "receipt.png",
+              mime_type: "image/png",
+              content_status: "available",
+              content: "OCR 결과와 이미지 설명이 함께 들어간 텍스트입니다.",
+              content_metadata: {
+                content_kind: "mixed",
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(html).toContain("inline image는 본문 추출 대상이 아닙니다.");
+    expect(html).toContain(
+      "첨부 본문 미리보기: OCR 결과와 이미지 설명이 함께 들어간 텍스트입니다.",
+    );
   });
 });

--- a/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
+++ b/src/widgets/node-data-panel/ui/DataPreviewBlock.tsx
@@ -249,7 +249,7 @@ const DocumentContentInlinePreview = ({
 const FileItemCard = ({
   item,
   index,
-  contentLabel = "본문",
+  contentLabel = "본문 미리보기",
 }: {
   item: DataRecord;
   index: number;
@@ -498,7 +498,7 @@ const SingleEmailPreview = ({ data }: { data: DataRecord }) => {
               key={`${getString(item.filename)}-${index}`}
               item={item}
               index={index}
-              contentLabel="첨부 본문"
+              contentLabel="첨부 본문 미리보기"
             />
           ))}
         </Box>


### PR DESCRIPTION
## Summary
- add Gmail attachment/OCR/Vision follow-up and implementation handoff docs
- update document content UI helpers to rely on content_status and read Gmail attachment aliases
- show inline image, too_large, mixed OCR/vision, and extraction failure states with stable user-facing messages

## Tests
- vitest run --passWithNoTests
- eslint --cache --fix .
- tsc --noEmit