### PR TITLE
[PR]Feat#196 workflow editor rosponsive UI fix

### DIFF
--- a/.docs/RESPONSIVE_UI_FIX_PLAN.md
+++ b/.docs/RESPONSIVE_UI_FIX_PLAN.md
@@ -474,6 +474,15 @@ Issue 18의 목표는 Flowify Frontend 워크플로우 에디터 화면에서 vi
 | 1920px FHD | 90%, 100%, 125% | wide/compact 전환 안정성, panel height, selected node focus |
 | 2560px QHD | 90%, 100%, 125% | wide layout 안정성, panel이 과하게 벌어지지 않는지, zoom consistency |
 
+## Step 5 QA 기록
+
+- 1366px, 1440px, 1920px FHD, 2560px QHD 크기는 `src/shared/libs/dual-panel-layout.test.ts`의 safe area boundary 테스트로 자동 검증한다.
+- browser zoom 125%처럼 CSS viewport가 줄어드는 경우를 보완하기 위해 1093px x 614px layout boundary 케이스를 함께 검증한다.
+- 노드 선택 zoom/center는 `Canvas.tsx`에서 시작 placeholder, 도착 placeholder, 일반 노드가 모두 동일한 `NODE_FOCUS_ZOOM`과 `focusNode`/`focusCanvasPoint` 경로를 사용하도록 정리했다.
+- 패널 open 상태에서는 `dual-panel-layout.ts`의 `getSafeCenteredPosition()` 기준으로 editor canvas safe area 안에 위치를 고정한다.
+- 패널 내부 콘텐츠 overflow는 `InputPanel`, `OutputPanel`, `ServiceSelectionPanel`에서 outer panel은 숨기고 body 영역만 scroll 되도록 정리했다.
+- 실제 브라우저 확대율별 visual screenshot 검증은 별도 Playwright/브라우저 QA 도구가 준비되면 후속으로 보강한다.
+
 # 7. 위험 요소 및 후속 작업
 
 ## 구현 중 깨질 수 있는 부분

--- a/.docs/RESPONSIVE_UI_FIX_PLAN.md
+++ b/.docs/RESPONSIVE_UI_FIX_PLAN.md
@@ -1,0 +1,508 @@
+# 1. 작업 개요
+
+## 목적
+
+Issue 18의 목표는 Flowify Frontend 워크플로우 에디터 화면에서 viewport 크기와 브라우저 확대 비율에 따라 패널, 캔버스, 노드 포커싱이 어색하게 보이는 문제를 수정하는 것이다. 이번 문서는 실제 구현 전에 현재 구조와 원인 후보를 정리하고, 이후 구현에서 따라야 할 수정 기준을 정의한다.
+
+## 수정 대상 화면
+
+- 워크플로우 에디터 페이지: `src/pages/workflow-editor/WorkflowEditorPage.tsx`
+- React Flow 기반 캔버스: `src/widgets/canvas/ui/Canvas.tsx`
+- 입력/출력/선택/설정 패널: `src/widgets/input-panel/ui/InputPanel.tsx`, `src/widgets/output-panel/ui/OutputPanel.tsx`, `src/features/add-node/ui/ServiceSelectionPanel.tsx`, `src/features/configure-node/ui/**`
+- 에디터 상단/원격 조작 UI: `src/widgets/editor-remote-bar/ui/**`
+
+## 이번 작업에서 해결하려는 문제
+
+- FHD, QHD, 1366px, 1440px 등 화면 폭/높이에 따라 패널과 캔버스가 어색하게 배치되는 문제
+- 패널이 화면 밖으로 나가거나 겹치는 문제
+- 시작 노드, 중간 노드, 도착 노드 선택 시 zoom과 center 기준이 달라지는 문제
+- 패널 border-radius가 과하게 커서 SaaS 도구 화면보다 둥글게 보이는 문제
+- 제목, 본문, 라벨, 버튼 텍스트 크기가 화면 크기에 따라 어색하게 보이는 문제
+
+## 이번 설계에서 제외하는 범위
+
+- 워크플로우 저장, 수정, 실행 API 연동 변경
+- OAuth, connector, template 데이터 구조 변경
+- React Flow 노드/엣지 데이터 모델 변경
+- Slack 제거 작업과 관련된 기능 변경
+- 신규 기능 추가나 화면 전면 리디자인
+- 공통 node/template/picker abstraction 변경
+
+# 2. 현재 구조 분석
+
+## 관련 컴포넌트 목록
+
+| 파일 | 역할 | 반응형 이슈와의 관련성 |
+| --- | --- | --- |
+| `src/pages/workflow-editor/WorkflowEditorPage.tsx` | 워크플로우 에디터 페이지의 최상위 composition. `ReactFlowProvider`, `Canvas`, `EditorRemoteBar`, `ServiceSelectionPanel`, `InputPanel`, `OutputPanel`을 배치한다. | 에디터 전체 높이, `overflow="hidden"`, 상대 위치 기준을 제공한다. |
+| `src/widgets/canvas/ui/Canvas.tsx` | React Flow 캔버스, 노드 클릭, placeholder 선택, fitView, setCenter 로직을 담당한다. | 노드 선택 시 zoom/center 불일치의 핵심 위치다. |
+| `src/widgets/input-panel/ui/InputPanel.tsx` | source 설정/입력 패널을 absolute 위치로 렌더링한다. | panel width, height, top, left, radius, overflow가 직접 지정된다. |
+| `src/widgets/output-panel/ui/OutputPanel.tsx` | sink 설정, 실행 결과, 노드 데이터 보기 패널을 absolute 위치로 렌더링한다. | panel width, height, top, left, radius, overflow가 직접 지정된다. |
+| `src/features/add-node/ui/ServiceSelectionPanel.tsx` | 시작 노드/다음 노드/도착 노드 선택 UI를 렌더링한다. | 시작 노드 선택 UI는 `flowToScreenPosition`과 clamp를 사용하고, 도착 노드 선택 UI는 dual panel layout을 사용한다. |
+| `src/features/configure-node/ui/PanelRenderer.tsx` | 노드 타입에 맞는 설정 패널을 선택한다. | 패널 내부 콘텐츠 높이와 overflow에 영향을 준다. |
+| `src/features/configure-node/ui/panels/NodePanelShell.tsx` | 설정 패널 공통 shell이다. | Heading, description, gap 등 패널 내부 typography와 spacing 기준이 있다. |
+| `src/entities/node/ui/BaseNode.tsx` | 일반 노드 카드 UI를 렌더링한다. | 노드 radius, title/body font-size, node click 경로와 관련된다. |
+| `src/entities/node/ui/custom-nodes/**` | Start, End, Placeholder 등 커스텀 노드 UI를 렌더링한다. | 시작/도착/placeholder 노드 크기와 center 계산 기준에 영향을 준다. |
+| `src/features/workflow-editor/model/workflowStore.ts` | active panel, placeholder, layout state를 관리한다. | UI 상태 전환은 담당하지만 저장/실행 API 변경 대상은 아니다. |
+
+## 관련 스타일 파일 목록
+
+| 파일 | 역할 |
+| --- | --- |
+| `src/shared/libs/dual-panel-layout.ts` | editor canvas 크기를 기준으로 wide, compact, stacked layout을 계산한다. |
+| `src/shared/styles/token/size/layout-token.ts` | panel width, height, gap, safe padding, wide/compact 기준값을 정의한다. |
+| `src/shared/theme/config/style-system-config.ts` | Chakra system config와 token 연결점이다. |
+| `src/shared/theme/global/global-style.ts` | 전역 body, scrollbar, selection 스타일을 정의한다. |
+| `src/shared/styles/token/colors/**` | 색상 token과 semantic token을 정의한다. |
+| 각 컴포넌트의 Chakra props | `borderRadius`, `fontSize`, `gap`, `px`, `py`, `boxShadow` 등 상당수가 inline prop으로 흩어져 있다. |
+
+## 노드 선택/확대/중앙 정렬 관련 로직 위치
+
+- `src/widgets/canvas/ui/Canvas.tsx`
+  - `useReactFlow()`에서 `fitView`, `getZoom`, `setCenter`를 사용한다.
+  - `handleNodeClick`
+    - `placeholder-start` 선택 시 `window.innerWidth * 0.2`를 더한 x 좌표로 `setCenter(..., { zoom: 1, duration: 300 })`를 호출한다.
+    - 일반 노드 선택 시 `openPanel(node.id, { mode: "view" })`를 호출하고, 실제 center 이동은 `activePanelNodeId` effect에서 처리된다.
+  - `handleSelectSinkNode`
+    - 도착 노드 preview center를 계산해 `setCenter(..., { zoom: 1, duration: 300 })`를 호출한다.
+  - `activePanelNodeId` effect
+    - 도착 노드는 해당 노드 중심으로 이동한다.
+    - 도착 노드가 아닌 경우 `getChainNodes(activePanelNodeId)`와 `getNodesBoundsCenter(chainNodes)`를 사용해 연결된 노드 묶음 중심으로 이동한다.
+    - zoom은 `getZoom()`을 유지한다.
+  - `pendingAutoLayoutFit` effect
+    - active panel, placeholder, next step이 없을 때 `fitView({ padding: 0.2 })`를 실행한다.
+
+## 시작 노드, 중간 노드, 도착 노드 선택 처리 방식
+
+- 시작 placeholder 선택은 `handleNodeClick` 내부에서 별도 branch로 처리되고, viewport 폭 기반 offset과 zoom 1이 적용된다.
+- 중간 노드 또는 일반 노드 선택은 panel open 이후 `activePanelNodeId` effect에서 처리되며, 현재 zoom을 유지한다.
+- 도착 노드 선택은 일반 노드 선택 branch 이후 `activePanelNodeId` effect에서 단일 노드 중심으로 이동한다.
+- 도착 placeholder 선택은 `handleSelectSinkNode`에서 별도 branch로 처리되고, preview center와 zoom 1이 적용된다.
+- 따라서 선택 대상의 종류에 따라 center 기준과 zoom 기준이 분리되어 있다.
+
+## 패널 레이아웃 관련 로직 위치
+
+- `src/shared/libs/dual-panel-layout.ts`
+  - `useDualPanelLayout()`이 `EDITOR_CANVAS_AREA_ID` element 크기를 `ResizeObserver`와 window resize로 추적한다.
+  - `getDualPanelLayout(targetSize)`가 wide, compact, stacked 모드를 결정한다.
+  - panel left/top, width/height, chain center를 계산한다.
+- `src/shared/styles/token/size/layout-token.ts`
+  - `basePanelWidth: 690`, `basePanelHeight: 800`, `baseGap: 296`
+  - `compactMinPanelWidth: 520`, `compactMinPanelHeight: 640`, `compactMinGap: 160`
+  - `safePaddingX: 24`, `safePaddingY: 24`
+  - `wideMinCanvasWidth: 1760`, `wideMinCanvasHeight: 864`
+  - `compactMinCanvasWidth: 1280`, `compactMinCanvasHeight: 720`
+- `InputPanel.tsx`, `OutputPanel.tsx`
+  - `useDualPanelLayout()` 결과를 absolute `top`, `left`, `width`, `height`에 적용한다.
+  - 패널 내부는 `overflowY="auto"`로 처리한다.
+- `ServiceSelectionPanel.tsx`
+  - 시작 선택 UI는 wrapper 크기를 측정해 overlay 안에서 clamp한다.
+  - 도착 선택 UI는 dual panel layout의 output panel 위치와 크기를 사용한다.
+
+## 글자 크기/spacing/radius 관련 스타일 위치
+
+- `InputPanel.tsx`, `OutputPanel.tsx`
+  - `borderRadius="20px"`, `fontSize="xl"`, `letterSpacing="-0.4px"`, `px={3}`, `py={6}`가 직접 지정되어 있다.
+- `ServiceSelectionPanel.tsx`
+  - 선택 패널과 검색 UI에서 `borderRadius="20px"`, 일부 `fontSize="24px"`, `fontSize="sm"` 등이 직접 지정되어 있다.
+- `BaseNode.tsx`
+  - node container는 `borderRadius="xl"`, icon container는 큰 원형/rounded 스타일, title은 `fontSize="lg"`, meta는 `xs` 계열을 사용한다.
+- `NodePanelShell.tsx`와 configure panel 파일들
+  - Chakra `Heading size="md"`, `Text fontSize="sm"`, `gap`, `Stack` spacing 등이 패널 내부별로 분산되어 있다.
+- 현재 확인 기준으로 radius/font-size 전용 design token은 명확히 분리되어 있지 않고, layout token 중심으로만 공통화되어 있다.
+
+## 반응형 breakpoint 또는 viewport 대응 로직
+
+- 에디터 핵심 패널은 Chakra breakpoint보다 `useDualPanelLayout()`의 pixel threshold 기반 custom layout을 사용한다.
+- `EditorRemoteBar`와 일부 설정 패널은 Chakra responsive prop인 `base`, `md`, `xl`, `2xl`를 사용한다.
+- `ServiceSelectionPanel`의 시작 선택 UI는 screen position과 measured size를 기준으로 viewport boundary clamp를 수행한다.
+- 전역적으로 scrollbar가 숨겨져 있어 overflow가 발생해도 사용자가 스크롤 가능 영역을 인지하기 어렵다.
+
+## 기존 workflow 저장/실행/API 연동과 관련 없는 UI 레이아웃 범위
+
+- 변경 대상은 React Flow viewport 이동, panel positioning, panel sizing, visual token 적용, typography/radius 정리에 한정한다.
+- `workflowStore`는 active UI state를 읽거나 dispatch하는 수준으로만 다룬다.
+- 다음 영역은 이번 이슈에서 변경하지 않는다.
+  - workflow query/mutation, hydrate/sync, save/execute API 호출
+  - node data schema, template schema, connector schema
+  - OAuth 연결과 token 처리
+  - backend contract
+
+# 3. 문제별 원인 후보
+
+## FHD 화면에서 UI가 깨지는 원인 후보
+
+- wide layout 진입 기준이 `1760 x 864`인데, FHD viewport라도 앱 shell, header, browser zoom, OS scaling 이후 실제 editor canvas height가 864px보다 작아질 수 있다.
+- `basePanelWidth 690`, `baseGap 296`, 좌우 safe padding을 합치면 wide layout의 가로 여유가 빠듯하다.
+- panel height가 800px 고정에 가깝게 계산되어 FHD에서 세로 여유가 부족할 수 있다.
+- React Flow canvas와 absolute panel이 같은 상대 container 안에 있으나, panel open/close transform이 layout mode별로 다르게 적용되어 전환 중 겹침이 보일 수 있다.
+
+## 패널이 화면 밖으로 나가는 원인 후보
+
+- `InputPanel`과 `OutputPanel`은 `top`, `left`, `width`, `height`를 계산값 그대로 사용하므로 최종 DOM 크기와 viewport boundary 사이에 추가 clamp가 없다.
+- `boxShadow`, padding, border, transform까지 포함한 실제 렌더링 영역이 계산된 panel box보다 커질 수 있다.
+- closed/open transition의 translate 값이 wide/stacked 모드별로 다르고, 작은 화면에서 off-screen 방향이 과하게 적용될 수 있다.
+- 패널 내부 content가 길 때 `overflowY="auto"`는 있지만 전역 scrollbar 숨김 때문에 overflow 상태가 시각적으로 드러나지 않는다.
+
+## 노드 선택 시 확대 비율이 다르게 적용되는 원인 후보
+
+- 시작 placeholder와 도착 placeholder는 `setCenter(..., { zoom: 1 })`을 사용한다.
+- 일반 노드와 도착 노드는 `activePanelNodeId` effect에서 `zoom: getZoom()`을 사용해 현재 zoom을 유지한다.
+- `fitView`가 auto layout 이후 padding 0.2로 실행되므로 이후 선택 시점의 current zoom이 workflow 크기에 따라 달라질 수 있다.
+- 노드 종류별 handler가 분리되어 있어 focus 정책이 한 곳에서 관리되지 않는다.
+
+## 선택된 노드가 중앙에 오지 않는 원인 후보
+
+- 시작 placeholder는 `window.innerWidth * 0.2` offset을 x 좌표에 더해 center가 실제 노드 중심에서 벗어난다.
+- 일반 중간 노드는 선택된 노드 중심이 아니라 `getChainNodes()` 결과의 bounds center를 사용한다.
+- 도착 노드는 단일 노드 중심을 사용하므로 중간 노드와 기준이 다르다.
+- React Flow 좌표계와 DOM screen 좌표계가 섞여 사용되는 branch가 있어 panel 상태와 viewport 상태에 따라 결과가 달라질 수 있다.
+
+## 패널 border-radius가 과하게 보이는 원인 후보
+
+- 주요 패널에 `borderRadius="20px"`가 반복 적용되어 큰 크기의 도구 패널이 카드처럼 둥글게 보인다.
+- 일부 내부 UI는 `28px`, `32px`, `40px`, `999px` 계열의 radius를 사용해 전체 인상이 더 부드럽게 치우친다.
+- radius 기준이 panel, card, button, input, pill로 분리되어 있지 않아 같은 화면에서 둥근 정도가 누적된다.
+
+## 글자 크기가 화면 크기별로 어색한 원인 후보
+
+- 패널 제목에 `fontSize="xl"` 또는 `24px`가 쓰이고, FHD나 browser zoom 125%에서 panel 내부 밀도가 낮아질 수 있다.
+- node title은 `lg`, panel body는 `sm`, helper는 `xs` 등 Chakra scale을 쓰지만 화면별 hierarchy 기준이 문서화되어 있지 않다.
+- 일부 텍스트에 negative letter spacing이 있어 작은 크기나 확대 환경에서 가독성이 흔들릴 수 있다.
+- layout은 viewport 크기에 따라 바뀌지만 typography는 mode별 기준 없이 고정되어 있다.
+
+# 4. 수정 설계
+
+## 4-1. 노드 선택 zoom/center 통일 설계
+
+### 기준
+
+- 시작 노드, 중간 노드, 도착 노드, placeholder 선택 모두 동일한 focus policy를 사용한다.
+- 사용자가 "선택한 노드"가 화면 중앙에 오는 것을 기본 기준으로 삼는다.
+- 선택 시 zoom은 노드 종류와 무관하게 하나의 상수로 통일한다.
+  - 제안값: `EDITOR_NODE_FOCUS_ZOOM = 1`
+  - transition: `EDITOR_NODE_FOCUS_DURATION_MS = 300`
+- 사용자가 직접 zoom 조작 중인 상태를 보존해야 한다는 별도 요구가 생기기 전까지, 선택 focus는 일관성을 우선한다.
+
+### 공통 함수화 제안
+
+- `Canvas.tsx` 내부에 흩어진 `setCenter` 호출을 공통 helper로 묶는다.
+- 구현 파일 후보:
+  - 작은 변경: `src/widgets/canvas/ui/Canvas.tsx` 내부 `focusNodeCenter()` 함수로 시작
+  - 재사용 필요 시: `src/widgets/canvas/lib/focus-node-viewport.ts`
+- 공통 함수가 받을 값:
+  - `node.position`
+  - `node.measured.width`, `node.measured.height`, 없으면 type별 fallback size
+  - `zoom`, `duration`
+- 함수 책임:
+  - React Flow 좌표계 기준 node center 계산
+  - `setCenter(centerX, centerY, { zoom: EDITOR_NODE_FOCUS_ZOOM, duration })` 호출
+  - `window.innerWidth` 기반 offset 제거
+
+### 선택 유형별 적용
+
+- 시작 placeholder
+  - 기존 `window.innerWidth * 0.2` offset을 제거한다.
+  - placeholder node의 React Flow 중심 좌표를 기준으로 focus한다.
+- 중간 노드
+  - `getChainNodes()` bounds center가 아니라 선택한 node center를 기준으로 focus한다.
+  - chain 전체를 보여줘야 하는 UX가 필요하면 별도 action인 "fit chain"으로 분리한다.
+- 도착 노드
+  - 중간 노드와 동일한 node center focus를 사용한다.
+- 도착 placeholder
+  - preview placeholder의 center 좌표를 같은 helper로 넘긴다.
+
+### React Flow API 사용 기준
+
+- 선택 focus: `setCenter(centerX, centerY, { zoom, duration })`
+- 전체 workflow 자동 맞춤: 기존처럼 `fitView({ padding })`를 유지하되, node selection focus와 충돌하지 않도록 조건을 명확히 한다.
+- `fitView`는 workflow load, auto layout 완료, 사용자가 명시적으로 전체 보기 버튼을 누른 경우에만 사용한다.
+- active panel이 열린 뒤 자동 `fitView`가 다시 실행되어 선택 focus를 덮어쓰지 않도록 `pendingAutoLayoutFit` 조건을 재확인한다.
+
+## 4-2. 패널 viewport boundary 설계
+
+### 기준
+
+- 모든 panel은 editor canvas area 내부의 safe boundary를 넘지 않아야 한다.
+- safe padding은 기존 `layoutToken.panel.safePaddingX/Y`를 우선 사용한다.
+- panel 크기는 base size를 목표로 하되, 실제 viewport가 작으면 `availableWidth`, `availableHeight` 안에서 축소한다.
+- panel 내부 콘텐츠가 길어질 경우 panel 자체는 화면 안에 유지하고 내부 영역만 scroll 처리한다.
+
+### max-width, max-height, overflow, position 기준
+
+- `width`
+  - `min(targetPanelWidth, availableWidth)`
+  - compact 이하에서는 최소 사용 가능 폭을 보장하되, 화면 밖으로 나갈 경우 stacked layout으로 전환한다.
+- `height`
+  - `min(targetPanelHeight, availableHeight)`
+  - panel header/footer가 있는 경우 body 영역에 `minHeight: 0`, `overflowY: auto`를 적용한다.
+- `position`
+  - 기존 absolute positioning은 유지하되, 최종 `left`, `top`을 safe boundary 안으로 clamp한다.
+  - clamp 기준은 `0 + safePadding`부터 `containerSize - panelSize - safePadding`까지로 둔다.
+- `transform`
+  - open 상태에서는 panel이 boundary 안에 있어야 한다.
+  - closed transition은 시각적 퇴장만 담당하고, open layout 계산과 섞이지 않게 한다.
+- `overflow`
+  - panel container는 `overflow: hidden` 또는 border clipping을 담당한다.
+  - content body는 `overflowY: auto`를 담당한다.
+  - 전역 scrollbar 숨김 정책 때문에 panel body에는 별도 scroll affordance를 줄지 검토한다.
+
+### 화면 크기별 대응
+
+- 1366px
+  - wide layout을 강제하지 않는다.
+  - compact 또는 stacked layout을 사용한다.
+  - 단일 panel width는 editor area의 safe boundary 안에 들어오게 한다.
+- 1440px
+  - compact layout을 기본으로 고려한다.
+  - input/output 동시 노출이 어렵다면 stacked 또는 한쪽 panel 우선 노출 정책을 유지한다.
+- 1920px FHD
+  - editor canvas의 실제 height가 충분하면 wide layout을 사용한다.
+  - browser zoom 125% 또는 header로 인해 height가 부족하면 compact layout으로 자연스럽게 내려간다.
+  - wide 기준을 viewport 전체가 아니라 editor canvas area 기준으로 판단한다.
+- 2560px QHD
+  - wide layout을 안정적으로 사용한다.
+  - panel width를 무한히 늘리지 않고 base width를 유지해 SaaS 도구 화면의 밀도를 유지한다.
+
+## 4-3. 패널 radius 조정 설계
+
+### 현재 과하게 보이는 부분
+
+- `InputPanel.tsx`, `OutputPanel.tsx`, `ServiceSelectionPanel.tsx`의 큰 panel radius 20px
+- 큰 검색/선택 영역과 카드성 UI의 20px 이상 radius
+- 버튼, badge, icon container, pill 성격 UI가 한 화면에서 모두 큰 radius를 사용해 전체 톤이 지나치게 둥글게 보이는 부분
+
+### 조정 기준 제안
+
+- panel/surface: 10px 또는 12px
+- repeated card: 8px
+- button/control/input: 6px 또는 8px
+- icon button: 6px 또는 원형이 필요한 경우에만 999px
+- badge/pill/status chip: 999px 허용
+
+### 적용 방향
+
+- 기존 Flowify의 깔끔한 SaaS 스타일을 유지하기 위해 큰 panel부터 radius를 낮춘다.
+- radius를 한 번에 전역 변경하지 않고 workflow editor 범위의 panel부터 정리한다.
+- 추후 공통화가 필요하면 `src/shared/styles/token/size` 또는 theme token에 radius 기준을 추가한다.
+- 카드 안에 또 다른 카드처럼 보이는 중첩 surface는 줄이고, panel 내부는 border/divider/spacing으로 hierarchy를 만든다.
+
+## 4-4. 글자 크기 조정 설계
+
+### 타입 기준 제안
+
+| 용도 | 권장 크기 | 적용 후보 |
+| --- | --- | --- |
+| 패널 제목 | 18px 또는 Chakra `lg` | 입력/출력/선택 패널 title |
+| 섹션 제목 | 16px 또는 Chakra `md` | 설정 패널 section heading |
+| 본문 | 14px 또는 Chakra `sm` | 설명, field body |
+| 보조 설명 | 12px 또는 Chakra `xs` | helper, meta text |
+| 버튼/라벨 | 13px 또는 14px | action button, form label |
+| 노드 title | 14px 또는 16px | BaseNode title, placeholder title |
+
+### px/rem/clamp 사용 기준
+
+- editor tool surface에서는 viewport 폭에 따라 font-size가 크게 변하지 않는 것이 좋다.
+- 기본은 Chakra scale 또는 rem 기반 고정 scale을 유지한다.
+- `clamp()`는 hero나 marketing text가 아니라면 남용하지 않는다.
+- panel title처럼 특정 화면에서만 과하게 커지는 텍스트는 `xl`에서 `lg` 또는 18px 계열로 낮춘다.
+- negative letter spacing은 제거하거나 0으로 맞춘다.
+
+### 기존 token/theme 활용
+
+- 우선 Chakra theme scale과 기존 style system을 사용한다.
+- layout token처럼 typography token이 필요해지면 별도 이슈로 `textStyle` 또는 size token을 추가한다.
+- 이번 이슈에서는 workflow editor 범위 안에서 일관된 scale을 먼저 적용한다.
+
+# 5. 단계별 구현 계획
+
+## Step 1: 관련 파일 및 현재 동작 확인
+
+- 목적
+  - 구현 직전 현재 UI 동작과 변경 범위를 다시 확인한다.
+- 수정 예상 파일
+  - 없음. 분석과 캡처 중심.
+- 작업 내용
+  - `WorkflowEditorPage.tsx`, `Canvas.tsx`, `dual-panel-layout.ts`, `layout-token.ts`, `InputPanel.tsx`, `OutputPanel.tsx`, `ServiceSelectionPanel.tsx`를 다시 확인한다.
+  - 1366, 1440, 1920, 2560 viewport에서 현재 panel 위치와 node focus 동작을 기록한다.
+- 주의사항
+  - workflow 저장/실행/API 파일은 수정하지 않는다.
+  - 현재 브랜치의 다른 이슈 변경사항과 섞지 않는다.
+- 검증 방법
+  - 변경 전 screenshot 또는 Playwright trace를 남긴다.
+  - node type별 선택 시 zoom 값과 center 좌표 변화를 기록한다.
+
+## Step 2: 노드 선택 zoom/center 로직 통일
+
+- 목적
+  - 시작, 중간, 도착 노드 선택 시 동일한 zoom과 center 기준을 적용한다.
+- 수정 예상 파일
+  - `src/widgets/canvas/ui/Canvas.tsx`
+  - 필요 시 `src/widgets/canvas/lib/focus-node-viewport.ts`
+- 작업 내용
+  - 공통 focus helper를 만든다.
+  - `handleNodeClick`, `handleSelectSinkNode`, `activePanelNodeId` effect의 center 계산을 공통 helper로 연결한다.
+  - `window.innerWidth * 0.2` offset과 chain bounds center 중심 이동을 제거하거나 명시적 별도 action으로 분리한다.
+- 주의사항
+  - `fitView`가 node selection focus를 덮어쓰지 않도록 조건을 유지한다.
+  - placeholder와 실제 node의 fallback width/height가 다를 수 있으므로 measured size가 없을 때 type별 fallback을 둔다.
+- 검증 방법
+  - 시작 노드, 중간 노드, 도착 노드, 도착 placeholder를 선택해 같은 zoom이 적용되는지 확인한다.
+  - 선택된 노드 중심이 viewport 중심과 일관되게 맞는지 확인한다.
+
+## Step 3: 패널 viewport boundary 처리
+
+- 목적
+  - panel이 editor canvas area 밖으로 나가지 않도록 한다.
+- 수정 예상 파일
+  - `src/shared/libs/dual-panel-layout.ts`
+  - `src/shared/styles/token/size/layout-token.ts`
+  - `src/widgets/input-panel/ui/InputPanel.tsx`
+  - `src/widgets/output-panel/ui/OutputPanel.tsx`
+  - `src/features/add-node/ui/ServiceSelectionPanel.tsx`
+- 작업 내용
+  - panel size와 position 계산 후 safe boundary clamp를 적용한다.
+  - `maxHeight`, body `overflowY`, `minHeight: 0` 기준을 정리한다.
+  - start selection panel의 clamp 기준과 dual panel clamp 기준을 맞춘다.
+- 주의사항
+  - closed animation용 transform이 open layout 계산을 망치지 않게 분리한다.
+  - compact/stacked 전환 기준을 과하게 바꾸면 기존 workflow editor UX가 크게 달라질 수 있다.
+- 검증 방법
+  - 1366, 1440, 1920, 2560 viewport에서 panel open/close를 반복한다.
+  - browser zoom 125%에서 panel top/left/right/bottom이 editor area 밖으로 나가지 않는지 확인한다.
+
+## Step 4: panel radius/font-size 정리
+
+- 목적
+  - workflow editor panel이 기존 Flowify SaaS 톤에 맞게 덜 둥글고 더 정돈되어 보이도록 한다.
+- 수정 예상 파일
+  - `src/widgets/input-panel/ui/InputPanel.tsx`
+  - `src/widgets/output-panel/ui/OutputPanel.tsx`
+  - `src/features/add-node/ui/ServiceSelectionPanel.tsx`
+  - `src/features/configure-node/ui/panels/**`
+  - 필요 시 `src/shared/styles/token/size/**` 또는 theme token 파일
+- 작업 내용
+  - 큰 panel radius를 10px 또는 12px 기준으로 낮춘다.
+  - card/control/input/badge radius 기준을 구분한다.
+  - panel title, section title, body, helper, button font-size 기준을 맞춘다.
+  - negative letter spacing은 제거한다.
+- 주의사항
+  - 전역 theme 변경은 다른 화면에 영향을 줄 수 있으므로 workflow editor 범위에서 먼저 적용한다.
+  - button, badge, input의 기존 상태 스타일을 깨지 않게 한다.
+- 검증 방법
+  - panel 내부 텍스트가 줄바꿈, 잘림, 겹침 없이 보이는지 확인한다.
+  - 90%, 100%, 125% browser zoom에서 panel title과 button label이 과하게 커지지 않는지 확인한다.
+
+## Step 5: 화면 크기별 QA
+
+- 목적
+  - 실제 문제가 보고된 화면 조건에서 UI가 안정적인지 확인한다.
+- 수정 예상 파일
+  - 없음. QA와 필요한 최소 수정만 후속 step에 반영한다.
+- 작업 내용
+  - 1366, 1440, 1920 FHD, 2560 QHD viewport로 확인한다.
+  - browser zoom 90%, 100%, 125%를 확인한다.
+  - 시작, 중간, 도착 노드 선택과 panel open/close를 반복한다.
+- 주의사항
+  - viewport 전체가 아니라 editor canvas area 기준으로 판정한다.
+  - OS scaling과 browser zoom이 겹치는 환경에서는 실제 screenshot 기준으로 판단한다.
+- 검증 방법
+  - panel boundary, node focus center, zoom consistency, text readability를 체크리스트로 기록한다.
+  - 가능하면 Playwright screenshot을 남겨 회귀 비교가 가능하게 한다.
+
+## Step 6: 기존 기능 회귀 테스트
+
+- 목적
+  - UI 레이아웃 수정이 workflow 저장/수정/실행 기능을 깨지 않았는지 확인한다.
+- 수정 예상 파일
+  - 없음. 테스트와 확인 중심.
+- 작업 내용
+  - workflow 불러오기, 노드 선택, 설정 변경, 저장, 실행 결과 panel 확인을 수행한다.
+  - connector/OAuth/template/API 동작은 코드 변경 대상이 아니므로 기존 경로가 유지되는지만 확인한다.
+- 주의사항
+  - API contract나 workflow schema를 수정하지 않는다.
+  - Slack 제거 이슈나 다른 브랜치 변경사항과 섞지 않는다.
+- 검증 방법
+  - `pnpm tsc`
+  - `pnpm test`
+  - `pnpm build`
+  - 수동 QA로 저장/수정/실행의 기본 흐름을 확인한다.
+
+# 6. QA 시나리오
+
+## 화면 크기
+
+- 1366px
+- 1440px
+- 1920px FHD
+- 2560px QHD
+
+## 브라우저 확대
+
+- 90%
+- 100%
+- 125%
+
+## 사용자 동작
+
+- 시작 노드 선택
+- 중간 노드 선택
+- 도착 노드 선택
+- 패널 열기/닫기
+- 템플릿/설정/실행 결과 패널 확인
+- 노드 여러 개가 있는 workflow 확인
+- 화면 가장자리 근처 노드 선택
+
+## 검증 기준
+
+- 패널이 editor canvas area 밖으로 나가지 않을 것
+- 패널끼리 겹치거나 주요 노드 조작 영역을 비정상적으로 가리지 않을 것
+- 선택된 노드가 일관된 기준으로 화면 중앙에 올 것
+- 확대 비율이 노드 종류에 따라 달라지지 않을 것
+- 시작 노드, 중간 노드, 도착 노드 선택 후 zoom 값이 동일할 것
+- 글자가 과하게 크거나 작지 않을 것
+- 버튼/라벨/제목 텍스트가 잘리거나 겹치지 않을 것
+- panel 내부 내용이 길어도 panel 자체는 화면 안에 남고 내부 scroll로 처리될 것
+- 기존 workflow 저장/수정/실행 기능이 깨지지 않을 것
+
+## QA 매트릭스
+
+| Viewport | Browser zoom | 확인 항목 |
+| --- | --- | --- |
+| 1366px | 90%, 100%, 125% | compact/stacked panel boundary, panel scroll, node selection center |
+| 1440px | 90%, 100%, 125% | compact panel 위치, panel open/close transition, text readability |
+| 1920px FHD | 90%, 100%, 125% | wide/compact 전환 안정성, panel height, selected node focus |
+| 2560px QHD | 90%, 100%, 125% | wide layout 안정성, panel이 과하게 벌어지지 않는지, zoom consistency |
+
+# 7. 위험 요소 및 후속 작업
+
+## 구현 중 깨질 수 있는 부분
+
+- `fitView`와 `setCenter` 호출 순서가 꼬이면 선택 직후 viewport가 다시 전체 보기로 돌아갈 수 있다.
+- placeholder node는 measured size가 없을 수 있어 fallback size가 부정확하면 center가 약간 어긋날 수 있다.
+- panel boundary clamp가 과하면 panel transition이 부자연스럽게 보일 수 있다.
+- compact/stacked threshold를 바꾸면 기존 사용자가 익숙한 panel 배치가 달라질 수 있다.
+- 전역 radius/font-size token을 수정하면 workflow editor 밖 화면까지 영향이 번질 수 있다.
+
+## 다른 이슈와 충돌 가능성이 있는 부분
+
+- Slack 제거 이슈와 직접 관련은 없지만, template/connector UI 파일을 동시에 수정하면 충돌이 날 수 있다.
+- dashboard, template detail, node configuration 개선 이슈가 같은 panel component를 수정할 경우 style conflict가 생길 수 있다.
+- `workflowStore`를 수정하는 다른 작업이 active panel/placeholder 상태 전환과 충돌할 수 있다.
+
+## 추후 별도 이슈로 분리해야 할 부분
+
+- Playwright 기반 workflow editor visual regression test 구축
+- radius/font-size를 전역 design token으로 정리하는 작업
+- mobile 또는 tablet 전용 workflow editor UX 설계
+- 숨겨진 scrollbar 정책 재검토와 panel scroll affordance 개선
+- chain 전체 보기, 선택 노드 보기, 실행 결과 보기 같은 viewport action을 명시적으로 분리하는 UX 개선
+
+## 이번 이슈에서 하지 말아야 할 작업
+
+- workflow 저장/실행 API 변경
+- OAuth, connector, template schema 변경
+- node data model 변경
+- Slack 제거 범위 재수정
+- dashboard나 template detail 등 editor 밖 화면의 전면 스타일 변경
+- 단순 문자열 검색 기반의 무차별 radius/font-size 치환

--- a/.docs/RESPONSIVE_UI_FIX_PLAN.md
+++ b/.docs/RESPONSIVE_UI_FIX_PLAN.md
@@ -483,6 +483,14 @@ Issue 18의 목표는 Flowify Frontend 워크플로우 에디터 화면에서 vi
 - 패널 내부 콘텐츠 overflow는 `InputPanel`, `OutputPanel`, `ServiceSelectionPanel`에서 outer panel은 숨기고 body 영역만 scroll 되도록 정리했다.
 - 실제 브라우저 확대율별 visual screenshot 검증은 별도 Playwright/브라우저 QA 도구가 준비되면 후속으로 보강한다.
 
+## Step 6 회귀 테스트 기록
+
+- workflow 저장/수정/실행 API, OAuth, connector schema, template schema, node data model 파일은 수정하지 않았다.
+- 변경 범위는 workflow editor의 canvas focus, panel layout, panel visual styling, QA 문서 기록으로 제한했다.
+- Gmail, Google Drive, Canvas, Notion 관련 catalog/schema/API 경로는 변경하지 않았다.
+- 회귀 검증 명령은 `pnpm tsc`, `pnpm test`, `pnpm build`로 수행한다.
+- Vite build의 500KB chunk warning은 기존 번들 크기 경고이며, responsive UI 변경으로 인한 실패가 아니다.
+
 # 7. 위험 요소 및 후속 작업
 
 ## 구현 중 깨질 수 있는 부분

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -107,7 +107,7 @@ const WizardCard = ({
       bg="white"
       border="1px solid"
       borderColor={WIZARD_CARD_BORDER}
-      borderRadius="20px"
+      borderRadius="12px"
       boxShadow="0 4px 4px rgba(0,0,0,0.25)"
       maxW={maxWidth}
       minW={minWidth}
@@ -279,7 +279,7 @@ const AuthPrompt = ({
       <Text fontSize="sm">뒤로</Text>
     </Box>
 
-    <Text fontSize="xl" fontWeight="bold" mb={3}>
+    <Text fontSize="lg" fontWeight="semibold" mb={3}>
       {authState.label}
     </Text>
     <Text color="text.secondary" fontSize="md" mb={6}>
@@ -326,7 +326,7 @@ const SourceModeList = ({
       <Text fontSize="sm">뒤로</Text>
     </Box>
 
-    <Text fontSize="xl" fontWeight="bold" mb={2}>
+    <Text fontSize="lg" fontWeight="semibold" mb={2}>
       {service.label}
     </Text>
     <Text color="text.secondary" fontSize="sm" mb={6}>
@@ -338,7 +338,7 @@ const SourceModeList = ({
         shouldHideSourceModeFromPrimaryList(service.key, mode.key) ? null : (
           <Box
             key={mode.key}
-            borderRadius="3xl"
+            borderRadius="8px"
             cursor="pointer"
             px={6}
             py={5}
@@ -423,7 +423,7 @@ const SourceTargetForm = ({
         <Text fontSize="sm">뒤로</Text>
       </Box>
 
-      <Text fontSize="xl" fontWeight="bold" mb={2}>
+      <Text fontSize="lg" fontWeight="semibold" mb={2}>
         대상 선택
       </Text>
       <Text color="text.secondary" fontSize="sm" mb={helperText ? 2 : 6}>
@@ -516,7 +516,7 @@ const StartNodeConfirm = ({
       <Text fontSize="sm">뒤로</Text>
     </Box>
 
-    <Text fontSize="xl" fontWeight="bold" mb={2}>
+    <Text fontSize="lg" fontWeight="semibold" mb={2}>
       시작 노드 확인
     </Text>
     <Text color="text.secondary" fontSize="sm" mb={6}>
@@ -524,7 +524,7 @@ const StartNodeConfirm = ({
     </Text>
 
     <VStack align="stretch" gap={3}>
-      <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+      <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
           서비스
         </Text>
@@ -532,7 +532,7 @@ const StartNodeConfirm = ({
           {service.label}
         </Text>
       </Box>
-      <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+      <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
           가져오는 방식
         </Text>
@@ -541,7 +541,7 @@ const StartNodeConfirm = ({
         </Text>
       </Box>
       {keyword ? (
-        <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+        <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
           <Text color="text.secondary" fontSize="sm">
             포함할 단어
           </Text>
@@ -550,7 +550,7 @@ const StartNodeConfirm = ({
           </Text>
         </Box>
       ) : null}
-      <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+      <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
           가져오는 데이터
         </Text>
@@ -559,7 +559,7 @@ const StartNodeConfirm = ({
         </Text>
       </Box>
       {targetValue ? (
-        <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+        <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
           <Text color="text.secondary" fontSize="sm">
             선택한 대상
           </Text>
@@ -604,7 +604,7 @@ const SinkNodeConfirm = ({
       <Text fontSize="sm">뒤로</Text>
     </Box>
 
-    <Text fontSize="xl" fontWeight="bold" mb={2}>
+    <Text fontSize="lg" fontWeight="semibold" mb={2}>
       도착 노드 확인
     </Text>
     <Text color="text.secondary" fontSize="sm" mb={6}>
@@ -612,7 +612,7 @@ const SinkNodeConfirm = ({
     </Text>
 
     <VStack align="stretch" gap={3}>
-      <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+      <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
           보낼 서비스
         </Text>
@@ -620,7 +620,7 @@ const SinkNodeConfirm = ({
           {service.label}
         </Text>
       </Box>
-      <Box bg="gray.50" borderRadius="2xl" px={5} py={4}>
+      <Box bg="gray.50" borderRadius="8px" px={5} py={4}>
         <Text color="text.secondary" fontSize="sm">
           보낼 데이터
         </Text>
@@ -1169,7 +1169,7 @@ export const ServiceSelectionPanel = () => {
         bg={isEndPlaceholder ? "white" : undefined}
         border={isEndPlaceholder ? "1px solid" : undefined}
         borderColor={isEndPlaceholder ? WIZARD_CARD_BORDER : undefined}
-        borderRadius={isEndPlaceholder ? "20px" : undefined}
+        borderRadius={isEndPlaceholder ? "12px" : undefined}
         boxShadow={isEndPlaceholder ? "0 4px 4px rgba(0,0,0,0.25)" : undefined}
         display={isEndPlaceholder ? "flex" : undefined}
         flexDirection={isEndPlaceholder ? "column" : undefined}
@@ -1205,7 +1205,7 @@ export const ServiceSelectionPanel = () => {
             justifyContent="space-between"
             px={3}
           >
-            <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+            <Text fontSize="lg" fontWeight="semibold">
               {getGuidelineTitle()}
             </Text>
             <Box cursor="pointer" onClick={handleOverlayClose}>
@@ -1214,7 +1214,7 @@ export const ServiceSelectionPanel = () => {
           </Box>
         ) : (
           <Text
-            fontSize="24px"
+            fontSize="20px"
             fontWeight="bold"
             lineHeight="shorter"
             pb="24px"

--- a/src/features/add-node/ui/ServiceSelectionPanel.tsx
+++ b/src/features/add-node/ui/ServiceSelectionPanel.tsx
@@ -50,6 +50,7 @@ import {
   storeOAuthConnectReturnPath,
   useDualPanelLayout,
 } from "@/shared";
+import { dualPanelLayoutSpec } from "@/shared/styles";
 
 import { isSinkServiceInRollout } from "../model/sink-rollout";
 import { isSourceModeInRollout } from "../model/source-rollout";
@@ -80,11 +81,14 @@ const START_END_PANEL_GAP = 48;
 const PLACEHOLDER_NODE_WIDTH = 100;
 const START_END_NODE_HEIGHT = 176;
 const EMPTY_TARGET_SENTINEL = "";
+const OVERLAY_SAFE_PADDING_X = dualPanelLayoutSpec.safePaddingX;
+const OVERLAY_SAFE_PADDING_Y = dualPanelLayoutSpec.safePaddingY;
+const START_WIZARD_MAX_WIDTH = `calc(100vw - ${OVERLAY_SAFE_PADDING_X * 2}px)`;
 
 const WizardCard = ({
   children,
   maxWidth,
-  minWidth = "520px",
+  minWidth = `min(520px, ${START_WIZARD_MAX_WIDTH})`,
   padding = 12,
   unstyled = false,
 }: {
@@ -145,8 +149,8 @@ const CatalogServiceGrid = ({
   setSearchQuery: (query: string) => void;
 }) => (
   <WizardCard
-    maxWidth={isPanelLayout ? "100%" : "820px"}
-    minWidth={isPanelLayout ? "0" : "820px"}
+    maxWidth={isPanelLayout ? "100%" : START_WIZARD_MAX_WIDTH}
+    minWidth={isPanelLayout ? "0" : `min(820px, ${START_WIZARD_MAX_WIDTH})`}
     padding={isPanelLayout ? 6 : 12}
     unstyled={isPanelLayout}
   >
@@ -870,12 +874,21 @@ export const ServiceSelectionPanel = () => {
 
     const centeredLeft =
       anchorScreenPosition.x - overlayRect.left + START_END_PANEL_GAP;
-    const maxLeft = Math.max(24, overlayRect.width - wrapperRect.width - 24);
-    const left = Math.min(Math.max(24, centeredLeft), maxLeft);
+    const maxLeft = Math.max(
+      OVERLAY_SAFE_PADDING_X,
+      overlayRect.width - wrapperRect.width - OVERLAY_SAFE_PADDING_X,
+    );
+    const left = Math.min(
+      Math.max(OVERLAY_SAFE_PADDING_X, centeredLeft),
+      maxLeft,
+    );
     const centeredTop =
       anchorScreenPosition.y - overlayRect.top - wrapperRect.height / 2;
-    const maxTop = Math.max(24, overlayRect.height - wrapperRect.height - 24);
-    const top = Math.min(Math.max(24, centeredTop), maxTop);
+    const maxTop = Math.max(
+      OVERLAY_SAFE_PADDING_Y,
+      overlayRect.height - wrapperRect.height - OVERLAY_SAFE_PADDING_Y,
+    );
+    const top = Math.min(Math.max(OVERLAY_SAFE_PADDING_Y, centeredTop), maxTop);
 
     wrapperElement.style.left = `${left}px`;
     wrapperElement.style.top = `${top}px`;
@@ -1163,8 +1176,19 @@ export const ServiceSelectionPanel = () => {
         gap={isEndPlaceholder ? 3 : undefined}
         h={isEndPlaceholder ? `${layout.panelHeight}px` : undefined}
         left={isEndPlaceholder ? `${layout.outputPanelLeft}px` : 0}
+        maxH={
+          isEndPlaceholder
+            ? `${layout.panelHeight}px`
+            : `calc(100% - ${OVERLAY_SAFE_PADDING_Y * 2}px)`
+        }
+        maxW={
+          isEndPlaceholder
+            ? `${layout.panelWidth}px`
+            : `calc(100% - ${OVERLAY_SAFE_PADDING_X * 2}px)`
+        }
+        minH={0}
         onClick={(event) => event.stopPropagation()}
-        overflow={isEndPlaceholder ? "hidden" : undefined}
+        overflow={isEndPlaceholder ? "hidden" : "auto"}
         pointerEvents="auto"
         position="absolute"
         px={isEndPlaceholder ? 3 : undefined}
@@ -1202,6 +1226,7 @@ export const ServiceSelectionPanel = () => {
 
         <Box
           flex={isEndPlaceholder ? 1 : undefined}
+          minH={isEndPlaceholder ? 0 : undefined}
           overflow={isEndPlaceholder ? "auto" : undefined}
           p={isEndPlaceholder ? 3 : undefined}
           position="relative"

--- a/src/features/configure-node/ui/panels/AuthPrompt.tsx
+++ b/src/features/configure-node/ui/panels/AuthPrompt.tsx
@@ -42,7 +42,7 @@ export const AuthPrompt = ({ authState, isConnecting, onConnect }: Props) => {
       bg={toneStyle.bg}
       border="1px solid"
       borderColor={toneStyle.borderColor}
-      borderRadius="2xl"
+      borderRadius="8px"
       display="flex"
       flexDirection="column"
       gap={3}

--- a/src/features/configure-node/ui/panels/GenericNodePanel.tsx
+++ b/src/features/configure-node/ui/panels/GenericNodePanel.tsx
@@ -23,7 +23,7 @@ export const GenericNodePanel = ({ nodeId, data }: NodePanelProps) => {
       title={presentation.title}
       description="선택한 설정으로 준비된 단계입니다."
     >
-      <Box bg="gray.50" borderRadius="xl" px={4} py={3}>
+      <Box bg="gray.50" borderRadius="8px" px={4} py={3}>
         <Text fontSize="sm" fontWeight="semibold">
           설정 정보
         </Text>
@@ -39,7 +39,7 @@ export const GenericNodePanel = ({ nodeId, data }: NodePanelProps) => {
         <Box
           as="pre"
           p={3}
-          borderRadius="lg"
+          borderRadius="8px"
           bg="bg.overlay"
           color="text.secondary"
           whiteSpace="pre-wrap"

--- a/src/shared/libs/dual-panel-layout.test.ts
+++ b/src/shared/libs/dual-panel-layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { dualPanelLayoutSpec } from "@/shared/styles";
+
+import { getDualPanelLayout } from "./dual-panel-layout";
+
+const expectPanelWithinSafeArea = (
+  layout: ReturnType<typeof getDualPanelLayout>,
+) => {
+  const { safePaddingX, safePaddingY } = dualPanelLayoutSpec;
+  const rightBoundary = layout.canvasWidth - safePaddingX;
+  const bottomBoundary = layout.canvasHeight - safePaddingY;
+
+  expect(layout.inputPanelLeft).toBeGreaterThanOrEqual(safePaddingX);
+  expect(layout.outputPanelLeft).toBeGreaterThanOrEqual(safePaddingX);
+  expect(layout.inputPanelLeft + layout.panelWidth).toBeLessThanOrEqual(
+    rightBoundary,
+  );
+  expect(layout.outputPanelLeft + layout.panelWidth).toBeLessThanOrEqual(
+    rightBoundary,
+  );
+  expect(layout.inputPanelTop).toBeGreaterThanOrEqual(safePaddingY);
+  expect(layout.outputPanelTop).toBeGreaterThanOrEqual(safePaddingY);
+  expect(layout.inputPanelTop + layout.panelHeight).toBeLessThanOrEqual(
+    bottomBoundary,
+  );
+  expect(layout.outputPanelTop + layout.panelHeight).toBeLessThanOrEqual(
+    bottomBoundary,
+  );
+};
+
+describe("getDualPanelLayout", () => {
+  it.each([
+    { height: 768, width: 1366 },
+    { height: 800, width: 1440 },
+    { height: 900, width: 1920 },
+    { height: 1440, width: 2560 },
+    { height: 614, width: 1093 },
+  ])(
+    "keeps panels inside the editor safe area at $width x $height",
+    (targetSize) => {
+      const layout = getDualPanelLayout(targetSize);
+
+      expectPanelWithinSafeArea(layout);
+    },
+  );
+});

--- a/src/shared/libs/dual-panel-layout.ts
+++ b/src/shared/libs/dual-panel-layout.ts
@@ -33,6 +33,17 @@ export const EDITOR_CANVAS_AREA_ID = "workflow-editor-canvas-area";
 const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(value, max));
 
+const getSafeCenteredPosition = (
+  canvasLength: number,
+  itemLength: number,
+  safePadding: number,
+) => {
+  const min = safePadding;
+  const max = Math.max(min, canvasLength - itemLength - safePadding);
+
+  return clamp((canvasLength - itemLength) / 2, min, max);
+};
+
 const readTargetSize = (targetId: string): LayoutTargetSize => {
   if (typeof window === "undefined") {
     return {
@@ -88,14 +99,19 @@ export const getDualPanelLayout = (
     canvasWidth >= wideMinCanvasWidth &&
     canvasHeight >= wideMinCanvasHeight
   ) {
-    const containerWidth = basePanelWidth * 2 + baseGap;
-    const containerHeight = basePanelHeight;
-    const containerLeft = Math.max(
-      (canvasWidth - containerWidth) / 2,
+    const panelWidth = Math.min(basePanelWidth, availableWidth);
+    const panelHeight = Math.min(basePanelHeight, availableHeight);
+    const gapWidth = baseGap;
+    const containerWidth = panelWidth * 2 + gapWidth;
+    const containerHeight = panelHeight;
+    const containerLeft = getSafeCenteredPosition(
+      canvasWidth,
+      containerWidth,
       safePaddingX,
     );
-    const containerTop = Math.max(
-      (canvasHeight - containerHeight) / 2,
+    const containerTop = getSafeCenteredPosition(
+      canvasHeight,
+      containerHeight,
       safePaddingY,
     );
 
@@ -103,16 +119,16 @@ export const getDualPanelLayout = (
       canvasWidth,
       canvasHeight,
       mode: "wide",
-      panelWidth: basePanelWidth,
-      panelHeight: basePanelHeight,
-      gapWidth: baseGap,
+      panelWidth,
+      panelHeight,
+      gapWidth,
       containerWidth,
       containerHeight,
       containerLeft,
       containerTop,
       inputPanelLeft: containerLeft,
       inputPanelTop: containerTop,
-      outputPanelLeft: containerLeft + basePanelWidth + baseGap,
+      outputPanelLeft: containerLeft + panelWidth + gapWidth,
       outputPanelTop: containerTop,
       chainCenterX: canvasWidth / 2,
       chainCenterY: canvasHeight / 2,
@@ -129,25 +145,29 @@ export const getDualPanelLayout = (
       availableHeight / basePanelHeight,
       1,
     );
+    const gapWidth = clamp(Math.round(baseGap * scale), compactMinGap, baseGap);
+    const maxPanelWidth = Math.max((availableWidth - gapWidth) / 2, 0);
     const panelWidth = clamp(
       Math.round(basePanelWidth * scale),
-      compactMinPanelWidth,
-      basePanelWidth,
+      Math.min(compactMinPanelWidth, maxPanelWidth),
+      Math.min(basePanelWidth, maxPanelWidth),
     );
+    const maxPanelHeight = Math.min(basePanelHeight, availableHeight);
     const panelHeight = clamp(
       Math.round(basePanelHeight * scale),
-      compactMinPanelHeight,
-      basePanelHeight,
+      Math.min(compactMinPanelHeight, maxPanelHeight),
+      maxPanelHeight,
     );
-    const gapWidth = clamp(Math.round(baseGap * scale), compactMinGap, baseGap);
     const containerWidth = panelWidth * 2 + gapWidth;
     const containerHeight = panelHeight;
-    const containerLeft = Math.max(
-      (canvasWidth - containerWidth) / 2,
+    const containerLeft = getSafeCenteredPosition(
+      canvasWidth,
+      containerWidth,
       safePaddingX,
     );
-    const containerTop = Math.max(
-      (canvasHeight - containerHeight) / 2,
+    const containerTop = getSafeCenteredPosition(
+      canvasHeight,
+      containerHeight,
       safePaddingY,
     );
 
@@ -171,25 +191,34 @@ export const getDualPanelLayout = (
     };
   }
 
-  const panelWidth = Math.min(availableWidth, stackedMaxPanelWidth);
-  const rawPanelHeight = Math.floor((availableHeight - stackedGap) / 2);
+  const panelWidth = Math.max(
+    0,
+    Math.min(availableWidth, stackedMaxPanelWidth),
+  );
+  const effectiveStackedGap =
+    availableHeight > stackedGap ? stackedGap : Math.max(availableHeight, 0);
+  const rawPanelHeight = Math.floor(
+    (availableHeight - effectiveStackedGap) / 2,
+  );
   const panelHeightCandidate = clamp(
     rawPanelHeight,
     stackedMinPanelHeight,
     stackedMaxPanelHeight,
   );
   const panelHeight =
-    panelHeightCandidate * 2 + stackedGap > availableHeight
+    panelHeightCandidate * 2 + effectiveStackedGap > availableHeight
       ? Math.max(rawPanelHeight, 0)
       : panelHeightCandidate;
   const containerWidth = panelWidth;
-  const containerHeight = panelHeight * 2 + stackedGap;
-  const containerLeft = Math.max(
-    (canvasWidth - containerWidth) / 2,
+  const containerHeight = panelHeight * 2 + effectiveStackedGap;
+  const containerLeft = getSafeCenteredPosition(
+    canvasWidth,
+    containerWidth,
     safePaddingX,
   );
-  const containerTop = Math.max(
-    (canvasHeight - containerHeight) / 2,
+  const containerTop = getSafeCenteredPosition(
+    canvasHeight,
+    containerHeight,
     safePaddingY,
   );
 
@@ -199,7 +228,7 @@ export const getDualPanelLayout = (
     mode: "stacked",
     panelWidth,
     panelHeight,
-    gapWidth: stackedGap,
+    gapWidth: effectiveStackedGap,
     containerWidth,
     containerHeight,
     containerLeft,
@@ -207,7 +236,7 @@ export const getDualPanelLayout = (
     inputPanelLeft: containerLeft,
     inputPanelTop: containerTop,
     outputPanelLeft: containerLeft,
-    outputPanelTop: containerTop + panelHeight + stackedGap,
+    outputPanelTop: containerTop + panelHeight + effectiveStackedGap,
     chainCenterX: canvasWidth / 2,
     chainCenterY: canvasHeight / 2,
   };

--- a/src/widgets/canvas/ui/Canvas.tsx
+++ b/src/widgets/canvas/ui/Canvas.tsx
@@ -76,6 +76,8 @@ const PLACEHOLDER_NODE_WIDTH = 100;
 const PLACEHOLDER_NODE_HEIGHT = 134;
 const NEXT_STEP_CHOICE_NODE_WIDTH = 244;
 const NEXT_STEP_CHOICE_NODE_HEIGHT = 148;
+const NODE_FOCUS_ZOOM = 1;
+const NODE_FOCUS_DURATION_MS = 300;
 
 type ActiveNextStep = {
   centerY: number;
@@ -95,9 +97,6 @@ const getCenterYFromTop = (topY: number, height: number) => topY + height / 2;
 
 const getNodeWidth = (node: Node, fallbackWidth = DEFAULT_FLOW_NODE_WIDTH) =>
   node.measured?.width ?? fallbackWidth;
-
-const getNodeHeight = (node: Node, fallbackHeight = DEFAULT_FLOW_NODE_HEIGHT) =>
-  node.measured?.height ?? fallbackHeight;
 
 const getNodeFallbackWidth = (node: Node) => {
   if (node.type === "placeholder") return PLACEHOLDER_NODE_WIDTH;
@@ -119,50 +118,6 @@ const getNodeCenterY = (
   fallbackHeight = DEFAULT_FLOW_NODE_HEIGHT,
 ) =>
   getCenterYFromTop(node.position.y, node.measured?.height ?? fallbackHeight);
-
-const getNodeBounds = (node: Node) => {
-  const width = getNodeWidth(node, getNodeFallbackWidth(node));
-  const height = getNodeHeight(node, getNodeFallbackHeight(node));
-
-  return {
-    minX: node.position.x,
-    maxX: node.position.x + width,
-    minY: node.position.y,
-    maxY: node.position.y + height,
-  };
-};
-
-const getNodesBoundsCenter = (chainNodes: Node[]) => {
-  const bounds = chainNodes.map((node) => getNodeBounds(node));
-  const minX = Math.min(...bounds.map((bound) => bound.minX));
-  const maxX = Math.max(...bounds.map((bound) => bound.maxX));
-  const minY = Math.min(...bounds.map((bound) => bound.minY));
-  const maxY = Math.max(...bounds.map((bound) => bound.maxY));
-
-  return {
-    centerX: (minX + maxX) / 2,
-    centerY: (minY + maxY) / 2,
-  };
-};
-
-const createVirtualPlaceholderNode = (
-  id: string,
-  x: number,
-  centerY: number,
-): Node => ({
-  id,
-  type: "placeholder",
-  position: {
-    x,
-    y: getTopYFromCenter(centerY, PLACEHOLDER_NODE_HEIGHT),
-  },
-  data: { label: "" },
-  initialWidth: PLACEHOLDER_NODE_WIDTH,
-  initialHeight: PLACEHOLDER_NODE_HEIGHT,
-  selectable: false,
-  draggable: false,
-  hidden: true,
-});
 
 const toPlaceholderRoutingMeta = (
   value: unknown,
@@ -388,7 +343,25 @@ export const Canvas = () => {
     [onNodesChange],
   );
 
-  const { fitView, getZoom, setCenter } = useReactFlow();
+  const { fitView, setCenter } = useReactFlow();
+  const focusCanvasPoint = useCallback(
+    (centerX: number, centerY: number) => {
+      setCenter(centerX, centerY, {
+        zoom: NODE_FOCUS_ZOOM,
+        duration: NODE_FOCUS_DURATION_MS,
+      });
+    },
+    [setCenter],
+  );
+  const focusNode = useCallback(
+    (node: Node) => {
+      focusCanvasPoint(
+        getNodeCenterX(node, getNodeFallbackWidth(node)),
+        getNodeCenterY(node, getNodeFallbackHeight(node)),
+      );
+    },
+    [focusCanvasPoint],
+  );
   const reactFlowStore = useStoreApi();
   const isInteractive = useStore(
     (state) =>
@@ -519,12 +492,7 @@ export const Canvas = () => {
             position: panelNodePosition,
           });
 
-          const viewportWidth = window.innerWidth;
-          const offsetX = viewportWidth * 0.2;
-          setCenter(node.position.x + offsetX, centerY, {
-            zoom: 1,
-            duration: 300,
-          });
+          focusNode(node);
           return;
         }
 
@@ -549,7 +517,7 @@ export const Canvas = () => {
         openPanel(node.id, { mode: "view" });
       }
     },
-    [canEditNodes, closePanel, openPanel, setActivePlaceholder, setCenter],
+    [canEditNodes, closePanel, focusNode, openPanel, setActivePlaceholder],
   );
 
   const handlePaneClick = useCallback(() => {
@@ -624,13 +592,11 @@ export const Canvas = () => {
     });
     setActiveNextStep(null);
 
-    const sinkPreviewCenterX =
-      activeNextStep.position.x + PLACEHOLDER_NODE_WIDTH / 2;
-    setCenter(sinkPreviewCenterX, activeNextStep.centerY, {
-      zoom: 1,
-      duration: 300,
-    });
-  }, [activeNextStep, closePanel, setActivePlaceholder, setCenter]);
+    focusCanvasPoint(
+      activeNextStep.position.x + PLACEHOLDER_NODE_WIDTH / 2,
+      activeNextStep.centerY,
+    );
+  }, [activeNextStep, closePanel, focusCanvasPoint, setActivePlaceholder]);
 
   const isAutoLayoutDisabled =
     !canEditNodes ||
@@ -937,101 +903,6 @@ export const Canvas = () => {
     );
   }, [edgesWithVirtualBranches, visibleNodeIds]);
 
-  const getChainNodes = useCallback(
-    (nodeId: string) => {
-      const activeNode =
-        nodesWithDragControl.find((node) => node.id === nodeId) ?? null;
-
-      if (!activeNode) return [];
-
-      const chainNodes: Node[] = [activeNode];
-      const incomingEdges = edgesWithVirtualBranches.filter(
-        (edge) => edge.target === nodeId,
-      );
-      const outgoingEdges = edgesWithVirtualBranches.filter(
-        (edge) => edge.source === nodeId,
-      );
-      const placeholderNodes = nodesWithDragControl.filter(
-        (node) =>
-          node.type === "placeholder" && node.data?.sourceNodeId === nodeId,
-      );
-      const activeNodeCenterY = getNodeCenterY(
-        activeNode,
-        getNodeFallbackHeight(activeNode),
-      );
-
-      if (incomingEdges.length > 0) {
-        for (const incomingEdge of incomingEdges) {
-          const previousNode = nodesWithDragControl.find(
-            (node) => node.id === incomingEdge.source,
-          );
-
-          if (previousNode) {
-            chainNodes.unshift(previousNode);
-          }
-        }
-      } else {
-        chainNodes.unshift(
-          createVirtualPlaceholderNode(
-            `virtual-placeholder-before-${nodeId}`,
-            activeNode.position.x - NODE_GAP_X - PLACEHOLDER_NODE_WIDTH,
-            activeNodeCenterY,
-          ),
-        );
-      }
-
-      const nextNodeIds = new Set<string>();
-
-      for (const outgoingEdge of outgoingEdges) {
-        if (nextNodeIds.has(outgoingEdge.target)) {
-          continue;
-        }
-
-        const nextNode = nodesWithDragControl.find(
-          (node) => node.id === outgoingEdge.target,
-        );
-
-        if (nextNode) {
-          chainNodes.push(nextNode);
-          nextNodeIds.add(outgoingEdge.target);
-        }
-      }
-
-      for (const placeholderNode of placeholderNodes) {
-        if (nextNodeIds.has(placeholderNode.id)) {
-          continue;
-        }
-
-        chainNodes.push(placeholderNode);
-        nextNodeIds.add(placeholderNode.id);
-      }
-
-      if (nextNodeIds.size === 0) {
-        const nextPlaceholder =
-          nodesWithDragControl.find(
-            (node) => node.id === getNextStepPlaceholderId(nodeId),
-          ) ?? null;
-
-        if (nextPlaceholder) {
-          chainNodes.push(nextPlaceholder);
-        } else {
-          chainNodes.push(
-            createVirtualPlaceholderNode(
-              `virtual-placeholder-after-${nodeId}`,
-              activeNode.position.x +
-                getNodeWidth(activeNode, getNodeFallbackWidth(activeNode)) +
-                NODE_GAP_X,
-              activeNodeCenterY,
-            ),
-          );
-        }
-      }
-
-      return chainNodes;
-    },
-    [edgesWithVirtualBranches, nodesWithDragControl],
-  );
-
   useEffect(() => {
     if (!activePanelNodeId) return;
 
@@ -1039,35 +910,10 @@ export const Canvas = () => {
       nodesWithDragControl.find((node) => node.id === activePanelNodeId) ??
       null;
 
-    if (activeNode && isEndWorkflowNodeId(activeNode.id, endNodeIds)) {
-      setCenter(
-        getNodeCenterX(activeNode, getNodeFallbackWidth(activeNode)),
-        getNodeCenterY(activeNode, getNodeFallbackHeight(activeNode)),
-        {
-          duration: 300,
-          zoom: getZoom(),
-        },
-      );
-      return;
-    }
+    if (!activeNode) return;
 
-    const chainNodes = getChainNodes(activePanelNodeId);
-    if (chainNodes.length === 0) return;
-
-    const { centerX, centerY } = getNodesBoundsCenter(chainNodes);
-
-    setCenter(centerX, centerY, {
-      duration: 300,
-      zoom: getZoom(),
-    });
-  }, [
-    activePanelNodeId,
-    endNodeIds,
-    getChainNodes,
-    getZoom,
-    nodesWithDragControl,
-    setCenter,
-  ]);
+    focusNode(activeNode);
+  }, [activePanelNodeId, focusNode, nodesWithDragControl]);
 
   useEffect(() => {
     if (!pendingAutoLayoutFit) {

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -152,7 +152,8 @@ export const InputPanel = () => {
       borderColor="#f2f2f2"
       borderRadius="20px"
       boxShadow="0 4px 4px rgba(0,0,0,0.25)"
-      overflowY="auto"
+      minH={0}
+      overflow="hidden"
       px={3}
       py={6}
       zIndex={5}
@@ -191,7 +192,7 @@ export const InputPanel = () => {
         </Box>
       </Box>
 
-      <Box flex={1} overflow="auto" p={3}>
+      <Box flex={1} minH={0} overflow="auto" p={3}>
         {activeNode ? (
           <Box display="flex" flexDirection="column" gap={6}>
             <Box>

--- a/src/widgets/input-panel/ui/InputPanel.tsx
+++ b/src/widgets/input-panel/ui/InputPanel.tsx
@@ -150,7 +150,7 @@ export const InputPanel = () => {
       bg="white"
       border="1px solid"
       borderColor="#f2f2f2"
-      borderRadius="20px"
+      borderRadius="12px"
       boxShadow="0 4px 4px rgba(0,0,0,0.25)"
       minH={0}
       overflow="hidden"
@@ -183,7 +183,7 @@ export const InputPanel = () => {
               sourceMode={headerSourceMode}
             />
           ) : null}
-          <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+          <Text fontSize="lg" fontWeight="semibold">
             들어오는 데이터
           </Text>
         </Box>
@@ -280,7 +280,7 @@ export const InputPanel = () => {
                 <Text fontSize="md" fontWeight="bold" mb={3}>
                   데이터 처리 방식
                 </Text>
-                <Box px={4} py={4} borderRadius="2xl" bg="gray.50">
+                <Box px={4} py={4} borderRadius="8px" bg="gray.50">
                   <Text fontSize="md" fontWeight="semibold">
                     {selectedAction.label}
                   </Text>
@@ -304,7 +304,7 @@ export const InputPanel = () => {
                       key={`${option}-${index}`}
                       px={4}
                       py={4}
-                      borderRadius="2xl"
+                      borderRadius="8px"
                       bg="gray.50"
                     >
                       <Text fontSize="sm" fontWeight="medium">
@@ -327,7 +327,7 @@ export const InputPanel = () => {
                       key={`${input}-${index}`}
                       px={4}
                       py={4}
-                      borderRadius="2xl"
+                      borderRadius="8px"
                       bg="gray.50"
                     >
                       <Text fontSize="sm" fontWeight="medium">
@@ -354,7 +354,7 @@ export const InputPanel = () => {
                   bg="orange.50"
                   border="1px solid"
                   borderColor="orange.100"
-                  borderRadius="2xl"
+                  borderRadius="8px"
                   px={4}
                   py={4}
                 >

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -109,7 +109,7 @@ const ChoiceStepStatus = ({
     alignItems="center"
     gap={2}
     p={4}
-    borderRadius="xl"
+    borderRadius="8px"
     bg={tone === "error" ? "red.50" : "gray.50"}
     border="1px solid"
     borderColor={tone === "error" ? "red.100" : "gray.200"}
@@ -295,7 +295,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
       bg="white"
       border="1px solid"
       borderColor="#f2f2f2"
-      borderRadius="20px"
+      borderRadius="12px"
       boxShadow="0 4px 4px rgba(0,0,0,0.25)"
       minH={0}
       overflow="hidden"
@@ -320,7 +320,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             justifyContent="space-between"
             px={3}
           >
-            <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+            <Text fontSize="lg" fontWeight="semibold">
               설정
             </Text>
             <Box cursor="pointer" onClick={handleClose}>
@@ -332,7 +332,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             {!canEditNodes ? (
               <Box
                 p={4}
-                borderRadius="xl"
+                borderRadius="8px"
                 bg="gray.50"
                 border="1px solid"
                 borderColor="gray.200"
@@ -435,7 +435,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             justifyContent="space-between"
             px={3}
           >
-            <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+            <Text fontSize="lg" fontWeight="semibold">
               가져올 곳 설정
             </Text>
             <Box cursor="pointer" onClick={handleClose}>
@@ -462,7 +462,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
           >
             <Box display="flex" gap={2} alignItems="center">
               {renderActiveNodeIcon()}
-              <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+              <Text fontSize="lg" fontWeight="semibold">
                 가져올 곳
               </Text>
             </Box>
@@ -497,7 +497,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             justifyContent="space-between"
             px={3}
           >
-            <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+            <Text fontSize="lg" fontWeight="semibold">
               설정
             </Text>
             <Box cursor="pointer" onClick={handleClose}>
@@ -521,7 +521,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             justifyContent="space-between"
             px={3}
           >
-            <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+            <Text fontSize="lg" fontWeight="semibold">
               설정
             </Text>
             <Box cursor="pointer" onClick={handleClose}>
@@ -547,7 +547,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
           >
             <Box display="flex" gap={2} alignItems="center">
               {renderActiveNodeIcon()}
-              <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+              <Text fontSize="lg" fontWeight="semibold">
                 보낼 곳
               </Text>
             </Box>
@@ -590,7 +590,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
           >
             <Box display="flex" gap={2} alignItems="center">
               {renderActiveNodeIcon()}
-              <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+              <Text fontSize="lg" fontWeight="semibold">
                 처리 방식
               </Text>
             </Box>
@@ -623,7 +623,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
           >
             <Box display="flex" gap={2} alignItems="center">
               {renderActiveNodeIcon()}
-              <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+              <Text fontSize="lg" fontWeight="semibold">
                 遺꾧린
               </Text>
             </Box>
@@ -659,7 +659,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
           >
             <Box display="flex" gap={2} alignItems="center">
               {renderActiveNodeIcon()}
-              <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+              <Text fontSize="lg" fontWeight="semibold">
                 출력 데이터
               </Text>
             </Box>
@@ -699,7 +699,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
                 bg="orange.50"
                 border="1px solid"
                 borderColor="orange.100"
-                borderRadius="2xl"
+                borderRadius="8px"
                 px={4}
                 py={4}
               >
@@ -783,7 +783,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
           >
             <Box display="flex" gap={2} alignItems="center">
               {renderActiveNodeIcon()}
-              <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+              <Text fontSize="lg" fontWeight="semibold">
                 설정
               </Text>
             </Box>
@@ -817,7 +817,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             justifyContent="space-between"
             px={3}
           >
-            <Text fontSize="xl" fontWeight="medium" letterSpacing="-0.4px">
+            <Text fontSize="lg" fontWeight="semibold">
               설정
             </Text>
             <Box cursor="pointer" onClick={handleClose}>

--- a/src/widgets/output-panel/ui/OutputPanel.tsx
+++ b/src/widgets/output-panel/ui/OutputPanel.tsx
@@ -297,7 +297,8 @@ export const OutputPanel = ({ wizardController }: Props) => {
       borderColor="#f2f2f2"
       borderRadius="20px"
       boxShadow="0 4px 4px rgba(0,0,0,0.25)"
-      overflowY="auto"
+      minH={0}
+      overflow="hidden"
       px={3}
       py={6}
       zIndex={5}
@@ -327,7 +328,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <Box flex={1} overflow="auto" p={3}>
+          <Box flex={1} minH={0} overflow="auto" p={3}>
             {!canEditNodes ? (
               <Box
                 p={4}
@@ -442,7 +443,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <Box flex={1} overflow="auto" p={3}>
+          <Box flex={1} minH={0} overflow="auto" p={3}>
             <SourceNodePanel
               data={activeNode.data}
               nodeId={activeNode.id}
@@ -470,7 +471,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <VStack align="stretch" flex={1} overflow="auto" p={3} gap={6}>
+          <VStack
+            align="stretch"
+            flex={1}
+            minH={0}
+            overflow="auto"
+            p={3}
+            gap={6}
+          >
             <SourceSetupSummaryBlock
               canEdit={canEditNodes}
               config={activeNode.data.config}
@@ -497,7 +505,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <Box flex={1} overflow="auto" p={3}>
+          <Box flex={1} minH={0} overflow="auto" p={3}>
             <PanelRenderer
               readOnly={!canEditNodes}
               onCancel={() => setActivePanelMode("view")}
@@ -521,7 +529,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <Box flex={1} overflow="auto" p={3}>
+          <Box flex={1} minH={0} overflow="auto" p={3}>
             <PanelRenderer
               readOnly={!canEditNodes}
               onCancel={() => setActivePanelMode("view")}
@@ -548,7 +556,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <VStack align="stretch" flex={1} overflow="auto" p={3} gap={6}>
+          <VStack
+            align="stretch"
+            flex={1}
+            minH={0}
+            overflow="auto"
+            p={3}
+            gap={6}
+          >
             <SinkSetupSummaryBlock
               canEdit={canEditNodes}
               config={activeNode.data.config}
@@ -584,7 +599,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <VStack align="stretch" flex={1} overflow="auto" p={3} gap={6}>
+          <VStack
+            align="stretch"
+            flex={1}
+            minH={0}
+            overflow="auto"
+            p={3}
+            gap={6}
+          >
             <ProcessingMethodSummaryBlock
               choiceNodeType={choiceNodeType}
               outputType={activeNode.data.outputTypes[0] ?? null}
@@ -610,7 +632,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <VStack align="stretch" flex={1} overflow="auto" p={3} gap={6}>
+          <VStack
+            align="stretch"
+            flex={1}
+            minH={0}
+            overflow="auto"
+            p={3}
+            gap={6}
+          >
             <BranchSetupSummaryBlock
               branchStates={branchPathStates}
               canEdit={canEditNodes}
@@ -639,7 +668,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <VStack align="stretch" flex={1} overflow="auto" p={3} gap={6}>
+          <VStack
+            align="stretch"
+            flex={1}
+            minH={0}
+            overflow="auto"
+            p={3}
+            gap={6}
+          >
             <Box>
               <Text fontSize="lg" fontWeight="bold" mb={2}>
                 {outputDataLabel}
@@ -756,7 +792,14 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <VStack align="stretch" flex={1} overflow="auto" p={3} gap={6}>
+          <VStack
+            align="stretch"
+            flex={1}
+            minH={0}
+            overflow="auto"
+            p={3}
+            gap={6}
+          >
             <FallbackNodeSummaryBlock
               canEdit={canEditNodes && !isProcessingMethodOnlyNode}
               hasConfigIssue={hasConfigIssue}
@@ -782,7 +825,7 @@ export const OutputPanel = ({ wizardController }: Props) => {
             </Box>
           </Box>
 
-          <Box flex={1} overflow="auto" p={3}>
+          <Box flex={1} minH={0} overflow="auto" p={3}>
             <Text color="text.secondary" fontSize="sm">
               노드를 선택하면 설정과 출력 정보를 확인할 수 있습니다.
             </Text>


### PR DESCRIPTION
## 📝 요약 (Summary)

Flowify Frontend Issue 18의 워크플로우 에디터 반응형 UI 수정 작업입니다.  
노드 선택 시 focus 기준을 통일하고, 화면 크기와 browser zoom에 따라 패널이 화면 밖으로 나가거나 UI가 어색하게 보이는 문제를 개선했습니다.

## ✅ 주요 변경 사항 (Key Changes)

- 시작/중간/도착/placeholder 노드 선택 시 zoom/center 기준 통일
- workflow editor panel이 editor canvas safe area 밖으로 나가지 않도록 layout 계산 보강
- 패널 내부 콘텐츠가 길어질 경우 outer panel이 아닌 내부 body가 scroll되도록 정리
- workflow editor 패널 radius 및 title typography를 SaaS UI 톤에 맞게 조정
- responsive QA 및 회귀 테스트 기록을 `.docs/RESPONSIVE_UI_FIX_PLAN.md`에 반영
- panel boundary 검증용 `dual-panel-layout` 단위 테스트 추가

## 💻 상세 구현 내용 (Implementation Details)

### Node Focus 동작 통일

`Canvas.tsx`에서 노드 종류별로 흩어져 있던 focus 로직을 공통 경로로 정리했습니다.

- `NODE_FOCUS_ZOOM = 1` 기준으로 선택 focus zoom 통일
- `focusCanvasPoint`, `focusNode` helper 추가
- 시작 placeholder의 `window.innerWidth` 기반 offset 제거
- 일반 노드와 도착 노드 모두 선택된 node center 기준으로 focus
- `fitView`는 auto layout 이후 전체 보기 용도로 유지

### Panel Viewport Boundary 처리

`dual-panel-layout.ts`에 safe boundary 기준 계산을 보강했습니다.

- `getSafeCenteredPosition()` 추가
- wide / compact / stacked layout에서 panel container가 safe area 안에 위치하도록 조정
- 1366px, 1440px, FHD, QHD 및 축소 viewport 케이스를 테스트로 검증

### Panel Scroll 구조 정리

`InputPanel`, `OutputPanel`, `ServiceSelectionPanel`에서 panel overflow 책임을 정리했습니다.

- outer panel은 화면 안에 고정
- 내부 body 영역에 `overflow="auto"` 적용
- `minH={0}`을 추가해 flex container 안에서 scroll이 안정적으로 동작하도록 보강

### Radius / Typography 정리

workflow editor 범위에서만 스타일을 최소 수정했습니다.

- 큰 panel radius: `20px` → `12px`
- 정보 카드류 radius: `8px` 기준으로 정리
- panel title: `xl + negative letterSpacing` → `lg / semibold`
- 전역 theme 변경 없이 editor panel 범위로 제한

## 🚀 트러블 슈팅 (Trouble Shooting)

### 1. 리베이스 이후 main 신규 변경 반영

작업 중 `origin/main`에 뉴스 출처 관련 신규 커밋이 반영되어 현재 브랜치를 최신 main 위로 rebase했습니다.

- `git fetch origin`
- `git rebase origin/main`
- 충돌 없이 rebase 완료
- rebase 이후 `pnpm tsc`, `pnpm lint`, `pnpm test`, `pnpm build` 재검증 완료

### 2. 기존 focus 로직의 기준 불일치

기존에는 노드 종류별로 focus 기준이 달랐습니다.

- 시작 placeholder: viewport width 기반 offset + `zoom: 1`
- 일반 노드: chain bounds center + current zoom
- 도착 노드: 단일 node center + current zoom

이를 선택된 node center + 고정 zoom 기준으로 통일했습니다.

### 3. Panel이 화면 밖으로 나갈 수 있는 구조

기존 layout은 editor canvas 크기를 기준으로 panel 위치를 계산했지만, 최종 위치가 오른쪽/아래 safe boundary 안에 들어오는지까지는 보장하지 않았습니다.  
`getSafeCenteredPosition()`을 추가하고 layout 테스트를 작성해 panel boundary를 검증했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

- 실제 browser zoom별 visual screenshot QA는 별도 Playwright/browser QA 도구가 준비되면 추가로 보강할 수 있습니다.
- `pnpm build`에서 Vite 500KB chunk size warning이 표시되지만, 빌드 실패가 아니며 기존 번들 크기 경고입니다.
- 이번 PR은 workflow editor UI 레이아웃 범위로 제한했습니다.
- 아래 영역은 수정하지 않았습니다.
  - workflow 저장/수정/실행 API
  - OAuth
  - connector schema
  - template schema
  - node data model
  - Spring Boot / FastAPI 서버
  - Slack 제거 작업 관련 파일
  - dashboard 기능/문서

## 📸 스크린샷 (Screenshots)

> 로컬 QA 후 1366px / 1920px / 2560px 화면 기준 워크플로우 에디터 스크린샷을 첨부하면 좋습니다.

## #️⃣ 관련 이슈 (Related Issues)

- Issue 18